### PR TITLE
Add missing quotes in example slim for radios

### DIFF
--- a/docs/components/radio.md
+++ b/docs/components/radio.md
@@ -180,9 +180,9 @@ Use the `contained` attribute to add a container around the radio.
 
 ```pug slim
 sl-radio-group label="Select an option" name="a" value="3"
-  sl-radio contained="true" value="1 Option 1
-  sl-radio contained="true" disabled="true" value="2 Option 2
-  sl-radio contained="true" value="3 Option 3
+  sl-radio contained="true" value="1" Option 1
+  sl-radio contained="true" disabled="true" value="2" Option 2
+  sl-radio contained="true" value="3" Option 3
     div slot="description" A short description about this option
 ```
 


### PR DESCRIPTION
Looks like these quotes were not properly closed in the slim example for contained radio buttons. Adding those back in for anyone copy-pasting!