### PR TITLE
Patch release 2.1.1 with checkbox group & bug fixes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
+  "html.customData": ["./node_modules/@teamshares/shoelace/dist/vscode.html-custom-data.json"],
   "editor.formatOnSave": true,
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.codeActionsOnSave": {

--- a/docs/_includes/default.njk
+++ b/docs/_includes/default.njk
@@ -133,7 +133,7 @@
             outline
             size="small"
             class="repo-button repo-button--github"
-            href="https://github.com/teamshares/shoelace/tree/v{{ meta.version }}"
+            href="https://github.com/teamshares/shoelace"
             target="_blank"
           >
             <sl-icon slot="prefix" library="fa" name="fab-github"></sl-icon> Version {{ meta.version }}

--- a/docs/pages/components/checkbox-group.md
+++ b/docs/pages/components/checkbox-group.md
@@ -29,7 +29,7 @@ A basic checkbox group lays out multiple checkbox items vertically.
 <sl-checkbox-group label="Financial products permissions" name="a" value="">
   <sl-checkbox value="initiate-outbound" checked>Initiate outbound transfers</sl-checkbox>
   <sl-checkbox value="approve-outbound" checked>Approve outbound transfers </sl-checkbox>
-  <sl-checkbox value="export" disabled>Export transactions</sl-checkbox>
+  <sl-checkbox value="export">Export transactions</sl-checkbox>
 </sl-checkbox-group>
 ```
 

--- a/docs/pages/components/checkbox-group.md
+++ b/docs/pages/components/checkbox-group.md
@@ -26,15 +26,15 @@ guidelines: |
 A basic checkbox group lays out multiple checkbox items vertically.
 
 ```html:preview
-<sl-checkbox-group label="Financial products permissions" name="a" value="">
-  <sl-checkbox value="initiate-outbound" checked>Initiate outbound transfers</sl-checkbox>
-  <sl-checkbox value="approve-outbound" checked>Approve outbound transfers </sl-checkbox>
+<sl-checkbox-group label="Financial products permissions" name="a">
+  <sl-checkbox value="initiate-outbound">Initiate outbound transfers</sl-checkbox>
+  <sl-checkbox value="approve-outbound">Approve outbound transfers </sl-checkbox>
   <sl-checkbox value="export">Export transactions</sl-checkbox>
 </sl-checkbox-group>
 ```
 
 ```pug:slim
-sl-checkbox-group label="Financial products permissions" name="a" value=""
+sl-checkbox-group label="Financial products permissions" name="a"
   sl-checkbox value="initiate-outbound" Initiate outbound transfers
   sl-checkbox value="approve-outbound" Approve outbound transfers
   sl-checkbox value="export" Export transactions
