### PR TITLE
Add code examples for `ts_form_for` components

### DIFF
--- a/docs/_includes/sidebar.njk
+++ b/docs/_includes/sidebar.njk
@@ -160,10 +160,7 @@
         <a href="/components/progress-ring">Progress Ring</a>
       </li>
       <li>
-        <a href="/components/radio">Radio (Radio Button)</a>
-      </li>
-      <li>
-        <a href="/components/radio-button">Radio Button (Segmented Control)</a>
+        <a href="/components/radio">Radio</a>
       </li>
       <li>
         <a href="/components/radio-group">Radio Group</a>
@@ -173,6 +170,9 @@
       </li>
       <li>
         <a href="/components/rating">Rating</a>
+      </li>
+      <li>
+        <a href="/components/radio-button">Segmented Control (Radio Button)</a>
       </li>
       <li>
         <a href="/components/select">Select</a>

--- a/docs/assets/styles/docs.css
+++ b/docs/assets/styles/docs.css
@@ -735,7 +735,7 @@ pre > code {
 }
 
 pre .token.comment {
-  color: var(--sl-color-neutral-600);
+  color: var(--sl-color-neutral-700);
 }
 
 pre .token.prolog,

--- a/docs/pages/components/checkbox-group.md
+++ b/docs/pages/components/checkbox-group.md
@@ -382,18 +382,20 @@ sl-checkbox-group[
     as: :check_boxes,
     label: "Financial products permissions",
     collection: [
+      // Use {} to keep additional attributes like 'description' and 'disabled'
+      // separate from the main label/value elements
       [
         "Initiate outbound transfers",
+        {},
         "initiate-outbound",
       ],
       [
         "Approve outbound transfers",
+        {},
         "approve-outbound",
       ],
       [
         "Export transactions",
-        // Use {} to keep additional attributes like 'description' and 'disabled'
-        // separate from the main label/value elements
         { disabled: true },
         "export",
       ],

--- a/docs/pages/components/checkbox-group.md
+++ b/docs/pages/components/checkbox-group.md
@@ -34,10 +34,27 @@ A basic checkbox group lays out multiple checkbox items vertically.
 ```
 
 ```pug:slim
-sl-checkbox-group label="Financial products permissions" name="a"
+sl-checkbox-group[
+  label="Financial products permissions"
+  name="a"
+]
   sl-checkbox value="initiate-outbound" Initiate outbound transfers
   sl-checkbox value="approve-outbound" Approve outbound transfers
   sl-checkbox value="export" Export transactions
+
+ /*
+  When rendering with ts_form_for
+*/
+
+= ts_form_for ... do |f|
+  = f.input :a,
+    as: :check_boxes,
+    label: "Financial products permissions",
+    collection: [
+      ["Initiate outbound transfers", "initiate-outbound"],
+      ["Approve outbound transfers", "approve-outbound"],
+      ["Export transactions", "export"],
+    ]
 ```
 
 ```jsx:react
@@ -66,10 +83,31 @@ Add descriptive help text to a checkbox group with the `help-text` attribute. Fo
 ```
 
 ```pug:slim
-sl-checkbox-group label="Financial products permissions" help-text="Outbound transfers require separate initiators and approvers" name="a"
+sl-checkbox-group[
+  label="Financial products permissions"
+  help-text="Outbound transfers require separate initiators and approvers"
+  name="a"
+]
   sl-checkbox value="initiate-outbound" Initiate outbound transfers
   sl-checkbox value="approve-outbound" Approve outbound transfers
   sl-checkbox value="export" Export transactions
+
+ /*
+  When rendering with ts_form_for
+*/
+
+= ts_form_for ... do |f|
+  = f.input :a,
+    as: :check_boxes,
+    label: "Financial products permissions",
+    collection: [
+      ["Initiate outbound transfers", "initiate-outbound"],
+      ["Approve outbound transfers", "approve-outbound"],
+      ["Export transactions", "export"],
+    ],
+    wrapper_html: {
+      "help-text": "Outbound transfers require separate initiators and approvers",
+    }
 ```
 
 ```jsx:react
@@ -102,10 +140,33 @@ Use the `label-tooltip` attribute to add text that appears in a tooltip triggere
 ```
 
 ```pug:slim
-sl-checkbox-group name="a" label="Financial products permissions" help-text="Outbound transfers require separate initiators and approvers" label-tooltip="These apply to cash account only"
+sl-checkbox-group[
+  name="a"
+  label="Financial products permissions"
+  help-text="Outbound transfers require separate initiators and approvers"
+  label-tooltip="These apply to cash account only"
+]
   sl-checkbox value="initiate-outbound" Initiate outbound transfers
   sl-checkbox value="approve-outbound" Approve outbound transfers
   sl-checkbox value="export" Export transactions
+
+/*
+  When rendering with ts_form_for
+*/
+
+= ts_form_for ... do |f|
+  = f.input :a,
+    as: :check_boxes,
+    label: "Financial products permissions",
+    collection: [
+      ["Initiate outbound transfers", "initiate-outbound"],
+      ["Approve outbound transfers", "approve-outbound"],
+      ["Export transactions", "export"],
+    ],
+    wrapper_html: {
+      "help-text": "Outbound transfers require separate initiators and approvers",
+      "label-tooltip": "These apply to cash account only",
+    }
 ```
 
 ```jsx:react
@@ -150,9 +211,30 @@ Use the `horizontal` attribute to lay out multiple checkbox items horizontally.
 ```
 
 ```pug:slim
-sl-checkbox-group name="a" id="permissions" label="Financial products permissions"
+sl-checkbox-group[
+  name="a"
+  id="permissions"
+  label="Financial products permissions"
+]
   sl-checkbox value="manage-transfers" Manage transfers
   sl-checkbox value="export" Export transactions
+
+/*
+  When rendering with ts_form_for
+*/
+
+= ts_form_for ... do |f|
+  = f.input :a,
+    as: :check_boxes,
+    label: "Financial products permissions",
+    collection: [
+      ["Manage transfers", "manage-transfers"],
+      ["Export transactions", "export"],
+    ],
+    wrapper_html: {
+      horizontal: true,
+      id: "permissions",
+    }
 
 css:
   sl-checkbox-group[id="permissions"] {
@@ -201,15 +283,56 @@ This option can be combined with the `horizontal` attribute.
 ```
 
 ```pug:slim
-sl-checkbox-group name="a"  label="Financial products permissions" help-text="Outbound transfers require separate initiators and approvers" contained="true"
+sl-checkbox-group[
+  name="a"
+  label="Financial products permissions"
+  help-text="Outbound transfers require separate initiators and approvers"
+  contained="true"
+]
   sl-checkbox value="initiate-outbound" Initiate outbound transfers
   sl-checkbox value="approve-outbound" Approve outbound transfers
   sl-checkbox value="export" Export transactions
 br
 br
-sl-checkbox-group name="b"  label="Financial products permissions" help-text="Outbound transfers require separate initiators and approvers" contained="true" horizontal="true"
+sl-checkbox-group[
+  name="b"
+  label="Financial products permissions"
+  help-text="Outbound transfers require separate initiators and approvers"
+  contained="true"
+  horizontal="true"
+]
   sl-checkbox value="initiate-outbound" Initiate outbound transfers
   sl-checkbox value="approve-outbound" Approve outbound transfers
+
+ /*
+  When rendering with ts_form_for
+*/
+
+= ts_form_for ... do |f|
+  = f.input :a,
+    as: :check_boxes,
+    label: "Financial products permissions",
+    collection: [
+      ["Initiate outbound transfers", "initiate-outbound"],
+      ["Approve outbound transfers", "approve-outbound"],
+      ["Export transactions", "export"],
+    ],
+    wrapper_html: {
+      "help-text": "Outbound transfers require separate initiators and approvers",
+      contained: true,
+    }
+  = f.input :b,
+    as: :check_boxes,
+    label: "Financial products permissions",
+    collection: [
+      ["Initiate outbound transfers", "initiate-outbound"],
+      ["Approve outbound transfers", "approve-outbound"],
+    ],
+    wrapper_html: {
+      "help-text": "Outbound transfers require separate initiators and approvers",
+      contained: true,
+      horizontal: true,
+    }
 ```
 
 ```jsx:react
@@ -242,10 +365,37 @@ Checkboxes can be disabled by adding the `disabled` attribute to the respective 
 ```
 
 ```pug:slim
-sl-checkbox-group name="a" label="Financial products permissions"
+sl-checkbox-group[
+  name="a"
+  label="Financial products permissions"
+]
   sl-checkbox value="initiate-outbound" Initiate outbound transfers
   sl-checkbox value="approve-outbound" Approve outbound transfers
-  sl-checkbox value="export" Export transactions
+  sl-checkbox value="export" disabled="true" Export transactions
+
+/*
+  When rendering with ts_form_for
+*/
+
+= ts_form_for ... do |f|
+  = f.input :a,
+    as: :check_boxes,
+    label: "Financial products permissions",
+    collection: [
+      [
+        "Initiate outbound transfers",
+        "initiate-outbound",
+      ],
+      [
+        "Approve outbound transfers",
+        "approve-outbound",
+      ],
+      [
+        "Export transactions",
+        "export",
+        disabled: true,
+      ],
+    ]
 ```
 
 ```jsx:react
@@ -293,12 +443,40 @@ Set the `required` attribute to make selecting at least one option mandatory. If
 
 ```pug:slim
 form.validation
-  sl-radio-group name="a" label="Select at least one option" required="true"
+  sl-radio-group[
+    name="a"
+    label="Select at least one option"
+    required="true"
+  ]
     sl-radio value="1" Option 1
     sl-radio value="2" Option 2
     sl-radio value="3" Option 3
   br
-  sl-button type="submit" variant="primary" Submit
+  sl-button[
+    type="submit"
+    variant="primary"
+  ]
+    | Submit
+
+/*
+  When rendering with ts_form_for
+*/
+
+= ts_form_for ... do |f|
+  = f.input :a,
+    as: :check_boxes,
+    label: "Select at least one option",
+    collection: [
+      ["Option 1", "1"],
+      ["Option 2", "2"],
+      ["Option 3", "3"],
+    ],
+    wrapper_html: {
+      required: true,
+    }
+  br
+    // ts_form_for automatically sets the form's submit button to variant="primary"
+  = f.submit "Submit"
 
 javascript:
   const form = document.querySelector(.validation);

--- a/docs/pages/components/checkbox-group.md
+++ b/docs/pages/components/checkbox-group.md
@@ -374,7 +374,12 @@ sl-checkbox-group[
   sl-checkbox value="export" disabled="true" Export transactions
 
 /*
-  When rendering with ts_form_for
+  When rendering `sl-checkbox-group` with ts_form_for, pass additional
+  attributes such as `disabled` and `description` as extra items
+  in the collection array after the label and value.
+  By default Simple Form will use the first item
+  as the label and the second item as the value, then pass
+  any additional array items as attributes on the `sl-checkbox`.
 */
 
 = ts_form_for ... do |f|
@@ -382,24 +387,20 @@ sl-checkbox-group[
     as: :check_boxes,
     label: "Financial products permissions",
     collection: [
-      // Use {} to keep additional attributes like 'description' and 'disabled'
-      // separate from the main label/value elements
       [
         "Initiate outbound transfers",
-        {},
         "initiate-outbound",
       ],
       [
         "Approve outbound transfers",
-        {},
         "approve-outbound",
       ],
       [
         "Export transactions",
-        { disabled: true },
         "export",
+        disabled: true,
       ],
-    ]
+    ],
 ```
 
 ```jsx:react

--- a/docs/pages/components/checkbox-group.md
+++ b/docs/pages/components/checkbox-group.md
@@ -392,8 +392,10 @@ sl-checkbox-group[
       ],
       [
         "Export transactions",
+        // Use {} to keep additional attributes like 'description' and 'disabled'
+        // separate from the main label/value elements
+        { disabled: true },
         "export",
-        disabled: true,
       ],
     ]
 ```

--- a/docs/pages/components/checkbox-group.md
+++ b/docs/pages/components/checkbox-group.md
@@ -475,7 +475,7 @@ form.validation
       required: true,
     }
   br
-    // ts_form_for automatically sets the form's submit button to variant="primary"
+  // ts_form_for automatically sets the form's submit button to variant="primary"
   = f.submit "Submit"
 
 javascript:

--- a/docs/pages/components/checkbox.md
+++ b/docs/pages/components/checkbox.md
@@ -124,6 +124,8 @@ sl-checkbox-group[
     as: :check_boxes,
     label: "Financial products permissions",
     collection: [
+      // Use {} to keep additional attributes like 'description' and 'disabled'
+      // separate from the main label/value elements
       [
         "Initiate outbound transfers",
         { description: "Requires separate initiators and approvers" }
@@ -136,8 +138,6 @@ sl-checkbox-group[
       ],
       [
         "Export transactions",
-        // Use {} to keep additional attributes like 'description' and 'disabled'
-        // separate from the main label/value elements
         {
           description: "Applies to both cash account and charge card",
           disabled: true,

--- a/docs/pages/components/checkbox.md
+++ b/docs/pages/components/checkbox.md
@@ -108,7 +108,12 @@ sl-checkbox-group[
   | Export transactions
 
 /*
-  When rendering with ts_form_for
+  When rendering `sl-checkbox-group` with ts_form_for, pass additional
+  attributes such as `disabled` and `description` as extra items
+  in the collection array after the label and value.
+  By default Simple Form will use the first item
+  as the label and the second item as the value, then pass
+  any additional array items as attributes on the `sl-checkbox`.
 */
 
 = ts_form_for ... do |f|
@@ -124,25 +129,21 @@ sl-checkbox-group[
     as: :check_boxes,
     label: "Financial products permissions",
     collection: [
-      // Use {} to keep additional attributes like 'description' and 'disabled'
-      // separate from the main label/value elements
       [
         "Initiate outbound transfers",
-        { description: "Requires separate initiators and approvers" }
         "initiate_outboard",
+        description: "Requires separate initiators and approvers",
       ],
       [
         "Approve outbound transfers",
-        { description: "Requires separate initiators and approvers" },
         "approve_outbound",
+        description: "Requires separate initiators and approvers",
       ],
       [
         "Export transactions",
-        {
-          description: "Applies to both cash account and charge card",
-          disabled: true,
-        },
         "export",
+        description: "Applies to both cash account and charge card",
+        disabled: true,
       ],
     ],
     wrapper_html: {

--- a/docs/pages/components/checkbox.md
+++ b/docs/pages/components/checkbox.md
@@ -20,6 +20,17 @@ guidelines: |
 
 ```pug:slim
 sl-checkbox Financial products access
+
+/*
+  When rendering with ts_form_for
+*/
+
+= ts_form_for ... do |f|
+  = f.input :access,
+    as: :boolean,
+    input_html: {
+      label: "Financial products access"
+    }
 ```
 
 ```jsx:react
@@ -42,6 +53,18 @@ Add descriptive help text to individual checkbox items with the `description` at
 
 ```pug:slim
 sl-checkbox description="Grants access to cash account and charge card features" Financial products access
+
+/*
+  When rendering with ts_form_for
+*/
+
+= ts_form_for ... do |f|
+  = f.input :access,
+    as: :boolean,
+    input_html: {
+      label: "Financial products access",
+      description: "Grants access to cash account and charge card features",
+    }
 ```
 
 ```jsx:react
@@ -66,16 +89,60 @@ Add the `contained` attribute to draw a card-like container around a checkbox. A
 ```
 
 ```pug:slim
-sl-checkbox description="Grants access to cash account and charge card features" contained="true" Financial products access
+sl-checkbox[
+  description="Grants access to cash account and charge card features"
+  contained="true"
+]
+  | Financial products access
 br
 br
-sl-checkbox-group label="Financial products permissions" contained="true"
+sl-checkbox-group[
+  label="Financial products permissions"
+  contained="true"
+]
   sl-checkbox description="Requires separate initiators and approvers"
   | Initiate outbound transfers
   sl-checkbox description="Requires separate initiators and approvers"
   | Approve outbound transfers
   sl-checkbox description="Applies to both cash account and charge card"
   | Export transactions
+
+/*
+  When rendering with ts_form_for
+*/
+
+= ts_form_for ... do |f|
+  = f.input :access,
+    as: :boolean,
+    input_html: {
+      label: "Financial products access",
+      description: "Grants access to cash account and charge card features",
+    }
+  br
+  br
+  = f.input :access_options,
+    as: :check_boxes,
+    label: "Financial products permissions",
+    collection: [
+      [
+        "Initiate outbound transfers",
+        "initiate_outboard",
+        description: "Requires separate initiators and approvers"
+      ],
+      [
+        "Approve outbound transfers",
+        "approve_outbound",
+        description: "Requires separate initiators and approvers"
+      ],
+      [
+        "Export transactions",
+        "export",
+        description: "Applies to both cash account and charge card"
+      ],
+    ],
+    wrapper_html: {
+      contained: true,
+    }
 ```
 
 ```jsx:react
@@ -104,6 +171,10 @@ When checkboxes are wrapped with [Checkbox Group](/components/checkbox-group), a
 
 Use the `selected-content` slot to display additional content (such as an input field) inside a `contained` checkbox when it is checked. The slot is unstyled by default. Use `::part(selected-content)` to style the content as needed.
 
+:::warning
+**Note:** `ts_form_for` doesn't support slots. The `selected-content` slot cannot be used for checkboxes rendered with `ts_form_for`.
+:::
+
 ```html:preview
 <sl-checkbox style="width:100%" contained>Grant financial products access
   <div slot="selected-content">
@@ -120,11 +191,25 @@ Use the `selected-content` slot to display additional content (such as an input 
 ```
 
 ```pug:slim
-sl-checkbox style="width:100%" contained="true"
+/*
+  NOTE: `ts_form_for` doesn't support slots. The `selected-content` slot
+  cannot be used for checkboxes rendered with `ts_form_for`.
+*/
+
+sl-checkbox[
+  style="width:100%"
+  contained="true"
+]
   | Grant financial products access
   div slot="selected-content"
     p A mobile number is required to grant this user access to financial products. The number will be used for login verification.
-    sl-input style="width: 280px;" label="Mobile number" type="tel" required="true" optional-icon="true"
+    sl-input[
+      style="width: 280px;"
+      label="Mobile number"
+      type="tel"
+      required="true"
+      optional-icon="true"
+    ]
 css:
     sl-checkbox::part(selected-content) {
     font-size: 14px;
@@ -161,6 +246,18 @@ Use the `checked` attribute to activate the checkbox.
 
 ```pug:slim
 sl-checkbox checked="true" Financial products access
+
+/*
+  When rendering with ts_form_for
+*/
+
+= ts_form_for ... do |f|
+  = f.input :access,
+    as: :boolean,
+    input_html: {
+      label: "Financial products access",
+      checked: true,
+    }
 ```
 
 ```jsx:react
@@ -183,6 +280,18 @@ The `indeterminate` option for a checkbox is currently not part of the Teamshare
 
 ```pug:slim
 sl-checkbox indeterminate="true" Indeterminate
+
+/*
+  When rendering with ts_form_for
+*/
+
+= ts_form_for ... do |f|
+  = f.input :access,
+    as: :boolean,
+    input_html: {
+      label: "Financial products access",
+      indeterminate: true,
+    }
 ```
 
 ```jsx:react
@@ -201,6 +310,18 @@ Use the `disabled` attribute to disable the checkbox.
 
 ```pug:slim
 sl-checkbox disabled="true" Disabled
+
+/*
+  When rendering with ts_form_for
+*/
+
+= ts_form_for ... do |f|
+  = f.input :access,
+    as: :boolean,
+    input_html: {
+      label: "Financial products access",
+      disabled: true,
+    }
 ```
 
 ```jsx:react

--- a/docs/pages/components/checkbox.md
+++ b/docs/pages/components/checkbox.md
@@ -84,7 +84,7 @@ Add the `contained` attribute to draw a card-like container around a checkbox. A
 <sl-checkbox-group label="Financial products permissions" contained>
   <sl-checkbox description="Requires separate initiators and approvers">Initiate outbound transfers</sl-checkbox>
   <sl-checkbox description="Requires separate initiators and approvers">Approve outbound transfers </sl-checkbox>
-  <sl-checkbox description="Applies to both cash account and charge card">Export transactions</sl-checkbox>
+  <sl-checkbox description="Applies to both cash account and charge card" disabled>Export transactions</sl-checkbox>
 </sl-checkbox-group>
 ```
 
@@ -104,7 +104,7 @@ sl-checkbox-group[
   | Initiate outbound transfers
   sl-checkbox description="Requires separate initiators and approvers"
   | Approve outbound transfers
-  sl-checkbox description="Applies to both cash account and charge card"
+  sl-checkbox description="Applies to both cash account and charge card" disabled
   | Export transactions
 
 /*
@@ -126,18 +126,23 @@ sl-checkbox-group[
     collection: [
       [
         "Initiate outbound transfers",
+        { description: "Requires separate initiators and approvers" }
         "initiate_outboard",
-        description: "Requires separate initiators and approvers"
       ],
       [
         "Approve outbound transfers",
+        { description: "Requires separate initiators and approvers" },
         "approve_outbound",
-        description: "Requires separate initiators and approvers"
       ],
       [
         "Export transactions",
+        // Use {} to keep additional attributes like 'description' and 'disabled'
+        // separate from the main label/value elements
+        {
+          description: "Applies to both cash account and charge card",
+          disabled: true,
+        },
         "export",
-        description: "Applies to both cash account and charge card"
       ],
     ],
     wrapper_html: {

--- a/docs/pages/components/input.md
+++ b/docs/pages/components/input.md
@@ -99,6 +99,16 @@ Use the `label` attribute to give the input an accessible label.
 
 ```pug:slim
 sl-input label="Name"
+
+/*
+  When rendering with ts_form_for
+*/
+
+= ts_form_for ... do |f|
+  = f.input :name,
+    input_html: {
+      label: "Name"
+    }
 ```
 
 ```jsx:react
@@ -124,7 +134,10 @@ Add descriptive help text to an input with the `help-text` attribute. For help t
 ```
 
 ```pug:slim
-sl-input label="Previous legal names" help-text="List full names, separated by a semicolon"
+sl-input[
+  label="Previous legal names"
+  help-text="List full names, separated by a semicolon"
+]
 br
 sl-input label="Previous legal names"
   div slot="help-text"
@@ -132,6 +145,18 @@ sl-input label="Previous legal names"
     strong full
     | names, separated by a
     strong semicolon
+
+/*
+  When rendering with ts_form_for
+  — NOTE: Slots are not supported with ts_form_for —
+*/
+
+= ts_form_for ... do |f|
+  = f.input :name,
+    input_html: {
+      label: "Previous legal  names",
+      "help-text": "List full names, separated by a semicolon",
+    }
 ```
 
 ```jsx:react
@@ -154,7 +179,23 @@ Use the `label-tooltip` attribute to add text that appears in a tooltip triggere
 ```
 
 ```pug:slim
-sl-input label="Previous legal names" label-tooltip="Names previously used on official government documents, such as passport, driver license, or ID card" help-text="List full names, separated by a semicolon"
+sl-input[
+  label="Previous legal names"
+  label-tooltip="Names previously used on official government documents, such as passport, driver license, or ID card"
+  help-text="List full names, separated by a semicolon"
+]
+
+/*
+  When rendering with ts_form_for
+*/
+
+= ts_form_for ... do |f|
+  = f.input :name,
+    input_html: {
+      label: "Previous legal names",
+      "label-tooltip": "Names previously used on official government documents, such as passport, driver license, or ID card",
+      "help-text": "List full names, separated by a semicolon",
+    }
 ```
 
 ```jsx:react
@@ -181,12 +222,35 @@ Use the `context-note` attribute to add text that provides additional context or
 ```
 
 ```pug:slim
-sl-input type="currency" label="Amount" context-note="$10,000.29 available" help-text="You can transfer up to $2,500 per day"
+sl-input[
+  type="currency"
+  label="Amount"
+  context-note="$10,000.29 available"
+  help-text="You can transfer up to $2,500 per day"
+]
 br
-sl-input type="currency" label="Amount" help-text="You can transfer up to $2,500 per day"
+sl-input[
+  type="currency"
+  label="Amount"
+  help-text="You can transfer up to $2,500 per day"
+]
   div slot="context-note"
     strong $10,000.29
     | available
+
+/*
+  When rendering with ts_form_for
+  — NOTE: Slots are not supported with ts_form_for —
+*/
+
+= ts_form_for ... do |f|
+  = f.input :currency,
+    input_html: {
+      type: "currency",
+      label: "Amount",
+      "context-note": "$10,000.29 available",
+      "help-text": "You can transfer up to $2,500 per day",
+    }
 ```
 
 ```jsx:react
@@ -223,7 +287,23 @@ Add the `clearable` attribute to add a clear button when the input has content.
 ```
 
 ```pug:slim
-sl-input label="Clearable input" value="I can be cleared!" clearable="true"
+sl-input[
+  label="Clearable input"
+  value="I can be cleared!"
+  clearable="true"
+]
+
+/*
+  When rendering with ts_form_for
+*/
+
+= ts_form_for ... do |f|
+  = f.input :clearable_input,
+    input_html: {
+      label: "Clearable input",
+      value: "I can be cleared!",
+      clearable: true,
+    }
 ```
 
 ```jsx:react
@@ -241,7 +321,23 @@ Add the `password-toggle` attribute to add a toggle button that will show the pa
 ```
 
 ```pug:slim
-sl-input type="password" label="Password" password-toggle="true"
+sl-input[
+  type="password"
+  label="Password"
+  password-toggle="true"
+]
+
+/*
+  When rendering with ts_form_for
+*/
+
+= ts_form_for ... do |f|
+  = f.input :password_toggle,
+    input_html: {
+      label: "Password",
+      type: "password",
+      "password-toggle": true,
+    }
 ```
 
 ```jsx:react
@@ -277,7 +373,21 @@ Use the `disabled` attribute to disable an input.
 ```
 
 ```pug:slim
-sl-input label="Disabled input" disabled="true"
+sl-input[
+  label="Disabled input"
+  disabled="true"
+]
+
+/*
+  When rendering with ts_form_for
+*/
+
+= ts_form_for ... do |f|
+  = f.input :disabled_input,
+    input_html: {
+      label: "Disabled input",
+      disabled: true,
+    }
 ```
 
 ```jsx:react
@@ -303,7 +413,25 @@ Size `small` is currently not part of the Teamshares Design System, and there is
 ```pug:slim
 sl-input label="Medium input"
 br
-sl-input label="Large input" size="large"
+sl-input[
+  label="Large input"
+  size="large"
+]
+
+/*
+  When rendering with ts_form_for
+*/
+
+= ts_form_for ... do |f|
+  = f.input :medium_input,
+    input_html: {
+      label: "Medium input"
+    }
+  = f.input :large_input,
+    input_html: {
+      label: "Large input",
+      size: "large",
+    }
 ```
 
 ```jsx:react
@@ -335,9 +463,33 @@ Use the `pill` attribute to give inputs rounded edges.
 ```
 
 ```pug:slim
-sl-input label="Medium pill" pill="true"
+sl-input[
+  label="Medium pill"
+  pill="true"
+]
 br
-sl-input label="Large pill" size="large" pill="true"
+sl-input[
+  label="Large pill"
+  size="large"
+  pill="true"
+]
+
+/*
+  When rendering with ts_form_for
+*/
+
+= ts_form_for ... do |f|
+  = f.input :medium_pill,
+    input_html: {
+      label: "Medium pill",
+      pill: true,
+    }
+  = f.input :large_pill,
+    input_html: {
+      label: "Large pill",
+      size: "large"
+      pill: true,
+    }
 ```
 
 ```jsx:react
@@ -390,7 +542,16 @@ The `type` attribute controls the type of input the browser renders. As shown in
 ```
 
 ```pug:slim
-sl-input[type="currency" label="Input type: Currency"]
+/*
+  When rendering with ts_form_for
+  — NOTE: Slots are not supported with ts_form_for —
+  — Attributes can be passed to `input_html`
+*/
+
+sl-input[
+  type="currency"
+  label="Input type: Currency"
+]
   div[slot="help-text"]
     | Has
     code
@@ -406,40 +567,70 @@ sl-input[type="currency" label="Input type: Currency"]
       | NOT
     |  have input masking at this time
 br
-sl-input[type="date" label="Input type: Date" placeholder="Date" help-text="Calendar icon opens the browser default date picker"]
+sl-input[
+  type="date"
+  label="Input type: Date"
+  placeholder="Date"
+  help-text="Calendar icon opens the browser default date picker"
+]
 br
-sl-input[type="email" label="Input type: Email"]
+sl-input[
+  type="email"
+  label="Input type: Email"
+]
   div[slot="help-text"]
     | Has no icon by default
 br
-sl-input[type="email" label="Input type: Email, with icon" optional-icon]
+sl-input[
+  type="email"
+  label="Input type: Email, with icon"
+  optional-icon="true"
+]
   div[slot="help-text"]
     | Use the
     code
       | optional-icon
     |  attribute to display the default optional icon for email inputs
 br
-sl-input[type="tel" label="Input type: Tel"]
+sl-input[
+  type="tel"
+  label="Input type: Tel"
+]
   div[slot="help-text"]
     | Has no icon by default
 br
-sl-input[type="tel" label="Input type: Tel, with icon" optional-icon]
+sl-input[
+  type="tel"
+  label="Input type: Tel, with icon"
+  optional-icon="true"
+]
   div[slot="help-text"]
     | Use the
     code
       | optional-icon
     |  attribute to display the default optional icon for phone number inputs
 br
-sl-input[type="number" label="Input type: Number"]
+sl-input[
+  type="number"
+  label="Input type: Number"
+]
 br
-sl-input[type="number" label="Input type: Number, no spin buttons" no-spin-buttons]
+sl-input[
+  type="number"
+  label="Input type: Number, no spin buttons"
+  no-spin-buttons="true"
+]
   div[slot="help-text"]
     | Use the
     code
       | no-spin-buttons
     |  attribute to hide the browser's default increment/decrement buttons for number inputs
 br
-sl-input[type="search" label="Input type: Search" clearable]
+sl-input[
+  type="search"
+  label="Input type: Search"
+  clearable="true"
+]
   div[slot="help-text"]
     | Has a search icon by default. Use the
     code
@@ -477,6 +668,9 @@ Follow these general guidelines when adding prefix and suffix icons to the input
 :::warning
 **Note:** If you find your use case requires a different size or color from the default, bring it up to the Design Team so that we can consider whether the pattern needs to be updated.
 :::
+:::warning
+**Note:** `ts_form_for` doesn't support slots. Prefix and suffix icons cannot be added when rendering `sl-input` with `ts_form_for`. However, the `optional-icon` attribute can be set to `true` to display default icons for input types `currency`, `email`, `tel`, and `search`.
+:::
 
 ```html:preview
 <sl-input label="Prefix icon example: DO">
@@ -497,17 +691,50 @@ Follow these general guidelines when adding prefix and suffix icons to the input
 ```
 
 ```pug:slim
-sl-input[label="Prefix icon example: DO"]
-  sl-icon[name="rocket-launch" library="fa" slot="prefix"]
+/*
+  NOTE: `ts_form_for` doesn't support slots. Prefix and suffix icons
+  cannot be added when rendering `sl-input` with `ts_form_for`. However,
+  the `optional-icon` attribute can be set to `true` to display default icons
+  for input types `currency`, `email`, `tel`, and `search`.
+*/
+
+sl-input label="Prefix icon example: DO"
+  sl-icon[
+    name="rocket-launch"
+    library="fa"
+    slot="prefix"
+  ]
 br
-sl-input[label="Prefix icon example: DON'T"]
-  sl-icon[name="fad-rocket-launch" library="fa" style="font-size: 1.25rem; color:mediumaquamarine;" slot="prefix"]
+sl-input label="Prefix icon example: DON'T"
+  sl-icon[
+    name="fad-rocket-launch"
+    library="fa"
+    style="font-size: 1.25rem; color:mediumaquamarine;"
+    slot="prefix"
+  ]
 br
-sl-input[label="Prefix icon example: POSSIBLE EXCEPTION" help-text="An icon that is hard to read at the default size." value="Input text, default alignment"]
-  sl-icon[name="user-magnifying-glass" library="fa" slot="prefix"]
+sl-input[
+  label="Prefix icon example: POSSIBLE EXCEPTION"
+  help-text="An icon that is hard to read at the default size."
+  value="Input text, default alignment"
+]
+  sl-icon[
+    name="user-magnifying-glass"
+    library="fa"
+    slot="prefix"
+  ]
 br
-sl-input[label="Prefix icon example: RESIZED" help-text="Same icon as above, resized. Note that a larger prefix or suffix icon will push the input text out of alignment." value="Input text, shifted 4px right due to icon size"]
-  sl-icon[name="user-magnifying-glass" library="fa" style="font-size: 1.25rem;" slot="prefix"]
+sl-input[
+  label="Prefix icon example: RESIZED"
+  help-text="Same icon as above, resized. Note that a larger prefix or suffix icon will push the input text out of alignment."
+  value="Input text, shifted 4px right due to icon size"
+]
+  sl-icon[
+    name="user-magnifying-glass"
+    library="fa"
+    style="font-size: 1.25rem;"
+    slot="prefix"
+  ]
 ```
 
 ```jsx:react
@@ -575,9 +802,45 @@ Use [CSS parts](#css-parts) to customize the way form controls are drawn. This e
 ```
 
 ```pug:slim
-sl-input.label-on-left label="Name" help-text="Enter your name"
-sl-input.label-on-left label="Email" type="email" help-text="Enter your email"
-sl-textarea.label-on-left label="Bio" help-text="Tell us something about yourself"
+sl-input.label-on-left[
+  label="Name"
+  help-text="Enter your name"
+]
+sl-input.label-on-left[
+  label="Email"
+  type="email"
+  help-text="Enter your email"
+]
+sl-textarea.label-on-left[
+  label="Bio"
+  help-text="Tell us something about yourself"
+]
+
+/*
+  When rendering with ts_form_for
+*/
+
+= ts_form_for ... do |f|
+  = f.input :name,
+    input_html: {
+      label: "Name",
+      "help-text": "Enter your name",
+      class: "label-on-left",
+    }
+  = f.input :name,
+    input_html: {
+      label: "Email",
+      type: "email",
+      "help-text": "Enter your email",
+      class: "label-on-left",
+    }
+  = f.input :name,
+    as: :text,
+    input_html: {
+      label: "Bio",
+      "help-text": "Tell us something about yourself",
+      class: "label-on-left",
+    }
 
 css:
   .label-on-left {

--- a/docs/pages/components/radio-button.md
+++ b/docs/pages/components/radio-button.md
@@ -30,13 +30,6 @@ sl-radio-group label="Select an option" name="a" value="1"
   sl-radio-button value="3" Option 3
 ```
 
-```pug:slim
-sl-radio-group label="Select an option" name="a" value="1"
-  sl-radio-button value="1" Option 1
-  sl-radio-button value="2" Option 2
-  sl-radio-button value="3" Option 3
-```
-
 ```jsx:react
 import SlRadioButton from '@teamshares/shoelace/dist/react/radio-button';
 import SlRadioGroup from '@teamshares/shoelace/dist/react/radio-group';
@@ -60,6 +53,13 @@ To set the initial value and checked state, use the `value` attribute on the con
   <sl-radio-button value="2">Option 2</sl-radio-button>
   <sl-radio-button value="3">Option 3</sl-radio-button>
 </sl-radio-group>
+```
+
+```pug:slim
+sl-radio-group label="Select an option" name="a" value="1"
+  sl-radio-button value="1" Option 1
+  sl-radio-button value="2" Option 2
+  sl-radio-button value="3" Option 3
 ```
 
 ```jsx:react

--- a/docs/pages/components/radio-group.md
+++ b/docs/pages/components/radio-group.md
@@ -26,7 +26,7 @@ guidelines: |
 A basic radio group lays out multiple radio items vertically. Generally a radio group should have one item selected by default.
 
 ```html:preview
-<sl-radio-group label="What would you like to do?" name="a" value="issue_shares" required>
+<sl-radio-group label="What would you like to do?" name="a" value="issue_shares">
   <sl-radio value="issue_shares">Issue shares</sl-radio>
   <sl-radio value="employee_buyback">Employee buyback</sl-radio>
   <sl-radio value="cancel_certificate">Cancel a certificate</sl-radio>
@@ -38,7 +38,6 @@ sl-radio-group[
   label="What would you like to do?"
   name="a"
   value="issue_shares"
-  required
 ]
   sl-radio value="issue_shares" Issue shares
   sl-radio value="employee_buyback" Employee buyback
@@ -60,10 +59,7 @@ sl-radio-group[
       ["Issue shares", "issue_shares"],
       ["Employee buyback", "employee_buyback"],
       ["Cancel a certificate", "cancel_certificate"],
-    ],
-    wrapper_html: {
-      required: true
-    }
+    ]
 ```
 
 ```jsx:react
@@ -477,7 +473,15 @@ sl-radio-group[
   When rendering with ts_form_for
   — NOTE: To set default value for initial page load, ensure a value is set
   in the controller's #new action:
-  e.g. if using `ts_form_for @cap_table_event`, set @cap_table_event = CapTableEvent.new(a: "issue_shares")
+  e.g. if using `ts_form_for @cap_table_event`,
+  set @cap_table_event = CapTableEvent.new(a: "issue_shares")
+
+  When rendering `sl-checkbox-group` with ts_form_for, pass additional
+  attributes such as `disabled` and `description` as extra items
+  in the collection array after the label and value.
+  By default Simple Form will use the first item
+  as the label and the second item as the value, then pass
+  any additional array items as attributes on the `sl-checkbox`.
 */
 
 = ts_form_for ... do |f|
@@ -485,14 +489,18 @@ sl-radio-group[
     as: :radio_buttons,
     label: "What would you like to do?",
     collection: [
-      // Use {} to keep additional attributes like 'description' and 'disabled'
-      // separate from the main label/value elements
-      ["Issue shares", {}, "issue_shares"],
-      ["Employee buyback", {}, "employee_buyback"],
+      [
+        "Issue shares",
+        "issue_shares"
+      ],
+      [
+        "Employee buyback",
+        "employee_buyback"
+      ],
       [
         "Cancel a certificate",
-        { disabled: true },
         "cancel_certificate"
+        disabled: true,
       ],
     ]
 ```

--- a/docs/pages/components/radio-group.md
+++ b/docs/pages/components/radio-group.md
@@ -49,7 +49,7 @@ sl-radio-group[
   — NOTE: To set default value for initial page load, ensure a value is set
   in the controller's #new action:
 
-  e.g. @cap_table_event = CapTableEvent.new(a: "issue_shares")
+  e.g. if using `ts_form_for @cap_table_event`, set @cap_table_event = CapTableEvent.new(a: "issue_shares")
 */
 
 = ts_form_for ... do |f|
@@ -127,7 +127,7 @@ sl-radio-group[
   When rendering with ts_form_for
   — NOTE: To set default value for initial page load, ensure a value is set
   in the controller's #new action:
-  e.g. @cap_table_event = CapTableEvent.new(a: "issue_shares")
+  e.g. if using `ts_form_for @cap_table_event`, set @cap_table_event = CapTableEvent.new(a: "issue_shares")
 
   — NOTE: Slots are not supported with ts_form_for —
 */
@@ -190,7 +190,7 @@ sl-radio-group[
   When rendering with ts_form_for
   — NOTE: To set default value for initial page load, ensure a value is set
   in the controller's #new action:
-  e.g. @cap_table_event = CapTableEvent.new(a: "issue_shares")
+  e.g. if using `ts_form_for @cap_table_event`, set @cap_table_event = CapTableEvent.new(a: "issue_shares")
 */
 
 = ts_form_for ... do |f|
@@ -264,7 +264,7 @@ sl-radio-group[
   When rendering with ts_form_for
   — NOTE: To set default value for initial page load, ensure a value is set
   in the controller's #new action:
-  e.g. @cap_table_event = CapTableEvent.new(a: "issue_shares")
+  e.g. if using `ts_form_for @cap_table_event`, set @cap_table_event = CapTableEvent.new(a: "issue_shares")
 */
 
 = ts_form_for ... do |f|
@@ -356,7 +356,7 @@ sl-radio-group[
   When rendering with ts_form_for
   — NOTE: To set default value for initial page load, ensure a value is set
   in the controller's #new action:
-  e.g. @cap_table_event = CapTableEvent.new(a: "issue_shares")
+  e.g. if using `ts_form_for @cap_table_event`, set @cap_table_event = CapTableEvent.new(a: "issue_shares")
 */
 
 = ts_form_for ... do |f|
@@ -477,7 +477,7 @@ sl-radio-group[
   When rendering with ts_form_for
   — NOTE: To set default value for initial page load, ensure a value is set
   in the controller's #new action:
-  e.g. @cap_table_event = CapTableEvent.new(a: "issue_shares")
+  e.g. if using `ts_form_for @cap_table_event`, set @cap_table_event = CapTableEvent.new(a: "issue_shares")
 */
 
 = ts_form_for ... do |f|
@@ -485,12 +485,12 @@ sl-radio-group[
     as: :radio_buttons,
     label: "What would you like to do?",
     collection: [
-      ["Issue shares", "issue_shares"],
-      ["Employee buyback", "employee_buyback"],
+      // Use {} to keep additional attributes like 'description' and 'disabled'
+      // separate from the main label/value elements
+      ["Issue shares", {}, "issue_shares"],
+      ["Employee buyback", {}, "employee_buyback"],
       [
         "Cancel a certificate",
-        // Use {} to keep additional attributes like 'description' and 'disabled'
-        // separate from the main label/value elements
         { disabled: true },
         "cancel_certificate"
       ],
@@ -550,7 +550,7 @@ sl-radio-group.radio-group-size[
   When rendering with ts_form_for
   — NOTE: To set default value for initial page load, ensure a value is set
   in the controller's #new action:
-  e.g. @cap_table_event = CapTableEvent.new(a: "issue_shares")
+  e.g. if using `ts_form_for @cap_table_event`, set @cap_table_event = CapTableEvent.new(a: "issue_shares")
 */
 
 = ts_form_for ... do |f|

--- a/docs/pages/components/radio-group.md
+++ b/docs/pages/components/radio-group.md
@@ -476,12 +476,12 @@ sl-radio-group[
   e.g. if using `ts_form_for @cap_table_event`,
   set @cap_table_event = CapTableEvent.new(a: "issue_shares")
 
-  When rendering `sl-checkbox-group` with ts_form_for, pass additional
+  When rendering `sl-radio-group` with ts_form_for, pass additional
   attributes such as `disabled` and `description` as extra items
   in the collection array after the label and value.
   By default Simple Form will use the first item
   as the label and the second item as the value, then pass
-  any additional array items as attributes on the `sl-checkbox`.
+  any additional array items as attributes on the `sl-radio`.
 */
 
 = ts_form_for ... do |f|

--- a/docs/pages/components/radio-group.md
+++ b/docs/pages/components/radio-group.md
@@ -487,7 +487,13 @@ sl-radio-group[
     collection: [
       ["Issue shares", "issue_shares"],
       ["Employee buyback", "employee_buyback"],
-      ["Cancel a certificate", "cancel_certificate", disabled: true],
+      [
+        "Cancel a certificate",
+        // Use {} to keep additional attributes like 'description' and 'disabled'
+        // separate from the main label/value elements
+        { disabled: true },
+        "cancel_certificate"
+      ],
     ]
 ```
 

--- a/docs/pages/components/radio-group.md
+++ b/docs/pages/components/radio-group.md
@@ -34,10 +34,36 @@ A basic radio group lays out multiple radio items vertically. Generally a radio 
 ```
 
 ```pug:slim
-sl-radio-group label="What would you like to do?" name="a" value="issue_shares" required
+sl-radio-group[
+  label="What would you like to do?"
+  name="a"
+  value="issue_shares"
+  required
+]
   sl-radio value="issue_shares" Issue shares
   sl-radio value="employee_buyback" Employee buyback
   sl-radio value="cancel_certificate" Cancel a certificate
+
+/*
+  When rendering with ts_form_for
+  — NOTE: To set default value for initial page load, ensure a value is set
+  in the controller's #new action:
+
+  e.g. @cap_table_event = CapTableEvent.new(a: "issue_shares")
+*/
+
+= ts_form_for ... do |f|
+  = f.input :a,
+    as: :radio_buttons,
+    label: "What would you like to do?",
+    collection: [
+      ["Issue shares", "issue_shares"],
+      ["Employee buyback", "employee_buyback"],
+      ["Cancel a certificate", "cancel_certificate"],
+    ],
+    wrapper_html: {
+      required: true
+    }
 ```
 
 ```jsx:react
@@ -74,19 +100,50 @@ Add descriptive help text to a radio group with the `help-text` attribute. For h
 ```
 
 ```pug:slim
-sl-radio-group label="What would you like to do?" name="a" value="issue_shares" help-text="Contact support if you don't see the option you need here"
+sl-radio-group[
+  label="What would you like to do?"
+  name="a"
+  value="issue_shares"
+  help-text="Contact support if you don't see the option you need here"
+]
   sl-radio value="issue_shares" Issue shares
   sl-radio value="employee_buyback" Employee buyback
   sl-radio value="cancel_certificate" Cancel a certificate
 br
 br
-sl-radio-group label="What would you like to do?" name="a" value="issue_shares"
+sl-radio-group[
+  label="What would you like to do?"
+  name="a"
+  value="issue_shares"
+]
   sl-radio value="issue_shares" Issue shares
   sl-radio value="employee_buyback" Employee buyback
   sl-radio value="cancel_certificate" Cancel a certificate
   div slot="help-text"
     a href="#" class="ts-text-link" Contact support
     | if you don't see the option you need here
+
+/*
+  When rendering with ts_form_for
+  — NOTE: To set default value for initial page load, ensure a value is set
+  in the controller's #new action:
+  e.g. @cap_table_event = CapTableEvent.new(a: "issue_shares")
+
+  — NOTE: Slots are not supported with ts_form_for —
+*/
+
+= ts_form_for ... do |f|
+  = f.input :a,
+    as: :radio_buttons,
+    label: "What would you like to do?",
+    collection: [
+      ["Issue shares", "issue_shares"],
+      ["Employee buyback", "employee_buyback"],
+      ["Cancel a certificate", "cancel_certificate"],
+    ],
+    wrapper_html: {
+      "help-text": "Contact support if you don't see the option you need here"
+    }
 ```
 
 ```jsx:react
@@ -119,10 +176,36 @@ Use the `label-tooltip` attribute to add text that appears in a tooltip triggere
 ```
 
 ```pug:slim
-sl-radio-group label="What would you like to do?" help-text="Contact support if you don't see the option you need here" name="a" value="issue_shares" label-tooltip="These changes will update the cap table"
+sl-radio-group[
+  label="What would you like to do?"
+  help-text="Contact support if you don't see the option you need here"
+  name="a" value="issue_shares"
+  label-tooltip="These changes will update the cap table"
+]
   sl-radio value="issue_shares" Issue shares
   sl-radio value="employee_buyback" Employee buyback
   sl-radio value="cancel_certificate" Cancel a certificate
+
+/*
+  When rendering with ts_form_for
+  — NOTE: To set default value for initial page load, ensure a value is set
+  in the controller's #new action:
+  e.g. @cap_table_event = CapTableEvent.new(a: "issue_shares")
+*/
+
+= ts_form_for ... do |f|
+  = f.input :a,
+    as: :radio_buttons,
+    label: "What would you like to do?",
+    collection: [
+      ["Issue shares", "issue_shares"],
+      ["Employee buyback", "employee_buyback"],
+      ["Cancel a certificate", "cancel_certificate"],
+    ],
+    wrapper_html: {
+      "help-text": "Contact support if you don't see the option you need here",
+      "label-tooltip": "These changes will update the cap table",
+    }
 ```
 
 ```jsx:react
@@ -167,9 +250,35 @@ Use the `horizontal` attribute to lay out multiple radio items horizontally.
 ```
 
 ```pug:slim
-sl-radio-group id="question-1" label="What would you like to do?" name="a" value="issue_shares" horizontal="true"
+sl-radio-group[
+  id="question-1"
+  label="What would you like to do?"
+  name="a"
+  value="issue_shares"
+  horizontal="true"
+]
   sl-radio value="issue_shares" Issue shares
   sl-radio value="employee_buyback" Employee buyback
+
+/*
+  When rendering with ts_form_for
+  — NOTE: To set default value for initial page load, ensure a value is set
+  in the controller's #new action:
+  e.g. @cap_table_event = CapTableEvent.new(a: "issue_shares")
+*/
+
+= ts_form_for ... do |f|
+  = f.input :a,
+    as: :radio_buttons,
+    label: "What would you like to do?",
+    collection: [
+      ["Issue shares", "issue_shares"],
+      ["Employee buyback", "employee_buyback"],
+    ],
+    wrapper_html: {
+      horizontal: true,
+      id: "question-1",
+    }
 
 css:
     sl-radio-group[id="question-1"] {
@@ -211,7 +320,7 @@ This option can be combined with the `horizontal` attribute.
 </sl-radio-group>
 <br/>
 <br/>
-<sl-radio-group label="What would you like to do?" help-text="Contact support if you don't see the option you need here" name="a" value="issue_shares" contained horizontal>
+<sl-radio-group label="What would you like to do?" help-text="Contact support if you don't see the option you need here" name="b" value="issue_shares" contained horizontal>
   <sl-radio value="issue_shares">Issue shares</sl-radio>
   <sl-radio value="employee_buyback">Employee buyback</sl-radio>
   <sl-radio value="cancel_certificate">Cancel a certificate</sl-radio>
@@ -219,17 +328,63 @@ This option can be combined with the `horizontal` attribute.
 ```
 
 ```pug:slim
-sl-radio-group label="What would you like to do?" name="a" value="issue_shares" help-text="Contact support if you don't see the option you need here" horizontal="true" contained="true"
+sl-radio-group[
+  label="What would you like to do?"
+  name="a"
+  value="issue_shares"
+  help-text="Contact support if you don't see the option you need here"
+  contained="true"
+]
   sl-radio value="issue_shares" Issue shares
   sl-radio value="employee_buyback" Employee buyback
   sl-radio value="cancel_certificate" Cancel a certificate
 br
 br
-sl-radio-group label="What would you like to do?" name="a" value="issue_shares" help-text="Contact support if you don't see the option you need here" horizontal="true" contained="true" horizontal="true"
+sl-radio-group[
+  label="What would you like to do?"
+  name="b"
+  value="issue_shares"
+  help-text="Contact support if you don't see the option you need here"
+  horizontal="true"
+  contained="true"
+]
   sl-radio value="issue_shares" Issue shares
   sl-radio value="employee_buyback" Employee buyback
   sl-radio value="cancel_certificate" Cancel a certificate
 
+/*
+  When rendering with ts_form_for
+  — NOTE: To set default value for initial page load, ensure a value is set
+  in the controller's #new action:
+  e.g. @cap_table_event = CapTableEvent.new(a: "issue_shares")
+*/
+
+= ts_form_for ... do |f|
+  = f.input :a,
+    as: :radio_buttons,
+    label: "What would you like to do?",
+    collection: [
+      ["Issue shares", "issue_shares"],
+      ["Employee buyback", "employee_buyback"],
+      ["Cancel a certificate", "cancel_certificate"],
+    ],
+    wrapper_html: {
+      "help-text": "Contact support if you don't see the option you need here"
+      horizontal: true,
+    }
+  = f.input :b,
+    as: :radio_buttons,
+    label: "What would you like to do?",
+    collection: [
+      ["Issue shares", "issue_shares"],
+      ["Employee buyback", "employee_buyback"],
+      ["Cancel a certificate", "cancel_certificate"],
+    ],
+    wrapper_html: {
+      "help-text": "Contact support if you don't see the option you need here"
+      horizontal: true,
+      contained: true,
+    }
 ```
 
 ```jsx:react
@@ -256,6 +411,9 @@ Shoelace's [radio buttons](/components/radio-button), also commonly called Segme
 :::warning
 **Note:** The Radio Button pattern is being redesigned. Please check with the design team before using this pattern.
 :::
+:::warning
+**Note:** `ts_form_for` doesn't support `sl-radio-button`.
+:::
 
 ```html:preview
 <sl-radio-group label="Select an option" help-text="Select an option that makes you proud." name="a" value="1">
@@ -266,7 +424,15 @@ Shoelace's [radio buttons](/components/radio-button), also commonly called Segme
 ```
 
 ```pug:slim
-sl-radio-group label="Select an option" help-text="Select an option that makes you proud." name="a" value="1"
+/*
+  NOTE: `ts_form_for` doesn't support `sl-radio-button`.
+*/
+sl-radio-group[
+  label="Select an option"
+  help-text="Select an option that makes you proud."
+  name="a"
+  value="1"
+]
   sl-radio-button value="1" Option 1
   sl-radio-button value="2" Option 2
   sl-radio-button value="3" Option 3
@@ -298,10 +464,31 @@ Radios and radio buttons can be disabled by adding the `disabled` attribute to t
 ```
 
 ```pug:slim
-sl-radio-group label="What would you like to do?" name="a" value="issue_shares"
+sl-radio-group[
+  label="What would you like to do?"
+  name="a"
+  value="issue_shares"
+]
   sl-radio value="issue_shares" Issue shares
   sl-radio value="employee_buyback" Employee buyback
-  sl-radio value="cancel_certificate" disabled="true"  Cancel a certificate
+  sl-radio value="cancel_certificate" disabled="true" Cancel a certificate
+
+/*
+  When rendering with ts_form_for
+  — NOTE: To set default value for initial page load, ensure a value is set
+  in the controller's #new action:
+  e.g. @cap_table_event = CapTableEvent.new(a: "issue_shares")
+*/
+
+= ts_form_for ... do |f|
+  = f.input :a,
+    as: :radio_buttons,
+    label: "What would you like to do?",
+    collection: [
+      ["Issue shares", "issue_shares"],
+      ["Employee buyback", "employee_buyback"],
+      ["Cancel a certificate", "cancel_certificate", disabled: true],
+    ]
 ```
 
 ```jsx:react
@@ -344,15 +531,36 @@ Sizes `small` and `large` are currently not part of the Teamshares Design System
 ```
 
 ```pug:slim
-sl-radio-group.radio-group-size[label="Select an option" size="medium" value="medium"]
-  sl-radio[value="small"]
-    | Small
-  sl-radio[value="medium"]
-    | Medium
-  sl-radio[value="large"]
-    | Large
+sl-radio-group.radio-group-size[
+  label="Select an option"
+  size="medium"
+  value="medium"
+]
+  sl-radio value="small" Small
+  sl-radio value="medium" Medium
+  sl-radio value="large" Large
 
-javascript
+/*
+  When rendering with ts_form_for
+  — NOTE: To set default value for initial page load, ensure a value is set
+  in the controller's #new action:
+  e.g. @cap_table_event = CapTableEvent.new(a: "issue_shares")
+*/
+
+= ts_form_for ... do |f|
+  = f.input :a,
+    as: :radio_buttons,
+    label: "Select an option",
+    collection: [
+      ["Small", "small"],
+      ["Medium", "medium"],
+      ["Large", "large"],
+    ],
+    wrapper_html: {
+      class: "radio-group-size"
+    }
+
+javascript:
   const radioGroup = document.querySelector('.radio-group-size');
   radioGroup.addEventListener('sl-change', () => {
     radioGroup.size = radioGroup.value;
@@ -422,12 +630,40 @@ Set the `required` attribute to make selecting an option mandatory. If a value h
 
 ```pug:slim
 form.validation
-  sl-radio-group label="Select an option" name="a" required="true"
+  sl-radio-group[
+    label="Select an option"
+    name="a"
+    required="true"
+  ]
     sl-radio value="1" Option 1
     sl-radio value="2" Option 2
     sl-radio value="3" Option 3
   br
-  sl-button type="submit" variant="primary" Submit
+  sl-button[
+    type="submit"
+    variant="primary"
+  ]
+    | Submit
+
+/*
+  When rendering with ts_form_for
+*/
+
+= ts_form_for ... do |f|
+  = f.input :a,
+    as: :radio_buttons,
+    label: "Select an option",
+    collection: [
+        ["Option 1", "1"],
+        ["Option 2", "2"],
+        ["Option 3", "3"],
+    ],
+    wrapper_html: {
+      required: true
+    }
+  br
+  // ts_form_for automatically sets the form's submit button to variant="primary"
+  = f.submit "Submit"
 
 javascript:
   const form = document.querySelector(.validation);

--- a/docs/pages/components/radio.md
+++ b/docs/pages/components/radio.md
@@ -24,10 +24,35 @@ Radios are designed to be used with [radio groups](/components/radio-group).
 ```
 
 ```pug:slim
-sl-radio-group label="What would you like to do?" name="a" value="issue_shares" required
+sl-radio-group[
+  label="What would you like to do?"
+  name="a"
+  value="issue_shares"
+  required
+]
   sl-radio value="issue_shares" Issue shares
   sl-radio value="employee_buyback" Employee buyback
   sl-radio value="cancel_certificate" Cancel a certificate
+
+/*
+  When rendering with ts_form_for
+  — NOTE: To set default value for initial page load, ensure a value is set
+  in the controller's #new action:
+  e.g. @cap_table_event = CapTableEvent.new(a: "issue_shares")
+*/
+
+= ts_form_for ... do |f|
+  = f.input :a,
+    as: :radio_buttons,
+    label: "What would you like to do?",
+    collection: [
+      ["Issue shares", "issue_shares"],
+      ["Employee buyback", "employee_buyback"],
+      ["Cancel a certificate", "cancel_certificate"],
+    ],
+    wrapper_html: {
+      required: true
+    }
 ```
 
 ```jsx:react
@@ -62,13 +87,62 @@ Add descriptive help text to individual radio items with the `description` attri
 ```
 
 ```pug:slim
-sl-radio-group label="What would you like to do?" name="a" value="issue_shares" required
-  sl-radio value="issue_shares" description="Awards company shares to an employee" Issue shares
-  sl-radio value="employee_buyback" description="Buys back vested shares from departing employee owners" Employee buyback
-  sl-radio value="cancel_certificate"
+sl-radio-group[
+  label="What would you like to do?"
+  name="a"
+  value="issue_shares"
+]
+  sl-radio[
+    value="issue_shares"
+    description="Awards company shares to an employee"
+  ]
+    | Issue shares
+  sl-radio[
+    value="employee_buyback"
+    description="Buys back vested shares from departing employee owners"
+   ]
+    | Employee buyback
+  sl-radio[
+    value="cancel_certificate"
+  ]
     | Cancel a certificate
     div slot="description" Declares certificate to be
       em null and void
+
+/*
+  When rendering with ts_form_for
+  — NOTE: To set default value for initial page load, ensure a value is set
+  in the controller's #new action:
+  e.g. @cap_table_event = CapTableEvent.new(a: "issue_shares")
+
+  — NOTE: Slots are not supported with ts_form_for —
+  — Example below shows usage of "description" as attribute —
+*/
+
+= ts_form_for ... do |f|
+  = f.input :a,
+    as: :radio_buttons,
+    label: "What would you like to do?",
+    collection: [
+      [
+        "Issue shares",
+        "issue_shares",
+        description: "Awards company shares to an employee",
+      ],
+      [
+        "Employee buyback",
+        "employee_buyback",
+        description: "Buys back vested shares from departing employee owners",
+      ],
+      [
+        "Cancel a certificate",
+        "cancel_certificate",
+        description: "Declares certificate to be null and void",
+      ],
+    ],
+    wrapper_html: {
+      required: true
+    }
 ```
 
 ```jsx:react
@@ -99,11 +173,63 @@ Add the `contained` attribute to the [Radio Group](/components/radio-group) to d
 ```
 
 ```pug:slim
-sl-radio-group label="Select an option" name="a" value="3"
-  sl-radio contained="true" value="1" Option 1
-  sl-radio contained="true" disabled="true" value="2" Option 2
-  sl-radio contained="true" value="3" Option 3
-    div slot="description" A short description about this option
+sl-radio-group[
+  label="What would you like to do?"
+  name="a"
+  value="issue_shares"
+  contained="true"
+]
+  sl-radio[
+    value="issue_shares"
+    description="Awards company shares to an employee"
+  ]
+    | Issue shares
+  sl-radio[
+    value="employee_buyback"
+    description="Buys back vested shares from departing employee owners"
+   ]
+    | Employee buyback
+  sl-radio[
+    value="cancel_certificate"
+  ]
+    | Cancel a certificate
+    div slot="description" Declares certificate to be
+      em null and void
+
+/*
+  When rendering with ts_form_for
+  — NOTE: To set default value for initial page load, ensure a value is set
+  in the controller's #new action:
+  e.g. @cap_table_event = CapTableEvent.new(a: "issue_shares")
+
+  — NOTE: Slots are not supported with ts_form_for —
+  — Example below shows usage of "description" as attribute —
+*/
+
+= ts_form_for ... do |f|
+  = f.input :a,
+    as: :radio_buttons,
+    label: "What would you like to do?",
+    collection: [
+      [
+        "Issue shares",
+        "issue_shares",
+        description: "Awards company shares to an employee",
+      ],
+      [
+        "Employee buyback",
+        "employee_buyback",
+        description: "Buys back vested shares from departing employee owners",
+      ],
+      [
+        "Cancel a certificate",
+        "cancel_certificate",
+        description: "Declares certificate to be null and void",
+      ]
+    ],
+    wrapper_html: {
+      contained: true
+    }
 ```
 
 ```jsx:react
@@ -134,6 +260,10 @@ Adding the `contained` attribute to the parent [Radio Group](/components/radio) 
 
 Use the `selected-content` slot to display additional content (such as an input field) inside a `contained` radio when the radio is selected (checked). The slot is unstyled by default. Use `::part(selected-content)` to style the content as needed.
 
+:::warning
+**Note:** `ts_form_for` doesn't support slots. The `selected-content` slot cannot be used for radio groups rendered with `ts_form_for`.
+:::
+
 ```html:preview
 <sl-radio-group label="Select your payment amount" name="a" value="statement-balance" contained>
   <sl-radio value="statement-balance" description="$10.00">Last statement balance
@@ -158,14 +288,39 @@ Use the `selected-content` slot to display additional content (such as an input 
 ```
 
 ```pug:slim
-sl-radio-group label="Select your payment amount" name="a" value="statement-balance" contained
-  sl-radio value="statement-balance" description="$10.00" Last statement balance
+/*
+  NOTE: `ts_form_for` doesn't support slots. The `selected-content` slot
+  cannot be used for radio groups rendered with `ts_form_for`.
+*/
+
+sl-radio-group[
+  label="Select your payment amount"
+  name="a"
+  value="statement-balance"
+  contained="true"
+]
+  sl-radio[
+    value="statement-balance"
+    description="$10.00"
+  ]
+    | Last statement balance
     div slot="selected-content" This is the amount you owe as of your Feb 21 statement
-  sl-radio value="current-balance" description="$150.00" Current balance
+  sl-radio[
+    value="current-balance"
+    description="$150.00"
+  ]
+    | Current balance
     div slot="selected-content" This is the amount you owe as of today
-  sl-radio value="custom"
+  sl-radio[
+    value="custom"
+  ]
     | Custom amount
-    sl-input style="width: 240px;" slot="selected-content" label="Amount" type="currency"
+    sl-input[
+      style="width: 240px;"
+      slot="selected-content"
+      label="Amount"
+      type="currency"
+    ]
 
 css:
   sl-radio::part(selected-content) {
@@ -199,6 +354,10 @@ const App = () => (
 
 To set the initial value and checked state, use the `value` attribute on the containing radio group. Generally a radio group should have one item selected by default.
 
+:::tip
+**Note:** When rendering with `ts_form_for`, set the initial value in the controller's #new action: e.g. `@cap_table_event = CapTableEvent.new(a: "issue_shares")`
+:::
+
 ```html:preview
 <sl-radio-group label="What would you like to do?" name="a" value="issue_shares">
   <sl-radio value="issue_shares">Issue shares</sl-radio>
@@ -208,10 +367,31 @@ To set the initial value and checked state, use the `value` attribute on the con
 ```
 
 ```pug:slim
-sl-radio-group label="What would you like to do?" name="a" value="issue_shares"
+sl-radio-group[
+  label="What would you like to do?"
+  name="a"
+  value="issue_shares"
+]
   sl-radio value="issue_shares" Issue shares
   sl-radio value="employee_buyback" Employee buyback
   sl-radio value="cancel_certificate" Cancel a certificate
+
+/*
+  When rendering with ts_form_for
+  — NOTE: To set default value for initial page load, ensure a value is set
+  in the controller's #new action:
+  e.g. @cap_table_event = CapTableEvent.new(a: "issue_shares")
+*/
+
+= ts_form_for ... do |f|
+  = f.input :a,
+    as: :radio_buttons,
+    label: "What would you like to do?",
+    collection: [
+      ["Issue shares", "issue_shares"],
+      ["Employee buyback", "employee_buyback"],
+      ["Cancel a certificate", "cancel_certificate"],
+    ]
 ```
 
 ```jsx:react
@@ -240,10 +420,31 @@ Use the `disabled` attribute to disable a radio.
 ```
 
 ```pug:slim
-sl-radio-group label="What would you like to do?" name="a" value="issue_shares"
+sl-radio-group[
+  label="What would you like to do?"
+  name="a"
+  value="issue_shares"
+]
   sl-radio value="issue_shares" Issue shares
   sl-radio value="employee_buyback" Employee buyback
-  sl-radio value="cancel_certificate" disabled="true"  Cancel a certificate
+  sl-radio value="cancel_certificate" disabled="true" Cancel a certificate
+
+/*
+  When rendering with ts_form_for
+  — NOTE: To set default value for initial page load, ensure a value is set
+  in the controller's #new action:
+  e.g. @cap_table_event = CapTableEvent.new(a: "issue_shares")
+*/
+
+= ts_form_for ... do |f|
+  = f.input :a,
+    as: :radio_buttons,
+    label: "What would you like to do?",
+    collection: [
+      ["Issue shares", "issue_shares"],
+      ["Employee buyback", "employee_buyback"],
+      ["Cancel a certificate", "cancel_certificate", disabled: true],
+    ]
 ```
 
 ```jsx:react

--- a/docs/pages/components/radio.md
+++ b/docs/pages/components/radio.md
@@ -126,18 +126,18 @@ sl-radio-group[
     collection: [
       [
         "Issue shares",
+        { description: "Awards company shares to an employee" },
         "issue_shares",
-        description: "Awards company shares to an employee",
       ],
       [
         "Employee buyback",
+        { description: "Buys back vested shares from departing employee owners" },
         "employee_buyback",
-        description: "Buys back vested shares from departing employee owners",
       ],
       [
         "Cancel a certificate",
+        { description: "Declares certificate to be null and void" },
         "cancel_certificate",
-        description: "Declares certificate to be null and void",
       ],
     ],
     wrapper_html: {
@@ -166,7 +166,7 @@ Add the `contained` attribute to the [Radio Group](/components/radio-group) to d
 <sl-radio-group label="What would you like to do?" name="a" value="issue_shares" contained>
   <sl-radio value="issue_shares" description="Awards company shares to an employee" >Issue shares</sl-radio>
   <sl-radio value="employee_buyback" description="Buys back vested shares from departing employee owners">Employee buyback</sl-radio>
-  <sl-radio value="cancel_certificate">Cancel a certificate
+  <sl-radio value="cancel_certificate" disabled>Cancel a certificate
     <div slot="description">Declares certificate to be <em>null and void</em></div>
   </sl-radio>
 </sl-radio-group>
@@ -191,6 +191,7 @@ sl-radio-group[
     | Employee buyback
   sl-radio[
     value="cancel_certificate"
+    disabled="true"
   ]
     | Cancel a certificate
     div slot="description" Declares certificate to be
@@ -213,18 +214,23 @@ sl-radio-group[
     collection: [
       [
         "Issue shares",
+        { description: "Awards company shares to an employee" },
         "issue_shares",
-        description: "Awards company shares to an employee",
       ],
       [
         "Employee buyback",
+        { description: "Buys back vested shares from departing employee owners" },
         "employee_buyback",
-        description: "Buys back vested shares from departing employee owners",
       ],
       [
         "Cancel a certificate",
+        // Use {} to keep additional attributes like 'description' and 'disabled'
+        // separate from the main label/value elements
+        {
+          description: "Declares certificate to be null and void",
+          disabled: true,
+        },
         "cancel_certificate",
-        description: "Declares certificate to be null and void",
       ]
     ],
     wrapper_html: {
@@ -443,7 +449,13 @@ sl-radio-group[
     collection: [
       ["Issue shares", "issue_shares"],
       ["Employee buyback", "employee_buyback"],
-      ["Cancel a certificate", "cancel_certificate", disabled: true],
+      [
+        "Cancel a certificate",
+        // Use {} to keep additional attributes like 'description' and 'disabled'
+        // separate from the main label/value elements
+        { disabled: true },
+        "cancel_certificate",
+      ],
     ]
 ```
 

--- a/docs/pages/components/radio.md
+++ b/docs/pages/components/radio.md
@@ -38,7 +38,7 @@ sl-radio-group[
   When rendering with ts_form_for
   — NOTE: To set default value for initial page load, ensure a value is set
   in the controller's #new action:
-  e.g. @cap_table_event = CapTableEvent.new(a: "issue_shares")
+  e.g. if using `ts_form_for @cap_table_event`, set @cap_table_event = CapTableEvent.new(a: "issue_shares")
 */
 
 = ts_form_for ... do |f|
@@ -113,7 +113,7 @@ sl-radio-group[
   When rendering with ts_form_for
   — NOTE: To set default value for initial page load, ensure a value is set
   in the controller's #new action:
-  e.g. @cap_table_event = CapTableEvent.new(a: "issue_shares")
+  e.g. if using `ts_form_for @cap_table_event`, set @cap_table_event = CapTableEvent.new(a: "issue_shares")
 
   — NOTE: Slots are not supported with ts_form_for —
   — Example below shows usage of "description" as attribute —
@@ -124,6 +124,8 @@ sl-radio-group[
     as: :radio_buttons,
     label: "What would you like to do?",
     collection: [
+      // Use {} to keep additional attributes like 'description' and 'disabled'
+      // separate from the main label/value elements
       [
         "Issue shares",
         { description: "Awards company shares to an employee" },
@@ -201,7 +203,7 @@ sl-radio-group[
   When rendering with ts_form_for
   — NOTE: To set default value for initial page load, ensure a value is set
   in the controller's #new action:
-  e.g. @cap_table_event = CapTableEvent.new(a: "issue_shares")
+  e.g. if using `ts_form_for @cap_table_event`, set @cap_table_event = CapTableEvent.new(a: "issue_shares")
 
   — NOTE: Slots are not supported with ts_form_for —
   — Example below shows usage of "description" as attribute —
@@ -212,6 +214,8 @@ sl-radio-group[
     as: :radio_buttons,
     label: "What would you like to do?",
     collection: [
+      // Use {} to keep additional attributes like 'description' and 'disabled'
+      // separate from the main label/value elements
       [
         "Issue shares",
         { description: "Awards company shares to an employee" },
@@ -224,8 +228,6 @@ sl-radio-group[
       ],
       [
         "Cancel a certificate",
-        // Use {} to keep additional attributes like 'description' and 'disabled'
-        // separate from the main label/value elements
         {
           description: "Declares certificate to be null and void",
           disabled: true,
@@ -386,7 +388,7 @@ sl-radio-group[
   When rendering with ts_form_for
   — NOTE: To set default value for initial page load, ensure a value is set
   in the controller's #new action:
-  e.g. @cap_table_event = CapTableEvent.new(a: "issue_shares")
+  e.g. if using `ts_form_for @cap_table_event`, set @cap_table_event = CapTableEvent.new(a: "issue_shares")
 */
 
 = ts_form_for ... do |f|
@@ -439,7 +441,7 @@ sl-radio-group[
   When rendering with ts_form_for
   — NOTE: To set default value for initial page load, ensure a value is set
   in the controller's #new action:
-  e.g. @cap_table_event = CapTableEvent.new(a: "issue_shares")
+  e.g. if using `ts_form_for @cap_table_event`, set @cap_table_event = CapTableEvent.new(a: "issue_shares")
 */
 
 = ts_form_for ... do |f|
@@ -447,12 +449,12 @@ sl-radio-group[
     as: :radio_buttons,
     label: "What would you like to do?",
     collection: [
-      ["Issue shares", "issue_shares"],
-      ["Employee buyback", "employee_buyback"],
+      // Use {} to keep additional attributes like 'description' and 'disabled'
+      // separate from the main label/value elements
+      ["Issue shares", {}, "issue_shares"],
+      ["Employee buyback", {}, "employee_buyback"],
       [
         "Cancel a certificate",
-        // Use {} to keep additional attributes like 'description' and 'disabled'
-        // separate from the main label/value elements
         { disabled: true },
         "cancel_certificate",
       ],

--- a/docs/pages/components/radio.md
+++ b/docs/pages/components/radio.md
@@ -363,7 +363,7 @@ const App = () => (
 To set the initial value and checked state, use the `value` attribute on the containing radio group. Generally a radio group should have one item selected by default.
 
 :::tip
-**Note:** When rendering with `ts_form_for`, set the initial value in the controller's #new action: e.g. `@cap_table_event = CapTableEvent.new(a: "issue_shares")`
+**Note:** When rendering with `ts_form_for`, set the initial value in the controller's #new action: e.g. if using `ts_form_for @cap_table_event`, `@cap_table_event = CapTableEvent.new(a: "issue_shares")`
 :::
 
 ```html:preview

--- a/docs/pages/components/radio.md
+++ b/docs/pages/components/radio.md
@@ -119,12 +119,12 @@ sl-radio-group[
   — NOTE: Slots are not supported with ts_form_for —
   — Example below shows usage of "description" as attribute —
 
-  When rendering `sl-checkbox-group` with ts_form_for, pass additional
+  When rendering `sl-radio-group` with ts_form_for, pass additional
   attributes such as `disabled` and `description` as extra items
   in the collection array after the label and value.
   By default Simple Form will use the first item
   as the label and the second item as the value, then pass
-  any additional array items as attributes on the `sl-checkbox`.
+  any additional array items as attributes on the `sl-radio`.
 */
 
 = ts_form_for ... do |f|
@@ -215,12 +215,12 @@ sl-radio-group[
   — NOTE: Slots are not supported with ts_form_for —
   — Example below shows usage of "description" as attribute —
 
-  When rendering `sl-checkbox-group` with ts_form_for, pass additional
+  When rendering `sl-radio-group` with ts_form_for, pass additional
   attributes such as `disabled` and `description` as extra items
   in the collection array after the label and value.
   By default Simple Form will use the first item
   as the label and the second item as the value, then pass
-  any additional array items as attributes on the `sl-checkbox`.
+  any additional array items as attributes on the `sl-radio`.
 */
 
 = ts_form_for ... do |f|
@@ -454,12 +454,12 @@ sl-radio-group[
   e.g. if using `ts_form_for @cap_table_event`,
   set @cap_table_event = CapTableEvent.new(a: "issue_shares")
 
-  When rendering `sl-checkbox-group` with ts_form_for, pass additional
+  When rendering `sl-radio-group` with ts_form_for, pass additional
   attributes such as `disabled` and `description` as extra items
   in the collection array after the label and value.
   By default Simple Form will use the first item
   as the label and the second item as the value, then pass
-  any additional array items as attributes on the `sl-checkbox`.
+  any additional array items as attributes on the `sl-radio`.
 */
 
 = ts_form_for ... do |f|

--- a/docs/pages/components/radio.md
+++ b/docs/pages/components/radio.md
@@ -113,10 +113,18 @@ sl-radio-group[
   When rendering with ts_form_for
   — NOTE: To set default value for initial page load, ensure a value is set
   in the controller's #new action:
-  e.g. if using `ts_form_for @cap_table_event`, set @cap_table_event = CapTableEvent.new(a: "issue_shares")
+  e.g. if using `ts_form_for @cap_table_event`,
+  set @cap_table_event = CapTableEvent.new(a: "issue_shares")
 
   — NOTE: Slots are not supported with ts_form_for —
   — Example below shows usage of "description" as attribute —
+
+  When rendering `sl-checkbox-group` with ts_form_for, pass additional
+  attributes such as `disabled` and `description` as extra items
+  in the collection array after the label and value.
+  By default Simple Form will use the first item
+  as the label and the second item as the value, then pass
+  any additional array items as attributes on the `sl-checkbox`.
 */
 
 = ts_form_for ... do |f|
@@ -124,22 +132,20 @@ sl-radio-group[
     as: :radio_buttons,
     label: "What would you like to do?",
     collection: [
-      // Use {} to keep additional attributes like 'description' and 'disabled'
-      // separate from the main label/value elements
       [
         "Issue shares",
-        { description: "Awards company shares to an employee" },
         "issue_shares",
+        description: "Awards company shares to an employee",
       ],
       [
         "Employee buyback",
-        { description: "Buys back vested shares from departing employee owners" },
         "employee_buyback",
+        description: "Buys back vested shares from departing employee owners",
       ],
       [
         "Cancel a certificate",
-        { description: "Declares certificate to be null and void" },
         "cancel_certificate",
+        description: "Declares certificate to be null and void",
       ],
     ],
     wrapper_html: {
@@ -203,10 +209,18 @@ sl-radio-group[
   When rendering with ts_form_for
   — NOTE: To set default value for initial page load, ensure a value is set
   in the controller's #new action:
-  e.g. if using `ts_form_for @cap_table_event`, set @cap_table_event = CapTableEvent.new(a: "issue_shares")
+  e.g. if using `ts_form_for @cap_table_event`,
+  set @cap_table_event = CapTableEvent.new(a: "issue_shares")
 
   — NOTE: Slots are not supported with ts_form_for —
   — Example below shows usage of "description" as attribute —
+
+  When rendering `sl-checkbox-group` with ts_form_for, pass additional
+  attributes such as `disabled` and `description` as extra items
+  in the collection array after the label and value.
+  By default Simple Form will use the first item
+  as the label and the second item as the value, then pass
+  any additional array items as attributes on the `sl-checkbox`.
 */
 
 = ts_form_for ... do |f|
@@ -214,25 +228,21 @@ sl-radio-group[
     as: :radio_buttons,
     label: "What would you like to do?",
     collection: [
-      // Use {} to keep additional attributes like 'description' and 'disabled'
-      // separate from the main label/value elements
       [
         "Issue shares",
-        { description: "Awards company shares to an employee" },
         "issue_shares",
+        description: "Awards company shares to an employee",
       ],
       [
         "Employee buyback",
-        { description: "Buys back vested shares from departing employee owners" },
         "employee_buyback",
+        description: "Buys back vested shares from departing employee owners",
       ],
       [
         "Cancel a certificate",
-        {
-          description: "Declares certificate to be null and void",
-          disabled: true,
-        },
         "cancel_certificate",
+        description: "Declares certificate to be null and void",
+        disabled: true,
       ]
     ],
     wrapper_html: {
@@ -441,7 +451,15 @@ sl-radio-group[
   When rendering with ts_form_for
   — NOTE: To set default value for initial page load, ensure a value is set
   in the controller's #new action:
-  e.g. if using `ts_form_for @cap_table_event`, set @cap_table_event = CapTableEvent.new(a: "issue_shares")
+  e.g. if using `ts_form_for @cap_table_event`,
+  set @cap_table_event = CapTableEvent.new(a: "issue_shares")
+
+  When rendering `sl-checkbox-group` with ts_form_for, pass additional
+  attributes such as `disabled` and `description` as extra items
+  in the collection array after the label and value.
+  By default Simple Form will use the first item
+  as the label and the second item as the value, then pass
+  any additional array items as attributes on the `sl-checkbox`.
 */
 
 = ts_form_for ... do |f|
@@ -449,14 +467,18 @@ sl-radio-group[
     as: :radio_buttons,
     label: "What would you like to do?",
     collection: [
-      // Use {} to keep additional attributes like 'description' and 'disabled'
-      // separate from the main label/value elements
-      ["Issue shares", {}, "issue_shares"],
-      ["Employee buyback", {}, "employee_buyback"],
+      [
+        "Issue shares",
+        "issue_shares",
+      ],
+      [
+        "Employee buyback",
+        "employee_buyback",
+      ],
       [
         "Cancel a certificate",
-        { disabled: true },
         "cancel_certificate",
+        disabled: true,
       ],
     ]
 ```

--- a/docs/pages/components/select.md
+++ b/docs/pages/components/select.md
@@ -55,6 +55,24 @@ sl-select label="Select one option"
   sl-option value="option-4" Option 4
   sl-option value="option-5" Option 5
   sl-option value="option-6" Option 6
+
+/*
+  When rendering with ts_form_for
+*/
+
+= ts_form_for ... do |f|
+  = f.input :select_one,
+    collection: [
+      ["Option 1", "option-1"],
+      ["Option 2", "option-2"],
+      ["Option 3", "option-3"],
+      ["Option 4", "option-4"],
+      ["Option 5", "option-5"],
+      ["Option 6", "option-6"],
+    ],
+    input_html: {
+      label: "Select one option"
+    }
 ```
 
 ```jsx:react
@@ -99,13 +117,18 @@ Add descriptive help text to a select with the `help-text` attribute. For help t
 ```
 
 ```pug:slim
-sl-select label="Skill level" help-text="Select one option that best describes your current skill level"
+sl-select[
+  label="Skill level"
+  help-text="Select one option that best describes your current skill level"
+]
   sl-option value="1" Novice
   sl-option value="2" Intermediate
   sl-option value="3" Advanced
   sl-option value="4" Expert
 br
-sl-select label="Skill level" help-text="Select one option that best describes your current skill level"
+sl-select[
+  label="Skill level"
+]
   sl-option value="1" Novice
   sl-option value="2" Intermediate
   sl-option value="3" Advanced
@@ -114,6 +137,24 @@ sl-select label="Skill level" help-text="Select one option that best describes y
     | Select one option that best describes your
     strong current
     | skill level
+
+/*
+  When rendering with ts_form_for
+  — NOTE: Slots are not supported with ts_form_for —
+*/
+
+= ts_form_for ... do |f|
+  = f.input :skill_level,
+    collection: [
+      ["Novice", "1"],
+      ["Intermediate", "2"],
+      ["Advanced", "3"],
+      ["Expert", "4"],
+    ],
+    input_html: {
+      label: "Skill level",
+      "help-text": "Select one option that best describes your current skill level",
+    }
 ```
 
 ```jsx:react
@@ -147,11 +188,31 @@ Use the `label-tooltip` attribute to add text that appears in a tooltip triggere
 ```
 
 ```pug:slim
-sl-select label="Select one" label-tooltip="Although skill doesn't always map to years of experience, the following can be used as a general guide: Novice (Less than 1 year); Intermediate (1-2 years); Advanced (3-5 years); Expert (5+ years)"
+sl-select[
+  label="Skill level"
+  label-tooltip="Although skill doesn't always map to years of experience, the following can be used as a general guide: Novice (Less than 1 year); Intermediate (1-2 years); Advanced (3-5 years); Expert (5+ years)"
+]
   sl-option value="1" Novice
   sl-option value="2" Intermediate
   sl-option value="3" Advanced
   sl-option value="4" Expert
+
+/*
+  When rendering with ts_form_for
+*/
+
+= ts_form_for ... do |f|
+  = f.input :skill_level,
+    collection: [
+      ["Novice", "1"],
+      ["Intermediate", "2"],
+      ["Advanced", "3"],
+      ["Expert", "4"],
+    ],
+    input_html: {
+      label: "Skill level",
+      "label-tooltip": "Although skill doesn't always map to years of experience, the following can be used as a general guide: Novice (Less than 1 year); Intermediate (1-2 years); Advanced (3-5 years); Expert (5+ years)",
+    }
 ```
 
 ```jsx:react
@@ -186,7 +247,10 @@ Use the `context-note` attribute to add text that provides additional context or
 ```
 
 ```pug:slim
-sl-select label="Skill level" help-text="Select one option that best describes your current skill level"
+sl-select[
+  label="Skill level"
+  help-text="Select one option that best describes your current skill level"
+]
   div slot="context-note"
     a href="javascript;" class="ts-text-link" See open positions by skill level
   sl-option value="1" Novice
@@ -194,6 +258,26 @@ sl-select label="Skill level" help-text="Select one option that best describes y
   sl-option value="3" Advanced
   sl-option value="4" Expert
 
+/*
+  When rendering with ts_form_for
+  — NOTE: Slots are not supported with ts_form_for —
+  — Example below shows usage of "context-note" as attribute —
+*/
+
+= ts_form_for ... do |f|
+  = f.input :skill_level,
+    collection: [
+      ["Novice", "1"],
+      ["Intermediate", "2"],
+      ["Advanced", "3"],
+      ["Expert", "4"],
+    ],
+    input_html: {
+      label: "Skill level",
+      "help-text": "Select one option that best describes your current skill level",
+      // Example of `context-note` attribute; slots not supported with ts_form_for
+      "context-note": "5 open positions",
+    }
 ```
 
 ```jsx:react
@@ -265,7 +349,13 @@ Use the `clearable` attribute to make the control clearable. The clear button on
 ```
 
 ```pug:slim
-sl-select label="Clearable select" clearable="true" multiple="true" value="option-1 option-2" help-text="For multi-choice selects only, display an icon button to let people clear their selections"
+sl-select[
+  label="Clearable multi-choice select"
+  clearable="true"
+  multiple="true"
+  value="option-1 option-2"
+  help-text="For multi-choice selects only, display an icon button to let people clear their selections"
+]
   sl-option value="option-1" Option 1
   sl-option value="option-2" Option 2
   sl-option value="option-3" Option 3
@@ -273,13 +363,53 @@ sl-select label="Clearable select" clearable="true" multiple="true" value="optio
   sl-option value="option-5" Option 5
   sl-option value="option-6" Option 6
 br
-  sl-select label="Clearable default select" help-text="Add an empty value option to allow people to clear their selection in a single-choice select"
+sl-select[
+  label="Clearable single-choice select"
+  help-text="Add an empty value option to allow people to clear their selection in a single-choice select"
+]
+  sl-option value=""
   sl-option value="option-1" Option 1
   sl-option value="option-2" Option 2
   sl-option value="option-3" Option 3
   sl-option value="option-4" Option 4
   sl-option value="option-5" Option 5
   sl-option value="option-6" Option 6
+
+/*
+  When rendering with ts_form_for
+*/
+
+= ts_form_for ... do |f|
+  = f.input :clearable_multiple,
+    collection: [
+      ["Option 1", "option-1"],
+      ["Option 2", "option-2"],
+      ["Option 3", "option-3"],
+      ["Option 4", "option-4"],
+      ["Option 5", "option-5"],
+      ["Option 6", "option-6"],
+    ],
+    input_html: {
+      label: "Clearable multi-choice select",
+      clearable: true,
+      multiple: true,
+      value: "option-1 option-2",
+      "help-text": "For multi-choice selects only, display an icon button to let people clear their selections",
+    }
+  = f.input :clearable_single,
+    collection: [
+      ["", ""],
+      ["Option 1", "option-1"],
+      ["Option 2", "option-2"],
+      ["Option 3", "option-3"],
+      ["Option 4", "option-4"],
+      ["Option 5", "option-5"],
+      ["Option 6", "option-6"],
+    ],
+    input_html: {
+      label: "Clearable single-choice select",
+      "help-text": "Add an empty value option to allow people to clear their selection in a single-choice select",
+    }
 ```
 
 ```jsx:react
@@ -356,7 +486,10 @@ Use the `pill` attribute to give selects rounded edges.
 ```
 
 ```pug:slim
-sl-select label="Medium pill" pill="true"
+sl-select[
+  label="Medium pill"
+  pill="true"
+]
   sl-option value="option-1" Option 1
   sl-option value="option-2" Option 2
   sl-option value="option-3" Option 3
@@ -364,13 +497,50 @@ sl-select label="Medium pill" pill="true"
   sl-option value="option-5" Option 5
   sl-option value="option-6" Option 6
 br
-sl-select label="Large pill" size="large" pill="true"
+sl-select[
+  label="Large pill"
+  size="large"
+  pill="true"
+]
   sl-option value="option-1" Option 1
   sl-option value="option-2" Option 2
   sl-option value="option-3" Option 3
   sl-option value="option-4" Option 4
   sl-option value="option-5" Option 5
   sl-option value="option-6" Option 6
+
+/*
+  When rendering with ts_form_for
+*/
+
+= ts_form_for ... do |f|
+  = f.input :pill_medium,
+    collection: [
+      ["Option 1", "option-1"],
+      ["Option 2", "option-2"],
+      ["Option 3", "option-3"],
+      ["Option 4", "option-4"],
+      ["Option 5", "option-5"],
+      ["Option 6", "option-6"],
+    ],
+    input_html: {
+      label: "Medium pill",
+      pill: true,
+    }
+  = f.input :pill_large,
+    collection: [
+      ["Option 1", "option-1"],
+      ["Option 2", "option-2"],
+      ["Option 3", "option-3"],
+      ["Option 4", "option-4"],
+      ["Option 5", "option-5"],
+      ["Option 6", "option-6"],
+    ],
+    input_html: {
+      label: "Large pill",
+      size: "large",
+      pill: true,
+    }
 ```
 
 ```jsx:react
@@ -402,13 +572,35 @@ Use the `disabled` attribute to disable a select.
 ```
 
 ```pug:slim
-sl-select labe="Disabled select" disabled="true"
+sl-select[
+  label="Disabled select"
+  disabled="true"
+]
   sl-option value="option-1" Option 1
   sl-option value="option-2" Option 2
   sl-option value="option-3" Option 3
   sl-option value="option-4" Option 4
   sl-option value="option-5" Option 5
   sl-option value="option-6" Option 6
+
+/*
+  When rendering with ts_form_for
+*/
+
+= ts_form_for ... do |f|
+  = f.input :disabled_select,
+    collection: [
+      ["Option 1", "option-1"],
+      ["Option 2", "option-2"],
+      ["Option 3", "option-3"],
+      ["Option 4", "option-4"],
+      ["Option 5", "option-5"],
+      ["Option 6", "option-6"],
+    ],
+    input_html: {
+      label: "Disabled select",
+      disabled: true,
+    }
 ```
 
 ```jsx:react
@@ -440,13 +632,39 @@ To allow multiple options to be selected, use the `multiple` attribute. When thi
 ```
 
 ```pug:slim
-sl-select label="Select one or more" value="option-1 option-2 option-3" multiple="true" clearable="true"
+sl-select[
+  label="Select one or more"
+  value="option-1 option-2 option-3"
+  multiple="true"
+  clearable="true"
+]
   sl-option value="option-1" Option 1
   sl-option value="option-2" Option 2
   sl-option value="option-3" Option 3
   sl-option value="option-4" Option 4
   sl-option value="option-5" Option 5
   sl-option value="option-6" Option 6
+
+/*
+  When rendering with ts_form_for
+*/
+
+= ts_form_for ... do |f|
+  = f.input :select_multiple,
+    collection: [
+      ["Option 1", "option-1"],
+      ["Option 2", "option-2"],
+      ["Option 3", "option-3"],
+      ["Option 4", "option-4"],
+      ["Option 5", "option-5"],
+      ["Option 6", "option-6"],
+    ],
+    input_html: {
+      label: "Select one or more",
+      value: "option-1 option-2 option-3",
+      multiple: true,
+      clearable: true,
+    }
 ```
 
 ```jsx:react
@@ -485,11 +703,37 @@ When using `multiple`, the `value` _attribute_ uses space-delimited values to se
 ```
 
 ```pug:slim
-sl-select label="Select one or more" value="option-1 option-2" multiple="true" clearable="true"
+sl-select[
+  label="Select one or more"
+  value="option-1 option-2"
+  multiple="true"
+  clearable="true"
+]
   sl-option value="option-1" Option 1
   sl-option value="option-2" Option 2
   sl-option value="option-3" Option 3
   sl-option value="option-4" Option 4
+
+/*
+  When rendering with ts_form_for
+*/
+
+= ts_form_for ... do |f|
+  = f.input :select_multiple,
+    collection: [
+      ["Option 1", "option-1"],
+      ["Option 2", "option-2"],
+      ["Option 3", "option-3"],
+      ["Option 4", "option-4"],
+      ["Option 5", "option-5"],
+      ["Option 6", "option-6"],
+    ],
+    input_html: {
+      label: "Select one or more",
+      value: "option-1 option-2",
+      multiple: true,
+      clearable: true,
+    }
 ```
 
 ```jsx:react
@@ -510,6 +754,10 @@ const App = () => (
 
 Use `<sl-divider>` to group listbox items visually. You can also use `<small>` to provide labels for each group, but they won't be announced by most assistive devices.
 
+:::warning
+**Note:** `ts_form_for` doesn't support grouping select options with labels and dividers.
+:::
+
 ```html:preview
 <sl-select label="Select an option from one of the groups">
   <sl-option value=""></sl-option>
@@ -526,6 +774,11 @@ Use `<sl-divider>` to group listbox items visually. You can also use `<small>` t
 ```
 
 ```pug:slim
+/*
+  — NOTE: grouping options with labels and dividers
+  is not supported with ts_form_for
+*/
+
 sl-select label="Select an option from one of the groups"
   sl-option value=""
   small Section 1
@@ -592,13 +845,47 @@ sl-select label="Medium input"
   sl-option value="option-5" Option 5
   sl-option value="option-6" Option 6
 br
-sl-select label="Large input" size="large"
+sl-select[
+  label="Large input"
+  size="large"
+]
   sl-option value="option-1" Option 1
   sl-option value="option-2" Option 2
   sl-option value="option-3" Option 3
   sl-option value="option-4" Option 4
   sl-option value="option-5" Option 5
   sl-option value="option-6" Option 6
+
+/*
+  When rendering with ts_form_for
+*/
+
+= ts_form_for ... do |f|
+  = f.input :size_medium,
+    collection: [
+      ["Option 1", "option-1"],
+      ["Option 2", "option-2"],
+      ["Option 3", "option-3"],
+      ["Option 4", "option-4"],
+      ["Option 5", "option-5"],
+      ["Option 6", "option-6"],
+    ],
+    input_html: {
+      label: "Medium input"
+    }
+  = f.input :size_large,
+    collection: [
+      ["Option 1", "option-1"],
+      ["Option 2", "option-2"],
+      ["Option 3", "option-3"],
+      ["Option 4", "option-4"],
+      ["Option 5", "option-5"],
+      ["Option 6", "option-6"],
+    ],
+    input_html: {
+      label: "Large input",
+      size: "large",
+    }
 ```
 
 ```jsx:react
@@ -648,13 +935,37 @@ The preferred placement of the select's listbox can be set with the `placement` 
 ```
 
 ```pug:slim
-sl-select label="Select an option" placement="top" help-text="This select’s panel of options will try to open on top first if there is room"
+sl-select[
+  label="Select an option"
+  placement="top"
+  help-text="This select’s panel of options will try to open on top first if there is room"
+]
   sl-option value="option-1" Option 1
   sl-option value="option-2" Option 2
   sl-option value="option-3" Option 3
   sl-option value="option-4" Option 4
   sl-option value="option-5" Option 5
   sl-option value="option-6" Option 6
+
+/*
+  When rendering with ts_form_for
+*/
+
+= ts_form_for ... do |f|
+  = f.input :select_placement,
+    collection: [
+      ["Option 1", "option-1"],
+      ["Option 2", "option-2"],
+      ["Option 3", "option-3"],
+      ["Option 4", "option-4"],
+      ["Option 5", "option-5"],
+      ["Option 6", "option-6"],
+    ],
+    input_html: {
+      label: "Select an option",
+      placement: "top",
+      "help-text": "This select’s panel of options will try to open on top first if there is room",
+    }
 ```
 
 ```jsx:react
@@ -684,6 +995,9 @@ Follow these general guidelines when adding prefix icons to the select:
 
 :::warning
 **Note:** If you find your use case requires a different size or color from the default, bring it up to the Design Team so that we can consider whether the pattern needs to be updated.
+:::
+:::warning
+**Note:** `ts_form_for` doesn't support slots. Prefix icons cannot be added when rendering `sl-select` with `ts_form_for`.
 :::
 
 ```html:preview
@@ -724,8 +1038,17 @@ Follow these general guidelines when adding prefix icons to the select:
 ```
 
 ```pug:slim
-sl-select[label="Prefix icon example: DO"]
-  sl-icon[name="rocket-launch" library="fa" slot="prefix"]
+/*
+  NOTE: `ts_form_for` doesn't support slots. Prefix icons
+  cannot be added when rendering `sl-select` with `ts_form_for`
+*/
+
+sl-select label="Prefix icon example: DO"
+  sl-icon[
+    name="rocket-launch"
+    library="fa"
+    slot="prefix"
+  ]
   sl-option value="option-1" Option 1
   sl-option value="option-2" Option 2
   sl-option value="option-3" Option 3
@@ -733,8 +1056,13 @@ sl-select[label="Prefix icon example: DO"]
   sl-option value="option-5" Option 5
   sl-option value="option-6" Option 6
 br
-sl-select[label="Prefix icon example: DON'T"]
-  sl-icon[name="fad-rocket-launch" library="fa" style="font-size: 1.25rem; color:mediumaquamarine;" slot="prefix"]
+sl-select label="Prefix icon example: DON'T"
+  sl-icon[
+    name="fad-rocket-launch"
+    library="fa"
+    style="font-size: 1.25rem; color:mediumaquamarine;"
+    slot="prefix"
+  ]
   sl-option value="option-1" Option 1
   sl-option value="option-2" Option 2
   sl-option value="option-3" Option 3
@@ -742,15 +1070,32 @@ sl-select[label="Prefix icon example: DON'T"]
   sl-option value="option-5" Option 5
   sl-option value="option-6" Option 6
 br
-sl-select[label="Prefix icon example: POSSIBLE EXCEPTION" help-text="An icon that is hard to read at the default size." value="option-1"]
-  sl-icon[name="building-circle-check" library="fa" slot="prefix"]
+sl-select[
+  label="Prefix icon example: POSSIBLE EXCEPTION"
+  help-text="An icon that is hard to read at the default size."
+  value="option-1"
+]
+  sl-icon[
+    name="building-circle-check"
+    library="fa"
+    slot="prefix"
+  ]
   sl-option value="option-1" Option 1 (default alignment)
   sl-option value="option-2" Option 2 (default alignment)
   sl-option value="option-3" Option 3 (default alignment)
   sl-option value="option-4" Option 4 (default alignment)
 br
-sl-select[label="Prefix icon example: RESIZED" help-text="Same icon as above, resized. Note that a larger prefix icon will push the option text out of alignment." value="option-1"]
-  sl-icon[name="building-circle-check" library="fa" style="font-size: 1.25rem;"  slot="prefix"]
+sl-select[
+  label="Prefix icon example: RESIZED"
+  help-text="Same icon as above, resized. Note that a larger prefix icon will push the option text out of alignment."
+  value="option-1"
+]
+  sl-icon[
+    name="building-circle-check"
+    library="fa"
+    style="font-size: 1.25rem;"
+    slot="prefix"
+  ]
   sl-option value="option-1" Option 1 (shifted 4px right due to icon size)
   sl-option value="option-2" Option 2 (shifted 4px right due to icon size)
   sl-option value="option-3" Option 3 (shifted 4px right due to icon size)
@@ -796,6 +1141,9 @@ Remember that custom tags are rendered in a shadow root. To style them, you can 
 
 :::warning
 **Note:** In general, you shouldn't need to do this. If you are working on a design that requires custom styling for the tag, please ensure that there's not a standard tag in the design system that would work instead.
+:::
+:::warning
+**Note:** `ts_form_for` doesn't support slots. Custom tags cannot be added when rendering `sl-select` with `ts_form_for`.
 :::
 
 ```html:preview

--- a/docs/pages/components/textarea.md
+++ b/docs/pages/components/textarea.md
@@ -22,6 +22,17 @@ Use the `label` attribute to give the textarea an accessible label.
 
 ```pug:slim
 sl-textarea label="Month in review"
+
+/*
+ When rendering with ts_form_for
+*/
+
+= ts_form_for ... do |f|
+  = f.input :month_in_review,
+    as: :text,
+    input_html: {
+      label: "Month in review"
+    }
 ```
 
 ```jsx:react
@@ -47,13 +58,29 @@ Add descriptive help text to a textarea with the `help-text` attribute. For help
 ```
 
 ```pug:slim
-sl-textarea label="Month in review" help-text="Tell us the highlights. Be sure to include details about any financial performance anomalies."
+sl-textarea[
+  label="Month in review"
+  help-text="Tell us the highlights. Be sure to include details about any financial performance anomalies."
+]
 br
 sl-textarea label="Month in review"
   div slot="help-text"
     | Tell us the highlights. Be sure to include details about any financial performance
     strong anomalies
     | .
+
+/*
+  When rendering with ts_form_for
+  — NOTE: Slots are not supported with ts_form_for —
+*/
+
+= ts_form_for ... do |f|
+  = f.input :month_in_review,
+    as: :text,
+    input_html: {
+      label: "Month in review",
+      "help-text": "Tell us the highlights. Be sure to include details about any financial performance anomalies.",
+    }
 ```
 
 ```jsx:react
@@ -75,7 +102,24 @@ Use the `label-tooltip` attribute to add text that appears in a tooltip triggere
 ```
 
 ```pug:slim
-sl-textarea[label="Month in review" help-text="Tell us the highlights. Be sure to include details about any financial performance anomalies." label-tooltip="There is no required format for this commentary. However, we suggest covering the following topics: 1) Revenue, 2) COGS, 3) Gross profit, and 4) Operating expenses."]
+sl-textarea[
+  label="Month in review"
+  help-text="Tell us the highlights. Be sure to include details about any financial performance anomalies."
+  label-tooltip="There is no required format for this commentary. However, we suggest covering the following topics: 1) Revenue, 2) COGS, 3) Gross profit, and 4) Operating expenses."
+]
+
+/*
+  When rendering with ts_form_for
+*/
+
+= ts_form_for ... do |f|
+  = f.input :month_in_review,
+    as: :text,
+    input_html: { \
+      label: "Month in review",
+      "help-text": "Tell us the highlights. Be sure to include details about any financial performance anomalies.",
+      "label-tooltip": "There is no required format for this commentary. However, we suggest covering the following topics: 1) Revenue, 2) COGS, 3) Gross profit, and 4) Operating expenses.",
+    }
 ```
 
 ```jsx:react
@@ -97,7 +141,25 @@ Use the `context-note` attribute to add text that provides additional context or
 ```
 
 ```pug:slim
-sl-textarea[label="Month in review" help-text="Tell us the highlights. Be sure to include details about any financial performance anomalies." context-note="Data synced 1 hr ago"]
+sl-textarea[
+  label="Month in review"
+  help-text="Tell us the highlights. Be sure to include details about any financial performance anomalies."
+  context-note="Data synced 1 hr ago"
+]
+
+/*
+  When rendering with ts_form_for
+  — NOTE: Slots are not supported with ts_form_for —
+*/
+
+= ts_form_for ... do |f|
+  = f.input :month_in_review,
+    as: :text,
+    input_html: { \
+      label: "Month in review",
+      "help-text": "Tell us the highlights. Be sure to include details about any financial performance anomalies.",
+      "context-note": "Data synced 1 hr ago",
+    }
 ```
 
 ```jsx:react
@@ -119,11 +181,44 @@ Use the `rows` attribute to change the number of text rows that the textarea sho
 ```
 
 ```pug:slim
-sl-textarea label="Textarea with 2 rows" rows="2"
+sl-textarea[
+  label="Textarea with 2 rows"
+  rows="2"
+]
 br
-sl-textarea label="Textarea with 4 rows (Default)" rows="4"
+sl-textarea[
+  label="Textarea with 4 rows (Default)"
+  rows="4"
+]
 br
-sl-textarea label="Textarea with 6 rows" rows="6"
+sl-textarea[
+  label="Textarea with 6 rows"
+  rows="6"
+]
+
+/*
+  When rendering with ts_form_for
+*/
+
+= ts_form_for ... do |f|
+  = f.input :rows_2,
+    as: :text,
+    input_html: {
+      label: "Textarea with 2 rows",
+      rows: "2",
+    }
+  = f.input :rows_4,
+    as: :text,
+    input_html: {
+      label: "Textarea with 4 rows (Default)",
+      rows: "4",
+    }
+  = f.input :rows_6,
+    as: :text,
+    input_html: {
+      label: "Textarea with 6 rows",
+      rows: "6",
+    }
 ```
 
 ```jsx:react
@@ -177,7 +272,22 @@ Use the `disabled` attribute to disable a textarea.
 ```
 
 ```pug:slim
-sl-textarea label="Disabled textarea" disabled="true"
+sl-textarea[
+  label="Disabled textarea"
+  disabled="true"
+]
+
+/*
+  When rendering with ts_form_for
+*/
+
+= ts_form_for ... do |f|
+  = f.input :disabled_textarea,
+    as: :text,
+    input_html: {
+      label: "Disabled textarea",
+      disabled: true,
+    }
 ```
 
 ```jsx:react
@@ -229,7 +339,24 @@ By default, textareas can be resized vertically by the user. To prevent resizing
 ```
 
 ```pug:slim
-sl-textarea label="Textarea with no resizing" resize="none"
+sl-textarea[
+  label="Textarea with no resizing"
+  resize="none"
+]
+
+/*
+  When rendering with ts_form_for
+  — NOTE: In ts_form_for resize="auto" is the default —
+  — Use resize="vertical" to match the Shoelace default —
+*/
+
+= ts_form_for ... do |f|
+  = f.input :no_resizing,
+    as: :text,
+    input_html: {
+      label: "Textarea with no resizing",
+      resize: "none",
+    }
 ```
 
 ```jsx:react
@@ -242,12 +369,38 @@ const App = () => <SlTextarea resize="none" />;
 
 Textareas will automatically resize to expand to fit their content when `resize` is set to `auto`.
 
+:::warning
+**Note:** If using `ts_form_for`, note that the default `resize` option is already set to `auto`. To match the `sl-textarea` default of `vertical`, set `resize: "vertical"` in `input_html` (see code example below).
+:::
+
 ```html:preview
 <sl-textarea label="Expanding textarea" resize="auto" value="Someone’s sitting in the shade today because someone planted a tree a long time ago. ... Keep typing to see the textarea expand..." rows="2"></sl-textarea>
 ```
 
 ```pug:slim
-sl-textarea label="Expanding textarea" resize="auto" value="Someone’s sitting in the shade today because someone planted a tree a long time ago. ... Keep typing to see the textarea expand..." rows="2"
+sl-textarea[
+  label="Expanding textarea"
+  resize="auto"
+  value="Someone’s sitting in the shade today because someone planted a tree a long time ago. ... Keep typing to see the textarea expand..."
+  rows="2"
+]
+
+/*
+  When rendering with ts_form_for
+  — NOTE: In ts_form_for resize="auto" is the default —
+  — Use resize="vertical" to match the Shoelace default —
+*/
+
+= ts_form_for ... do |f|
+  = f.input :expanding,
+    as: :text,
+    input_html: {
+      label: "Textarea with no resizing",
+      label: "Expanding textarea",
+      resize: "auto",
+      value: "Someone’s sitting in the shade today because someone planted a tree a long time ago. ... Keep typing to see the textarea expand...",
+      rows: "2",
+    }
 ```
 
 ```jsx:react

--- a/docs/pages/getting-started/form-controls.md
+++ b/docs/pages/getting-started/form-controls.md
@@ -6,6 +6,12 @@ meta:
 
 # Form Controls
 
+### Note
+
+:::warning
+This page contains form control documentation relevant to Shoelace components in general, but **is not relevant to `ts_form_for`**, our custom Simple Form wrapper. More `ts_form_for` documentation is in the works. In the meantime, please **refer to the SLIM code examples for specific components** (e.g. [Basic Select with Label](/components/select#basic-select-with-label)) to see how to render specific components using `ts_form_for`.
+:::
+
 > Every Shoelace component makes use of a [shadow DOM](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_shadow_DOM) to encapsulate markup, styles, and behavior. One caveat of this approach is that native `<form>` elements do not recognize form controls located inside a shadow root.
 
 Shoelace solves this problem by using the [`formdata`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/formdata_event) event, which is [available in all modern browsers](https://caniuse.com/mdn-api_htmlformelement_formdata_event). This means, when a form is submitted, Shoelace form controls will automatically append their values to the `FormData` object that's used to submit the form. In most cases, things will "just work." However, if you're using a form serialization library, it might need to be adapted to recognize Shoelace form controls.


### PR DESCRIPTION
- Add `ts_form_for` code examples to all examples that can be rendered with `ts_form_for`, for these components:
  - `sl-checkbox-group`
  - `sl-checkbox`
  - `sl-radio`
  - `sl-radio-group`
  - `sl-input`
  - `sl-select`
  - `sl-textarea`
- Also fix related Slim code to be more readable
- Add note to Form Controls doc page that more `ts_form_for` documentation is coming, plus link to sample component example with `ts_form_for` code
- Plus misc:
  -  Fix broken code example for `sl-radio-button`
  - Make code comment text color darker (to be more readable)
 ---
### Note to reviewers
This is a docs-page only change, so I plan to just merge to `next` after approval and deploy to design.teamshares.com. No new release version would be needed for these changes.