### PR TITLE
Minor component styling and doc site example updates

### DIFF
--- a/docs/components/alert.md
+++ b/docs/components/alert.md
@@ -62,7 +62,7 @@ Set the `variant` attribute to change the alert's variant.
 <br />
 
 <sl-alert variant="danger" open>
-  <sl-icon slot="icon" name="exclamation-circle-solid"></sl-icon>
+  <sl-icon slot="icon" name="exclamation-circle"></sl-icon>
   <strong>Your account has been deleted</strong><br />
   We're very sorry to see you go!
 </sl-alert>

--- a/docs/components/button-group.md
+++ b/docs/components/button-group.md
@@ -298,13 +298,13 @@ const App = () => (
 
 ### Split Buttons
 
-Create a split button using a button and a dropdown. Use a [visually hidden](/components/visually-hidden) label to ensure the dropdown is accessible to users with assistive devices.
+Create a split button using a button and a dropdown. Use a [visually hidden](/components/visually-hidden) label to ensure the dropdown is accessible to users with assistive devices. Also use a `no-pad-l` class to remove extra padding from the caret button.
 
 ```html preview
 <sl-button-group label="Example Button Group">
   <sl-button variant="primary">Save</sl-button>
   <sl-dropdown placement="bottom-end">
-    <sl-button slot="trigger" variant="primary" caret>
+    <sl-button class="no-pad-l" slot="trigger" variant="primary" caret>
       <sl-visually-hidden>More options</sl-visually-hidden>
     </sl-button>
     <sl-menu>
@@ -323,7 +323,7 @@ const App = () => (
   <SlButtonGroup label="Example Button Group">
     <SlButton variant="primary">Save</SlButton>
     <SlDropdown placement="bottom-end">
-      <SlButton slot="trigger" variant="primary" caret></SlButton>
+      <SlButton class="no-pad-l" slot="trigger" variant="primary" caret></SlButton>
       <SlMenu>
         <SlMenuItem>Save</SlMenuItem>
         <SlMenuItem>Save as&hellip;</SlMenuItem>

--- a/src/themes/tokens.css
+++ b/src/themes/tokens.css
@@ -383,6 +383,15 @@
   --sl-spacing-4x-large: var(--ts-spacing-4x-large);
   /* Input font color */
   --sl-input-color: var(--ts-color-text-default);
+  --sl-input-color-hover: var(--ts-color-text-default);
+  --sl-input-color-focus: var(--ts-color-text-default);
+  --sl-input-color-disabled: var(--ts-color-text-default);
+  --sl-input-placeholder-color: var(--ts-color-text-subdued);
+  --sl-input-placeholder-color-disabled: var(--ts-color-text-subdued);
+  /* Input icon colors */
+  --sl-input-icon-color: var(--sl-color-neutral-700);
+  --sl-input-icon-color-hover: var(--sl-color-neutral-700);
+  --sl-input-icon-color-focus: var(--sl-color-neutral-700);
   /* Input sizes */
   --sl-input-height-small: var(--ts-input-height-small);
   --sl-input-height-medium: var(--ts-input-height-medium);
@@ -396,10 +405,6 @@
   /* Input border colors */
   --sl-input-border-color: var(--sl-color-neutral-400);
   --sl-input-border-color-hover: var(--sl-color-neutral-400);
-  /* Input icon colors */
-  --sl-input-icon-color: var(--sl-color-neutral-600);
-  --sl-input-icon-color-hover: var(--sl-color-neutral-700);
-  --sl-input-icon-color-focus: var(--sl-color-neutral-700);
   /* Focus rings */
   --sl-focus-ring-color: rgba(var(--ts-color-blue-500-rgb), 0.5);
   --sl-focus-ring-style: solid;
@@ -1062,6 +1067,18 @@ sl-select::part(control):not(:focus),
 sl-input::part(input):not(:focus),
 sl-textarea::part(textarea):not(:focus) {
   box-shadow: var(--sl-shadow-small);
+}
+
+/* Set prefix icon color to subdued text color */
+sl-select::part(prefix),
+sl-input::part(prefix),
+sl-input::part(suffix) {
+  color: var(--ts-color-text-subdued);
+}
+
+/* Set color of text displayed in select */
+sl-select::part(display-input) {
+  color: var(--ts-color-text-default);
 }
 
 /** ********** **/

--- a/src/themes/tokens.css
+++ b/src/themes/tokens.css
@@ -712,9 +712,20 @@ sl-button[size='large']::part(label) {
   /* 12px */
 }
 
+sl-button[size='x-large']::part(base) {
+  padding: 0 var(--sl-spacing-2x-large); /* 32px */
+}
+
+sl-button[size='x-large']::part(label) {
+  font-size: var(--ts-font-base); /* 16px */
+  line-height: calc(var(--sl-spacing-4x-large) - var(--sl-input-border-width) * 2);
+  padding: 0 var(--sl-spacing-x-small); /* 8px */
+}
+
 sl-button[size='medium']::part(caret),
 sl-button[size='medium']::part(prefix),
-sl-button[size='medium']::part(suffix) {
+sl-button[size='medium']::part(suffix),
+sl-button[size='medium'][circle]::part(label) {
   font-size: var(--ts-font-base);
   /* 16px */
 }
@@ -722,10 +733,16 @@ sl-button[size='medium']::part(suffix) {
 sl-button[size='large']::part(caret),
 sl-button[size='large']::part(prefix),
 sl-button[size='large']::part(suffix),
-sl-button[size='medium'][circle]::part(base),
-sl-button[size='large'][circle]::part(base) {
+sl-button[size='large'][circle]::part(label) {
   font-size: var(--ts-font-xl);
   /* 20px */
+}
+
+sl-button[size='x-large']::part(caret),
+sl-button[size='x-large']::part(prefix),
+sl-button[size='x-large']::part(suffix),
+sl-button[size='x-large'][circle]::part(label) {
+  font-size: var(--ts-font-2xl); /* 24px */
 }
 
 /* To remove default padding from split buttons */

--- a/src/themes/tokens.css
+++ b/src/themes/tokens.css
@@ -1206,11 +1206,12 @@ sl-select::part(listbox) {
 /* Option styling */
 /** ********** **/
 sl-option::part(base) {
+  color: var(--ts-color-text-default);
   padding: var(--sl-spacing-x-small) var(--sl-spacing-2x-small);
 }
 
-sl-option::part(base):not(.option--selected),
-sl-option::part(base):not(.option--current) {
+sl-option[tabindex="0"]::part(base) {
+  background-color: var(--sl-color-neutral-100);
   color: var(--ts-color-text-default);
 }
 

--- a/src/themes/tokens.css
+++ b/src/themes/tokens.css
@@ -437,8 +437,6 @@ sl-divider {
 
 sl-select[multiple] {
   appearance: initial;
-  appearance: initial;
-  appearance: initial;
   background-color: transparent;
   border: none;
   font-size: initial;

--- a/src/themes/tokens.css
+++ b/src/themes/tokens.css
@@ -1231,6 +1231,14 @@ sl-option:active::part(base) {
   color: var(--ts-color-text-default);
 }
 
+sl-option::part(checked-icon) {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg width='16' height='16' viewBox='0 0 20 20' fill='currentColor' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M16.704 4.153a.75.75 0 01.143 1.052l-8 10.5a.75.75 0 01-1.127.075l-4.5-4.5a.75.75 0 011.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 011.05-.143z' fill='%232e333c' stroke='none'/%3E%3C/svg%3E");
+  background-position: center;
+  background-repeat: no-repeat;
+  color: transparent;
+  padding-right: var(--sl-spacing-x-small);
+}
+
 sl-option::part(label) {
   font-size: var(--sl-font-size-small);
   line-height: var(--ts-leading-5);

--- a/src/themes/tokens.css
+++ b/src/themes/tokens.css
@@ -1027,10 +1027,12 @@ sl-theme {
   /* normal */
   line-height: var(--ts-leading-5);
   /* 1.25rem * 20px */
+  margin-top: var(--sl-spacing-x-small);
+  /* .5rem * 8px */
 }
 
 ::part(form-control-input) {
-  margin: var(--sl-spacing-2x-small) 0 var(--sl-spacing-x-small);
+  margin: var(--sl-spacing-2x-small) 0 0;
 }
 
 ::part(input),

--- a/src/themes/tokens.css
+++ b/src/themes/tokens.css
@@ -1091,9 +1091,21 @@ sl-radio::part(base) {
 /** ********** **/
 /* Switch & range */
 /** ********** **/
-sl-switch {
-  --height: calc(var(--sl-toggle-size) + 6px);
-  --thumb-size: calc(var(--sl-toggle-size) + 4px);
+sl-switch[size='small'] {
+  --height: calc(var(--sl-toggle-size-small) + 6px);
+  --thumb-size: calc(var(--sl-toggle-size-small) + 4px);
+  --width: calc(var(--height) * 1.8);
+}
+
+sl-switch[size='medium'] {
+  --height: calc(var(--sl-toggle-size-medium) + 6px);
+  --thumb-size: calc(var(--sl-toggle-size-medium) + 4px);
+  --width: calc(var(--height) * 1.8);
+}
+
+sl-switch[size='large'] {
+  --height: calc(var(--sl-toggle-size-large) + 6px);
+  --thumb-size: calc(var(--sl-toggle-size-large) + 4px);
   --width: calc(var(--height) * 1.8);
 }
 

--- a/src/themes/tokens.css
+++ b/src/themes/tokens.css
@@ -1113,6 +1113,12 @@ sl-range::part(input) {
   padding: 0;
 }
 
+sl-range {
+  --track-height: var(--sl-spacing-x-small); /* 8px */
+  --track-color-active: var(--sl-color-neutral-300);
+  --track-color-inactive:  var(--sl-color-neutral-300);
+}
+
 /** ******************************** */
 /** Icon */
 /** ******************************** */


### PR DESCRIPTION
Updates to overrides in `/themes/tokens.css` files to test updates before copying over to `/shared-ui` & also some doc site example updates. Minor changes made to styling overrides for:

- Select component
- New x-large buttons
- Switch component
- Range component

plus some doc site example updates for the Alert page ("danger" alert) & Button Group page (split button example)