### PR TITLE
Disable dark theme (dark.css) for now

### DIFF
--- a/docs/_includes/default.njk
+++ b/docs/_includes/default.njk
@@ -35,7 +35,7 @@
 
     {# Shoelace #}
     <link rel="stylesheet" href="/dist/themes/light.css" />
-    <link rel="stylesheet" href="/dist/themes/dark.css" />
+    <!-- <link rel="stylesheet" href="/dist/themes/dark.css" /> -->
     <script type="module" src="/dist/shoelace-autoloader.js"></script>
 
     {# Teamshares #}


### PR DESCRIPTION
Commenting out `dark.css` to disable the doc site's dark theme, as we've skipped updating the dark.css styles for now & as a result the dark theme is broken