@@ -58,7 +58,7 @@ const App = () => (
 Add descriptive help text to a checkbox group with the `help-text` attribute. For help texts that contain HTML, use the `help-text` slot instead.
 
 ```html:preview
-<sl-checkbox-group label="Financial products permissions" help-text="Outbound transfers require separate initiators and approvers" name="a" value="">
+<sl-checkbox-group label="Financial products permissions" help-text="Outbound transfers require separate initiators and approvers" name="a">
   <sl-checkbox value="initiate-outbound">Initiate outbound transfers</sl-checkbox>
   <sl-checkbox value="approve-outbound">Approve outbound transfers </sl-checkbox>
   <sl-checkbox value="export">Export transactions</sl-checkbox>
@@ -66,7 +66,7 @@ Add descriptive help text to a checkbox group with the `help-text` attribute. Fo
 ```
 
 ```pug:slim
-sl-checkbox-group label="Financial products permissions" help-text="Outbound transfers require separate initiators and approvers" name="a" value=""
+sl-checkbox-group label="Financial products permissions" help-text="Outbound transfers require separate initiators and approvers" name="a"
   sl-checkbox value="initiate-outbound" Initiate outbound transfers
   sl-checkbox value="approve-outbound" Approve outbound transfers
   sl-checkbox value="export" Export transactions
@@ -94,7 +94,7 @@ Use the `label-tooltip` attribute to add text that appears in a tooltip triggere
 :::
 
 ```html:preview
-<sl-checkbox-group name="a" value="" label="Financial products permissions" help-text="Outbound transfers require separate initiators and approvers" label-tooltip="These apply to cash account only">
+<sl-checkbox-group name="a" label="Financial products permissions" help-text="Outbound transfers require separate initiators and approvers" label-tooltip="These apply to cash account only">
   <sl-checkbox value="initiate-outbound">Initiate outbound transfers</sl-checkbox>
   <sl-checkbox value="approve-outbound">Approve outbound transfers </sl-checkbox>
   <sl-checkbox value="export">Export transactions</sl-checkbox>
@@ -102,7 +102,7 @@ Use the `label-tooltip` attribute to add text that appears in a tooltip triggere
 ```
 
 ```pug:slim
-sl-checkbox-group name="a" value="" label="Financial products permissions" help-text="Outbound transfers require separate initiators and approvers" label-tooltip="These apply to cash account only"
+sl-checkbox-group name="a" label="Financial products permissions" help-text="Outbound transfers require separate initiators and approvers" label-tooltip="These apply to cash account only"
   sl-checkbox value="initiate-outbound" Initiate outbound transfers
   sl-checkbox value="approve-outbound" Approve outbound transfers
   sl-checkbox value="export" Export transactions
@@ -130,7 +130,7 @@ Use the `horizontal` attribute to lay out multiple checkbox items horizontally.
 :::
 
 ```html:preview
-<sl-checkbox-group name="a" value="" id="permissions" label="Financial products permissions" horizontal>
+<sl-checkbox-group name="a" id="permissions" label="Financial products permissions" horizontal>
   <sl-checkbox value="manage-transfers">Manage transfers</sl-checkbox>
   <sl-checkbox value="export">Export transactions</sl-checkbox>
 </sl-checkbox-group>
@@ -150,7 +150,7 @@ Use the `horizontal` attribute to lay out multiple checkbox items horizontally.
 ```
 
 ```pug:slim
-sl-checkbox-group name="a" value="" id="permissions" label="Financial products permissions"
+sl-checkbox-group name="a" id="permissions" label="Financial products permissions"
   sl-checkbox value="manage-transfers" Manage transfers
   sl-checkbox value="export" Export transactions
 
@@ -187,27 +187,27 @@ Use the `contained` attribute to draw a card-like container around each checkbox
 This option can be combined with the `horizontal` attribute.
 
 ```html:preview
-<sl-checkbox-group name="a" value="" label="Financial products permissions" help-text="Outbound transfers require separate initiators and approvers" contained>
+<sl-checkbox-group name="a" label="Financial products permissions" help-text="Outbound transfers require separate initiators and approvers" contained>
   <sl-checkbox value="initiate-outbound">Initiate outbound transfers</sl-checkbox>
   <sl-checkbox value="approve-outbound">Approve outbound transfers </sl-checkbox>
   <sl-checkbox value="export">Export transactions</sl-checkbox>
 </sl-checkbox-group>
 <br/>
 <br/>
-<sl-checkbox-group name="b" value="" label="Financial products permissions" help-text="Outbound transfers require separate initiators and approvers" contained horizontal>
+<sl-checkbox-group name="b" label="Financial products permissions" help-text="Outbound transfers require separate initiators and approvers" contained horizontal>
   <sl-checkbox value="initiate-outbound">Initiate outbound transfers</sl-checkbox>
   <sl-checkbox value="approve-outbound">Approve outbound transfers </sl-checkbox>
 </sl-checkbox-group>
 ```
 
 ```pug:slim
-sl-checkbox-group name="a" value="" label="Financial products permissions" help-text="Outbound transfers require separate initiators and approvers" contained="true"
+sl-checkbox-group name="a"  label="Financial products permissions" help-text="Outbound transfers require separate initiators and approvers" contained="true"
   sl-checkbox value="initiate-outbound" Initiate outbound transfers
   sl-checkbox value="approve-outbound" Approve outbound transfers
   sl-checkbox value="export" Export transactions
 br
 br
-sl-checkbox-group name="b" value="" label="Financial products permissions" help-text="Outbound transfers require separate initiators and approvers" contained="true" horizontal="true"
+sl-checkbox-group name="b"  label="Financial products permissions" help-text="Outbound transfers require separate initiators and approvers" contained="true" horizontal="true"
   sl-checkbox value="initiate-outbound" Initiate outbound transfers
   sl-checkbox value="approve-outbound" Approve outbound transfers
 ```
@@ -234,7 +234,7 @@ When [checkboxes](/components/checkbox) are wrapped with the Checkbox Group , ad
 Checkboxes can be disabled by adding the `disabled` attribute to the respective options inside the checkbox group.
 
 ```html:preview
-<sl-checkbox-group name="a" value="" label="Financial products permissions" help-text="Exporting is currently disabled for all users" required>
+<sl-checkbox-group name="a"  label="Financial products permissions" help-text="Exporting is currently disabled for all users" required>
   <sl-checkbox value="initiate-outbound">Initiate outbound transfers</sl-checkbox>
   <sl-checkbox value="approve-outbound">Approve outbound transfers </sl-checkbox>
   <sl-checkbox value="export" disabled>Export transactions</sl-checkbox>
@@ -242,7 +242,7 @@ Checkboxes can be disabled by adding the `disabled` attribute to the respective 
 ```
 
 ```pug:slim
-sl-checkbox-group name="a" value="" label="Financial products permissions"
+sl-checkbox-group name="a" label="Financial products permissions"
   sl-checkbox value="initiate-outbound" Initiate outbound transfers
   sl-checkbox value="approve-outbound" Approve outbound transfers
   sl-checkbox value="export" Export transactions
@@ -267,7 +267,7 @@ Set the `required` attribute to make selecting at least one option mandatory. If
 
 ```html:preview
 <form class="validation">
-  <sl-checkbox-group name="a" value="" label="Select at least one option" required>
+  <sl-checkbox-group name="a" label="Select at least one option" required>
     <sl-checkbox value="option-1">Option 1</sl-checkbox>
     <sl-checkbox value="option-2">Option 2</sl-checkbox>
     <sl-checkbox value="option-3">Option 3</sl-checkbox>
@@ -293,7 +293,7 @@ Set the `required` attribute to make selecting at least one option mandatory. If
 
 ```pug:slim
 form.validation
-  sl-radio-group name="a" value="" label="Select at least one option" required="true"
+  sl-radio-group name="a" label="Select at least one option" required="true"
     sl-radio value="1" Option 1
     sl-radio value="2" Option 2
     sl-radio value="3" Option 3
@@ -354,7 +354,7 @@ Use the `setCustomValidity()` method to set a custom validation message. This wi
 
 ```html:preview
 <form class="custom-validity">
-  <sl-checkbox-group name="a" value="" label="Select the third option" required>
+  <sl-checkbox-group name="a" label="Select the third option" required>
     <sl-checkbox value="option-1">You can optionally choose me</sl-checkbox>
     <sl-checkbox value="option-2">I'm optional too</sl-checkbox>
     <sl-checkbox value="option-3">You must choose me</sl-checkbox>
@@ -393,7 +393,7 @@ Use the `setCustomValidity()` method to set a custom validation message. This wi
 
 ```pug:slim
 form.validation
-  sl-radio-group name="a" value="" label="Select the third option" required="true"
+  sl-radio-group name="a" label="Select the third option" required="true"
     sl-radio value="1" You can optionally choose me
     sl-radio value="2" I'm optional too
     sl-radio value="3" You must choose me

--- a/docs/pages/components/checkbox-group.md
+++ b/docs/pages/components/checkbox-group.md
@@ -26,15 +26,15 @@ guidelines: |
 A basic checkbox group lays out multiple checkbox items vertically.
 
 ```html:preview
-<sl-checkbox-group label="Financial products permissions">
-  <sl-checkbox value="initiate-outbound">Initiate outbound transfers</sl-checkbox>
+<sl-checkbox-group label="Financial products permissions" name="a" value="">
+  <sl-checkbox value="initiate-outbound" checked>Initiate outbound transfers</sl-checkbox>
   <sl-checkbox value="approve-outbound" checked>Approve outbound transfers </sl-checkbox>
-  <sl-checkbox value="export">Export transactions</sl-checkbox>
+  <sl-checkbox value="export" disabled>Export transactions</sl-checkbox>
 </sl-checkbox-group>
 ```
 
 ```pug:slim
-sl-checkbox-group label="Financial products permissions"
+sl-checkbox-group label="Financial products permissions" name="a" value=""
   sl-checkbox value="initiate-outbound" Initiate outbound transfers
   sl-checkbox value="approve-outbound" Approve outbound transfers
   sl-checkbox value="export" Export transactions
@@ -58,7 +58,7 @@ const App = () => (
 Add descriptive help text to a checkbox group with the `help-text` attribute. For help texts that contain HTML, use the `help-text` slot instead.
 
 ```html:preview
-<sl-checkbox-group label="Financial products permissions" help-text="Outbound transfers require separate initiators and approvers">
+<sl-checkbox-group label="Financial products permissions" help-text="Outbound transfers require separate initiators and approvers" name="a" value="">
   <sl-checkbox value="initiate-outbound">Initiate outbound transfers</sl-checkbox>
   <sl-checkbox value="approve-outbound">Approve outbound transfers </sl-checkbox>
   <sl-checkbox value="export">Export transactions</sl-checkbox>
@@ -66,7 +66,7 @@ Add descriptive help text to a checkbox group with the `help-text` attribute. Fo
 ```
 
 ```pug:slim
-sl-checkbox-group label="Financial products permissions" help-text="Outbound transfers require separate initiators and approvers"
+sl-checkbox-group label="Financial products permissions" help-text="Outbound transfers require separate initiators and approvers" name="a" value=""
   sl-checkbox value="initiate-outbound" Initiate outbound transfers
   sl-checkbox value="approve-outbound" Approve outbound transfers
   sl-checkbox value="export" Export transactions
@@ -94,7 +94,7 @@ Use the `label-tooltip` attribute to add text that appears in a tooltip triggere
 :::
 
 ```html:preview
-<sl-checkbox-group label="Financial products permissions" help-text="Outbound transfers require separate initiators and approvers" label-tooltip="These apply to cash account only">
+<sl-checkbox-group name="a" value="" label="Financial products permissions" help-text="Outbound transfers require separate initiators and approvers" label-tooltip="These apply to cash account only">
   <sl-checkbox value="initiate-outbound">Initiate outbound transfers</sl-checkbox>
   <sl-checkbox value="approve-outbound">Approve outbound transfers </sl-checkbox>
   <sl-checkbox value="export">Export transactions</sl-checkbox>
@@ -102,7 +102,7 @@ Use the `label-tooltip` attribute to add text that appears in a tooltip triggere
 ```
 
 ```pug:slim
-sl-checkbox-group label="Financial products permissions" help-text="Outbound transfers require separate initiators and approvers" label-tooltip="These apply to cash account only"
+sl-checkbox-group name="a" value="" label="Financial products permissions" help-text="Outbound transfers require separate initiators and approvers" label-tooltip="These apply to cash account only"
   sl-checkbox value="initiate-outbound" Initiate outbound transfers
   sl-checkbox value="approve-outbound" Approve outbound transfers
   sl-checkbox value="export" Export transactions
@@ -130,7 +130,7 @@ Use the `horizontal` attribute to lay out multiple checkbox items horizontally.
 :::
 
 ```html:preview
-<sl-checkbox-group id="permissions" label="Financial products permissions" horizontal>
+<sl-checkbox-group name="a" value="" id="permissions" label="Financial products permissions" horizontal>
   <sl-checkbox value="manage-transfers">Manage transfers</sl-checkbox>
   <sl-checkbox value="export">Export transactions</sl-checkbox>
 </sl-checkbox-group>
@@ -150,7 +150,7 @@ Use the `horizontal` attribute to lay out multiple checkbox items horizontally.
 ```
 
 ```pug:slim
-sl-checkbox-group id="permissions" label="Financial products permissions"
+sl-checkbox-group name="a" value="" id="permissions" label="Financial products permissions"
   sl-checkbox value="manage-transfers" Manage transfers
   sl-checkbox value="export" Export transactions
 
@@ -187,27 +187,27 @@ Use the `contained` attribute to draw a card-like container around each checkbox
 This option can be combined with the `horizontal` attribute.
 
 ```html:preview
-<sl-checkbox-group label="Financial products permissions" help-text="Outbound transfers require separate initiators and approvers" contained>
+<sl-checkbox-group name="a" value="" label="Financial products permissions" help-text="Outbound transfers require separate initiators and approvers" contained>
   <sl-checkbox value="initiate-outbound">Initiate outbound transfers</sl-checkbox>
   <sl-checkbox value="approve-outbound">Approve outbound transfers </sl-checkbox>
   <sl-checkbox value="export">Export transactions</sl-checkbox>
 </sl-checkbox-group>
 <br/>
 <br/>
-<sl-checkbox-group label="Financial products permissions" help-text="Outbound transfers require separate initiators and approvers" contained horizontal>
+<sl-checkbox-group name="b" value="" label="Financial products permissions" help-text="Outbound transfers require separate initiators and approvers" contained horizontal>
   <sl-checkbox value="initiate-outbound">Initiate outbound transfers</sl-checkbox>
   <sl-checkbox value="approve-outbound">Approve outbound transfers </sl-checkbox>
 </sl-checkbox-group>
 ```
 
 ```pug:slim
-sl-checkbox-group label="Financial products permissions" help-text="Outbound transfers require separate initiators and approvers" contained="true"
+sl-checkbox-group name="a" value="" label="Financial products permissions" help-text="Outbound transfers require separate initiators and approvers" contained="true"
   sl-checkbox value="initiate-outbound" Initiate outbound transfers
   sl-checkbox value="approve-outbound" Approve outbound transfers
   sl-checkbox value="export" Export transactions
 br
 br
-sl-checkbox-group label="Financial products permissions" help-text="Outbound transfers require separate initiators and approvers" contained="true" horizontal="true"
+sl-checkbox-group name="b" value="" label="Financial products permissions" help-text="Outbound transfers require separate initiators and approvers" contained="true" horizontal="true"
   sl-checkbox value="initiate-outbound" Initiate outbound transfers
   sl-checkbox value="approve-outbound" Approve outbound transfers
 ```
@@ -234,7 +234,7 @@ When [checkboxes](/components/checkbox) are wrapped with the Checkbox Group , ad
 Checkboxes can be disabled by adding the `disabled` attribute to the respective options inside the checkbox group.
 
 ```html:preview
-<sl-checkbox-group label="Financial products permissions" help-text="Exporting is currently disabled for all users" required>
+<sl-checkbox-group name="a" value="" label="Financial products permissions" help-text="Exporting is currently disabled for all users" required>
   <sl-checkbox value="initiate-outbound">Initiate outbound transfers</sl-checkbox>
   <sl-checkbox value="approve-outbound">Approve outbound transfers </sl-checkbox>
   <sl-checkbox value="export" disabled>Export transactions</sl-checkbox>
@@ -242,7 +242,7 @@ Checkboxes can be disabled by adding the `disabled` attribute to the respective 
 ```
 
 ```pug:slim
-sl-checkbox-group label="Financial products permissions"
+sl-checkbox-group name="a" value="" label="Financial products permissions"
   sl-checkbox value="initiate-outbound" Initiate outbound transfers
   sl-checkbox value="approve-outbound" Approve outbound transfers
   sl-checkbox value="export" Export transactions
@@ -267,7 +267,7 @@ Set the `required` attribute to make selecting at least one option mandatory. If
 
 ```html:preview
 <form class="validation">
-  <sl-checkbox-group label="Select at least one option" required>
+  <sl-checkbox-group name="a" value="" label="Select at least one option" required>
     <sl-checkbox value="option-1">Option 1</sl-checkbox>
     <sl-checkbox value="option-2">Option 2</sl-checkbox>
     <sl-checkbox value="option-3">Option 3</sl-checkbox>
@@ -293,7 +293,7 @@ Set the `required` attribute to make selecting at least one option mandatory. If
 
 ```pug:slim
 form.validation
-  sl-radio-group label="Select at least one option" required="true"
+  sl-radio-group name="a" value="" label="Select at least one option" required="true"
     sl-radio value="1" Option 1
     sl-radio value="2" Option 2
     sl-radio value="3" Option 3
@@ -354,7 +354,7 @@ Use the `setCustomValidity()` method to set a custom validation message. This wi
 
 ```html:preview
 <form class="custom-validity">
-  <sl-checkbox-group label="Select the third option" required>
+  <sl-checkbox-group name="a" value="" label="Select the third option" required>
     <sl-checkbox value="option-1">You can optionally choose me</sl-checkbox>
     <sl-checkbox value="option-2">I'm optional too</sl-checkbox>
     <sl-checkbox value="option-3">You must choose me</sl-checkbox>
@@ -375,7 +375,7 @@ Use the `setCustomValidity()` method to set a custom validation message. This wi
 
   // Update validity when a selection is made
   form.addEventListener('sl-change', () => {
-    const isValid = checkboxGroup.value.some(value => value.includes('option-3: true'));
+    const isValid = checkboxGroup.value.some(value => value.includes('option-3'));
     checkboxGroup.setCustomValidity(isValid ? '' : errorMessage);
   });
 
@@ -393,7 +393,7 @@ Use the `setCustomValidity()` method to set a custom validation message. This wi
 
 ```pug:slim
 form.validation
-  sl-radio-group label="Select the third option" required="true"
+  sl-radio-group name="a" value="" label="Select the third option" required="true"
     sl-radio value="1" You can optionally choose me
     sl-radio value="2" I'm optional too
     sl-radio value="3" You must choose me
@@ -412,7 +412,7 @@ javascript:
 
   // Update validity when a selection is made
   form.addEventListener('sl-change', () => {
-    const isValid = checkboxGroup.value.some(value => value.includes('option-3: true'));
+    const isValid = checkboxGroup.value.some(value => value.includes('option-3'));
     checkboxGroup.setCustomValidity(isValid ? '' : errorMessage);
   });
 

--- a/docs/pages/components/checkbox.md
+++ b/docs/pages/components/checkbox.md
@@ -253,7 +253,7 @@ Use the `setCustomValidity()` method to set a custom validation message. This wi
   <br />
   <sl-button type="submit" variant="primary" style="margin-top: 1rem;">Submit</sl-button>
 </form>
-<script>
+<script type="module">
   const form = document.querySelector('.custom-validity');
   const checkbox = form.querySelector('sl-checkbox');
   const errorMessage = `Do not forget to check me!`;
@@ -269,10 +269,14 @@ Use the `setCustomValidity()` method to set a custom validation message. This wi
     checkbox.setCustomValidity(checkbox.checked ? '' : errorMessage);
   });
 
-  // Handle submit
-  form.addEventListener('submit', event => {
-    event.preventDefault();
-    alert('All fields are valid!');
+  // Wait for controls to be defined before attaching form listeners
+  await Promise.all([
+    customElements.whenDefined('sl-checkbox'),
+  ]).then(() => {
+    form.addEventListener('submit', event => {
+      event.preventDefault();
+      alert('All fields are valid!');
+    });
   });
 </script>
 ```
@@ -298,10 +302,15 @@ javascript:
     checkbox.setCustomValidity(checkbox.checked ?  : errorMessage);
   });
 
