### PR TITLE
Fix: console error on reparenting by `ts-wrapper`

### DIFF
--- a/src/components/textarea/textarea.component.ts
+++ b/src/components/textarea/textarea.component.ts
@@ -163,7 +163,9 @@ export default class SlTextarea extends ShoelaceElement implements ShoelaceFormC
 
   disconnectedCallback() {
     super.disconnectedCallback();
-    this.resizeObserver.unobserve(this.input);
+    if (this.input) {
+      this.resizeObserver.unobserve(this.input);
+    }
   }
 
   private handleBlur() {


### PR DESCRIPTION
Fixes an error that shows up in the browser console. When ts-wrapper re-parents this element, it tries to remove the resizeobserver, but the element hasn't actually been instantiated yet, so the input doesn't exist. The error doesn't actually cause a bug, but it looks alarming in the console.