-  // Handle submit
-  form.addEventListener(submit, event => {
-    event.preventDefault();
-    alert(All fields are valid!);
+  // Wait for controls to be defined before attaching form listeners
+  await Promise.all([
+    customElements.whenDefined('sl-checkbox'),
+  ]).then(() => {
+    // Handle form submit
+    form.addEventListener(submit, event => {
+      event.preventDefault();
+      alert(All fields are valid!);
+    });
   });
 ```
 

--- a/docs/pages/teamshares/changelog.md
+++ b/docs/pages/teamshares/changelog.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2.1.1
+
+- Minor updates to `sl-checkbox-group`
+  - Update how checkbox group value is stored, to match how the Simple Form checkboxes collection stores values
+  - Update `sl-checkbox` styling so that if the parent Checkbox Group is `data-user-invalid`, all slotted checkboxes in the group are styled as `data-user-invalid`
+- Misc bug fixes 🐞
+  - Remove margin-top from `sl-checkbox` when not nested in a `sl-checkbox-group`
+  - Remove unnecessary padding from `sl-dialog` with header icon for mobile screens
+  - Fix wrong class reference for `sl-checkbox-group` (was using `sl-radio-group` class)
+- Minor doc site example updates to `Checkbox Group` and `Checkbox`
+- Update doc site sidebar link to Github to always point to `teamshares/shoelace` rather than a (wrong) tag
+
 ## 2.1.0
 
 - Upstream merge, going from 2.11.2 -> 2.14.0. Most of the changes are pretty minor. See the [upstream changelog](https://shoelace.style/resources/changelog) for details.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@teamshares/shoelace",
-  "version": "2.2.0",
+  "version": "2.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@teamshares/shoelace",
-      "version": "2.2.0",
+      "version": "2.1.1",
       "license": "MIT",
       "dependencies": {
         "@ctrl/tinycolor": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamshares/shoelace",
   "description": "The Teamshares flavor of a forward-thinking library of web components.",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "upstreamVersion": "2.14.0",
   "homepage": "https://github.com/teamshares/shoelace",
   "author": "Cory LaViska",

--- a/src/components/checkbox-group/checkbox-group.component.ts
+++ b/src/components/checkbox-group/checkbox-group.component.ts
@@ -279,7 +279,7 @@ export default class SlCheckboxGroup extends ShoelaceElement implements Shoelace
           'form-control--small': this.size === 'small',
           'form-control--medium': this.size === 'medium',
           'form-control--large': this.size === 'large',
-          'form-control--radio-group': true,
+          'form-control--checkbox-group': true,
           'form-control--has-label': hasLabel,
           'form-control--has-label-tooltip': hasLabelTooltip,
           'form-control--has-help-text': hasHelpText

--- a/src/components/checkbox-group/checkbox-group.styles.ts
+++ b/src/components/checkbox-group/checkbox-group.styles.ts
@@ -22,6 +22,20 @@ export default css`
     gap: var(--sl-spacing-x-small);
   }
 
+  ::slotted(sl-checkbox) {
+    margin-top: var(--sl-spacing-medium);
+  }
+
+  ::slotted(sl-checkbox[horizontal]),
+  ::slotted(sl-checkbox[contained]) {
+    margin-top: var(--sl-spacing-small);
+  }
+
+  ::slotted(sl-checkbox[horizontal][contained]) {
+    margin-top: 0;
+    height: 100%;
+  }
+
   .form-control {
     position: relative;
     border: none;

--- a/src/components/checkbox-group/checkbox-group.test.ts
+++ b/src/components/checkbox-group/checkbox-group.test.ts
@@ -218,9 +218,8 @@ describe('when submitting a form', () => {
     checkbox.click();
     button.click();
     await waitUntil(() => submitHandler.calledOnce);
-
-    expect(formData!.getAll('a')).to.include('1: true');
-    expect(formData!.getAll('a')).to.include('2: true');
+    expect(formData!.getAll('a')).to.include('1');
+    expect(formData!.getAll('a')).to.include('2');
   });
 
   it('should be present in form data when using the form attribute and located outside of a <form>', async () => {
@@ -238,9 +237,8 @@ describe('when submitting a form', () => {
     `);
     const form = el.querySelector('form')!;
     const formData = new FormData(form);
-
-    expect(formData.getAll('a')).to.include('1: true');
-    expect(formData.getAll('a')).to.include('2: true');
+    expect(formData.getAll('a')).to.include('1');
+    expect(formData.getAll('a')).to.include('2');
   });
 });
 
@@ -265,8 +263,8 @@ describe('when the value changes', () => {
 
     expect(changeHandler).to.have.been.called;
     expect(inputHandler).to.have.been.called;
-    expect(checkboxGroup.value).to.include('1: true');
-    expect(checkboxGroup.value).to.include('2: false');
+    expect(checkboxGroup.value).to.include('1');
+    expect(checkboxGroup.value).to.not.include('2');
   });
 
   it('should emit sl-change and sl-input when clicked', async () => {
@@ -285,10 +283,9 @@ describe('when the value changes', () => {
 
     expect(event.target).to.equal(checkboxGroup);
     expect(inputHandler).to.have.been.called;
-    expect(checkboxGroup.value).to.include('1: true');
-    expect(checkboxGroup.value).to.include('2: false');
+    expect(checkboxGroup.value).to.include('1');
+    expect(checkboxGroup.value).to.not.include('2');
   });
-
   it('should not emit sl-change or sl-input when the value is changed programmatically', async () => {
     const checkboxGroup = await fixture<SlCheckboxGroup>(html`
       <sl-checkbox-group>
@@ -296,13 +293,11 @@ describe('when the value changes', () => {
         <sl-checkbox id="checkbox-2" value="2"></sl-checkbox>
       </sl-checkbox-group>
     `);
-
     checkboxGroup.addEventListener('sl-change', () => expect.fail('sl-change should not be emitted'));
     checkboxGroup.addEventListener('sl-input', () => expect.fail('sl-input should not be emitted'));
-    checkboxGroup.value = ['1: false', '2: true'];
+    checkboxGroup.value = ['2'];
     await checkboxGroup.updateComplete;
   });
-
   it('should relatively position content to prevent visually hidden scroll bugs', async () => {
     //
     // See https://github.com/shoelace-style/shoelace/issues/1380
@@ -312,13 +307,10 @@ describe('when the value changes', () => {
         <sl-checkbox id="checkbox-1" value="1"></sl-checkbox>
       </sl-checkbox-group>
     `);
-
     const formControl = checkboxGroup.shadowRoot!.querySelector('.form-control')!;
     const visuallyHidden = checkboxGroup.shadowRoot!.querySelector('.visually-hidden')!;
-
     expect(getComputedStyle(formControl).position).to.equal('relative');
     expect(getComputedStyle(visuallyHidden).position).to.equal('absolute');
   });
-
   runFormControlBaseTests('sl-checkbox-group');
 });

--- a/src/components/checkbox/checkbox.styles.ts
+++ b/src/components/checkbox/checkbox.styles.ts
@@ -122,7 +122,7 @@ export default css`
     display: none;
   }
 
-  /* If parent Checkbox Group has 'data-user-invalid', style all checkboxes in the group as 'data-user-invalid' by targeting with a class ('checkbox-user-invalid'), since the checkboxes can't be targeted using :slotted */
+  /* If parent Checkbox Group has 'data-user-invalid', style all checkboxes in the group as 'data-user-invalid' by targeting with a class ('checkbox-user-invalid'), since the checkboxes can't be targeted using ::slotted */
   :host(.checkbox-user-invalid) .checkbox__control {
     border-color: var(--sl-color-danger-600);
   }

--- a/src/components/checkbox/checkbox.styles.ts
+++ b/src/components/checkbox/checkbox.styles.ts
@@ -133,6 +133,20 @@ export default css`
     display: none;
   }
 
+  /* If parent Checkbox Group has 'data-user-invalid', style all checkboxes in the group as 'data-user-invalid' by targeting with a class ('checkbox-user-invalid'), since the checkboxes can't be targeted using :slotted */
+  :host(.checkbox-user-invalid) .checkbox__control {
+    border-color: var(--sl-color-danger-600);
+  }
+
+  :host(.checkbox-user-invalid)
+    .checkbox:not(.checkbox--checked):not(.checkbox--disabled)
+    .checkbox__input:focus-visible
+    ~ .checkbox__control {
+    border-color: var(--sl-color-danger-600);
+    outline: var(--sl-focus-ring-style) var(--sl-focus-ring-width) var(--sl-error-focus-ring-color);
+    outline-offset: var(--sl-focus-ring-offset);
+  }
+
   .checkbox__label {
     display: inline-block;
     color: var(--sl-input-label-color);

--- a/src/components/checkbox/checkbox.styles.ts
+++ b/src/components/checkbox/checkbox.styles.ts
@@ -3,17 +3,6 @@ import { css } from 'lit';
 export default css`
   :host {
     display: block;
-    margin-top: var(--sl-spacing-medium);
-  }
-
-  :host([horizontal]),
-  :host([contained]) {
-    margin-top: var(--sl-spacing-small);
-  }
-
-  :host([horizontal][contained]) {
-    margin-top: 0;
-    height: 100%;
   }
 
   .checkbox {

--- a/src/components/dialog/dialog.styles.ts
+++ b/src/components/dialog/dialog.styles.ts
@@ -241,10 +241,6 @@ export default css`
       padding: var(--header-spacing);
     }
 
-    .dialog--has-header-icon {
-      padding: var(--body-spacing);
-    }
-
     .dialog--has-header-icon .dialog__title {
       flex-direction: column;
     }

--- a/src/styles/exports/overrides.css
+++ b/src/styles/exports/overrides.css
@@ -101,6 +101,7 @@
   --sl-focus-ring: var(--sl-focus-ring-style) var(--sl-focus-ring-width) var(--sl-focus-ring-color);
   --sl-focus-ring-offset: 0;
   --sl-input-focus-ring-color: rgba(var(--ts-color-blue-500-rgb), 0.5);
+  --sl-error-focus-ring-color: rgba(var(--ts-color-red-600-rgb), 0.5);
 
   /* Panel (used in dropdown menu, popovers, etc.) */
   --sl-panel-background-color: var(--sl-color-neutral-0);

--- a/src/styles/form-control.styles.ts
+++ b/src/styles/form-control.styles.ts
@@ -36,7 +36,8 @@ export default css`
     color: var(--sl-input-required-content-color);
   }
 
-  .form-control--has-label.form-control--radio-group .form-control__label {
+  .form-control--has-label.form-control--radio-group .form-control__label,
+  .form-control--has-label.form-control--checkbox-group .form-control__label {
     margin-bottom: 0;
   }
 

--- a/src/styles/form-control.styles.ts
+++ b/src/styles/form-control.styles.ts
@@ -109,7 +109,8 @@ export default css`
     font-size: var(--sl-input-help-text-font-size-large);
   }
 
-  .form-control--has-help-text.form-control--radio-group .form-control__help-text {
+  .form-control--has-help-text.form-control--radio-group .form-control__help-text,
+  .form-control--has-help-text.form-control--checkbox-group .form-control__help-text {
     margin-top: var(--sl-spacing-medium);
   }
 


### PR DESCRIPTION
- Minor updates to `sl-checkbox-group`
  - Update how checkbox group value is stored, to match how the Simple Form checkboxes collection stores values
  - Update `sl-checkbox` styling so that if the parent Checkbox Group is `data-user-invalid`, all slotted checkboxes in the group are styled as `data-user-invalid`
- Misc bug fixes 🐞
  - Remove margin-top from `sl-checkbox` when not nested in a `sl-checkbox-group`
  - Remove unnecessary padding from `sl-dialog` with header icon for mobile screens
  - Fix wrong class reference for `sl-checkbox-group` (was using `sl-radio-group` class)
- Minor doc site example updates to `Checkbox Group` and `Checkbox`
- Update doc site sidebar link to Github to always point to `teamshares/shoelace` rather than a (wrong) tag (we're not currently using Github tags or releases, so the link was pointing instead to the upstream Shoelace tag)

[Doc Site Preview ](https://shoelace-kats4548z-teamshares.vercel.app)