### PR TITLE
Bug fixes + minor doc site improvements

### DIFF
--- a/docs/_includes/component.njk
+++ b/docs/_includes/component.njk
@@ -77,11 +77,11 @@
   {# Guidelines #}
   {% if
   guidelines %}
-    <h2>Usage Guidelines</h2>
+    <h2>Usage</h2>
     <div id="guidelines-content">{{ guidelines | markdown | safe }}</div>
   {% endif %}
   {# Importing #}
-  <h2>Importing</h2>
+  {# <h2>Importing</h2>
   <p>
     If you're using the autoloader or the traditional loader, you can ignore this
     section. Otherwise, feel free to use any of the following snippets to
@@ -134,7 +134,84 @@
       </p>
       <pre><code class="language-js">import {{ component.name }} from '@shoelace-style/shoelace/{{ meta.npmdir }}/react/{{ component.tagNameWithoutPrefix }}';</code></pre>
     </sl-tab-panel>
-  </sl-tab-group>
+  </sl-tab-group> #}
+
+  {# Properties #}
+  {% if component.properties.length %}
+    <h2>Props</h2>
+    {% if unusedProperties.length %}
+      <div role="alert" class="callout callout--warning">
+        <p>
+          <strong>Note</strong>: The following appear as options in the Properties
+          table but are currently not part of the Teamshares Design System. Please
+          check with the design team before using these options:
+        </p>
+        {{ unusedProperties | markdown | safe }}
+      </div>
+    {% endif %}
+
+    <table>
+      <thead>
+        <tr>
+          <th class="table-name">Property</th>
+          <th class="table-default">Default</th>
+          <th class="table-description">Details</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for prop in component.properties %}
+          <tr>
+            <td class="table-name">
+              <code class="nowrap prop">{{ prop.name }}</code>
+              {% if prop.attribute | length > 0 %}
+                {% if prop.reflects %}
+                  <sl-tooltip content="Property reflects">
+                    <sl-icon library="fa" label="yes" name="fas-circle-check" style="color: var(--sl-color-teal-500);"></sl-icon>
+                  </sl-tooltip>
+                {% endif %}
+                {% if prop.attribute != prop.name %}
+                  <br/>
+                  <sl-tooltip content="This attribute is different from its property">
+                    <small>
+                      <code class="nowrap">
+                        {{ prop.attribute }}
+                      </code>
+                    </small>
+                  </sl-tooltip>
+                {% endif %}
+              {% endif %}
+            </td>
+            <td class="table-default">
+              {% if prop.default %}
+                <code class="nowrap">{{ prop.default | markdownInline | safe }}</code>
+              {% else %} &mdash; {% endif %}
+            </td>
+            <td class="table-description">
+              <p>
+                {% if prop.type.text %}
+                  <code>{{ prop.type.text | trimPipes | markdownInline | safe }}</code>
+                {% else %} &mdash; {% endif %}
+              </p>
+              <p>{{ prop.description | markdownInline | safe }}</p>
+            </td>
+          </tr>
+        {% endfor %}
+        <tr>
+          <td class="table-name">
+            <code class="prop">updateComplete</code>
+          </td>
+          <td></td>
+          <td>
+            A read-only promise that resolves when the component has <a href="/getting-started/usage?#component-rendering-and-updating">finished updating</a>.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    <p>
+      <em>Learn more about <a href="{{ rootUrl('/getting-started/usage#attributes-and-properties') }}" >attributes and properties</a >.</em>
+    </p>
+  {% endif %}
 
   {# Slots #}
   {% if component.slots.length %}
@@ -144,7 +221,7 @@
       <thead>
         <tr>
           <th class="table-name">Name</th>
-          <th class="table-description">Description</th>
+          <th class="table-description">Details</th>
         </tr>
       </thead>
       <tbody>
@@ -166,89 +243,6 @@
     </p>
   {% endif %}
 
-  {# Properties #}
-  {% if component.properties.length %}
-    <h2>Properties</h2>
-    {% if unusedProperties.length %}
-      <div role="alert" class="callout callout--warning">
-        <p>
-          <strong>Note</strong>: The following appear as options in the Properties
-          table but are currently not part of the Teamshares Design System. Please
-          check with the design team before using these options:
-        </p>
-        {{ unusedProperties | markdown | safe }}
-      </div>
-    {% endif %}
-    <div role="alert" class="callout callout--tip">
-      <p>Scroll right to see the entire table</p>
-    </div>
-
-    <table>
-      <thead>
-        <tr>
-          <th class="table-name">Name</th>
-          <th class="table-description">Description</th>
-          <th class="table-reflects">Reflects</th>
-          <th class="table-type">Type</th>
-          <th class="table-default">Default</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for prop in component.properties %}
-          <tr>
-            <td>
-              <code class="nowrap">{{ prop.name }}</code>
-              {% if prop.attribute | length > 0 %}
-                {% if prop.attribute != prop.name
- %}
-                  <br/>
-                  <sl-tooltip content="This attribute is different from its property">
-                    <small>
-                      <code class="nowrap">
-                        {{ prop.attribute }}
-                      </code>
-                    </small>
-                  </sl-tooltip>
-                {% endif %}
-              {% endif %}
-            </td>
-            <td>{{ prop.description | markdownInline | safe }}</td>
-            <td style="text-align: center">
-              {% if prop.reflects %}
-                <sl-icon label="yes" name="check-lg"></sl-icon>
-              {% endif %}
-            </td>
-            <td>
-              {% if prop.type.text %}
-                <code>{{ prop.type.text | trimPipes | markdownInline | safe }}</code>
-              {% else %} - {% endif %}
-            </td>
-            <td>
-              {% if prop.default %}
-                <code>{{ prop.default | markdownInline | safe }}</code>
-              {% else %} - {% endif %}
-            </td>
-          </tr>
-        {% endfor %}
-        <tr>
-          <td class="nowrap">
-            <code>updateComplete</code>
-          </td>
-          <td>
-            A read-only promise that resolves when the component has <a href="/getting-started/usage?#component-rendering-and-updating">finished updating</a>.
-          </td>
-          <td></td>
-          <td></td>
-          <td></td>
-        </tr>
-      </tbody>
-    </table>
-
-    <p>
-      <em>Learn more about <a href="{{ rootUrl('/getting-started/usage#attributes-and-properties') }}" >attributes and properties</a >.</em>
-    </p>
-  {% endif %}
-
   {# Events #}
   {% if component.events.length %}
     <h2>Events</h2>
@@ -258,8 +252,7 @@
         <tr>
           <th class="table-name" data-flavor="html">Name</th>
           <th class="table-name" data-flavor="react">React Event</th>
-          <th class="table-description">Description</th>
-          <th class="table-event-detail">Event Detail</th>
+          <th class="table-description">Details</th>
         </tr>
       </thead>
       <tbody>
@@ -271,12 +264,15 @@
             <td data-flavor="react">
               <code class="nowrap">{{ event.reactName }}</code>
             </td>
-            <td>{{ event.description | markdownInline | safe }}</td>
             <td>
               {% if event.type.text %}
-                <code>{{ event.type.text | trimPipes }}</code>
-              {% else %} - {% endif %}
+                <p>
+                  <code>{{ event.type.text | trimPipes }}</code>
+                </p>
+              {% endif %}
+              <p>{{ event.description | markdownInline | safe }}</p>
             </td>
+            <td></td>
           </tr>
         {% endfor %}
       </tbody>
@@ -295,8 +291,7 @@
       <thead>
         <tr>
           <th class="table-name">Name</th>
-          <th class="table-description">Description</th>
-          <th class="table-arguments">Arguments</th>
+          <th class="table-description">Details</th>
         </tr>
       </thead>
       <tbody>
@@ -305,16 +300,18 @@
             <td class="nowrap">
               <code>{{ method.name }}()</code>
             </td>
-            <td>{{ method.description | markdownInline | safe }}</td>
             <td>
               {% if method.parameters.length %}
-                <code>
-                  {% for param in method.parameters %}
-                    {{ param.name }}: {{ param.type.text | trimPipes }}
-                    {% if not loop.last %},{% endif %}
-                  {% endfor %}
-                </code>
-              {% else %} - {% endif %}
+                <p>
+                  <code>
+                    {% for param in method.parameters %}
+                      {{ param.name }}: {{ param.type.text | trimPipes }}
+                      {% if not loop.last %},{% endif %}
+                    {% endfor %}
+                  </code>
+                </p>
+              {% endif %}
+              <p>{{ method.description | markdownInline | safe }}</p>
             </td>
           </tr>
         {% endfor %}
@@ -334,8 +331,7 @@
       <thead>
         <tr>
           <th class="table-name">Name</th>
-          <th class="table-description">Description</th>
-          <th class="table-default">Default</th>
+          <th class="table-description">Details</th>
         </tr>
       </thead>
       <tbody>
@@ -344,8 +340,12 @@
             <td class="nowrap">
               <code>{{ cssProperty.name }}</code>
             </td>
-            <td>{{ cssProperty.description | markdownInline | safe }}</td>
-            <td>{{ cssProperty.default }}</td>
+            <td>
+              {% if cssProperty.default.length %}
+                <p>{{ cssProperty.default }}</p>
+              {% endif %}
+              <p>{{ cssProperty.description | markdownInline | safe }}</p>
+            </td>
           </tr>
         {% endfor %}
       </tbody>

--- a/docs/_includes/component.njk
+++ b/docs/_includes/component.njk
@@ -166,7 +166,7 @@
               {% if prop.attribute | length > 0 %}
                 {% if prop.reflects %}
                   <sl-tooltip content="Property reflects">
-                    <sl-icon library="fa" label="yes" name="fas-circle-check" style="color: var(--sl-color-teal-500);"></sl-icon>
+                    <sl-icon library="fa" label="yes" name="fas-star" style="color: var(--sl-color-teal-500);"></sl-icon>
                   </sl-tooltip>
                 {% endif %}
                 {% if prop.attribute != prop.name %}

--- a/docs/_includes/component.njk
+++ b/docs/_includes/component.njk
@@ -138,7 +138,7 @@
 
   {# Properties #}
   {% if component.properties.length %}
-    <h2>Props</h2>
+    <h2>Component Props</h2>
     {% if unusedProperties.length %}
       <div role="alert" class="callout callout--warning">
         <p>
@@ -251,6 +251,7 @@
       <thead>
         <tr>
           <th class="table-name" data-flavor="html">Name</th>
+          <th class="table-name" data-flavor="slim">Name</th>
           <th class="table-name" data-flavor="react">React Event</th>
           <th class="table-description">Details</th>
         </tr>
@@ -259,6 +260,9 @@
         {% for event in component.events %}
           <tr>
             <td data-flavor="html">
+              <code class="nowrap">{{ event.name }}</code>
+            </td>
+            <td data-flavor="slim">
               <code class="nowrap">{{ event.name }}</code>
             </td>
             <td data-flavor="react">
@@ -358,7 +362,7 @@
 
   {# CSS Parts #}
   {% if component.cssParts.length %}
-    <h2>Parts</h2>
+    <h2>CSS Parts</h2>
 
     <table>
       <thead>

--- a/docs/_includes/sidebar.njk
+++ b/docs/_includes/sidebar.njk
@@ -23,19 +23,19 @@
     <h2>Tutorials</h2>
     <ul>
       <li>
-        <a href="/teamshares/recipes/protips">Protips</a>
+        <a href="/teamshares/recipes/protips">Shoelace Protips</a>
+      </li>
+      <li>
+        <a href="/teamshares/recipes/rails-ujs">Shoelace &amp; Rails UJS</a>
+      </li>
+      <li>
+        <a href="/teamshares/recipes/cypress">Shoelace &amp; Cypress</a>
       </li>
       <li>
         <a href="/teamshares/view-components/wrapping">View Components</a>
       </li>
       <li>
         <a href="/getting-started/form-controls">Form Controls</a>
-      </li>
-      <li>
-        <a href="/teamshares/recipes/rails-ujs">Rails UJS</a>
-      </li>
-      <li>
-        <a href="/teamshares/recipes/cypress">Cypress</a>
       </li>
     </ul>
   </li>
@@ -140,6 +140,9 @@
       </li>
       <li>
         <a href="/components/input">Input</a>
+      </li>
+      <li>
+        <a href="/teamshares/link">Link</a>
       </li>
       <li>
         <a href="/components/menu">Menu</a>

--- a/docs/assets/styles/docs.css
+++ b/docs/assets/styles/docs.css
@@ -124,7 +124,7 @@ body {
   font: 16px var(--sl-font-sans);
   font-weight: var(--sl-font-weight-normal);
   background-color: var(--docs-background-color);
-  line-height: var(--sl-line-height-normal);
+  line-height: var(--ts-leading-6);
   color: var(--sl-color-neutral-900);
   padding: 0;
   margin: 0;
@@ -1084,6 +1084,7 @@ pre:hover .copy-code-button,
   border-radius: 0;
   padding: 2rem;
   margin: 0;
+  line-height: var(--sl-line-height-normal);
   overflow: auto;
   scrollbar-width: thin;
   transition: var(--docs-sidebar-transition-speed) translate ease-in-out;
@@ -1180,62 +1181,6 @@ pre:hover .copy-code-button,
   .sidebar-open #sidebar {
     translate: 0;
   }
-}
-
-.sidebar-version {
-  font-size: var(--sl-font-size-x-small);
-  font-weight: var(--sl-font-weight-normal);
-  color: var(--sl-color-neutral-700);
-  text-align: center;
-  padding: 0 var(--sl-spacing-small);
-  margin: -1rem 0 0.6rem 0;
-}
-
-.sidebar .sidebar-version-link {
-  color: var(--ts-color-link);
-  color: var(--sl-color-neutral-500);
-  text-align: right;
-  margin-top: -0.5rem;
-  margin-right: 1rem;
-  margin-bottom: -0.5rem;
-}
-
-.sidebar-buttons {
-  display: flex;
-  justify-content: space-between;
-}
-
-.sidebar-nav li.collapse > a,
-.sidebar-nav li.active > a {
-  color: var(--ts-color-link);
-  font-weight: var(--sl-font-weight-semibold);
-  text-decoration: underline;
-  text-decoration-thickness: 2px;
-  text-underline-offset: 6px;
-  transition: all ease-in-out 300ms;
-}
-
-.sidebar-nav li > a:hover {
-  color: var(--ts-color-link);
-  font-weight: var(--sl-font-weight-semibold);
-}
-
-.sidebar li > p {
-  font-weight: var(--ts-font-semibold);
-  border-bottom: solid 1px var(--sl-color-neutral-300);
-  margin: 0 0.75rem 0.5rem 0;
-  padding: 0 0 0.5rem 0;
-}
-
-.sidebar ul li ul {
-  padding-left: 0.125rem;
-  margin: 0 0.75rem 2rem 0;
-}
-
-.sidebar ul ul ul li {
-  font-size: var(--ts-font-sm);
-  list-style: disc;
-  margin-left: 1.5rem;
 }
 
 /* Main content */
@@ -1769,11 +1714,12 @@ html.sidebar-open #menu-toggle {
   height: 100%;
 }
 
-#guidelines .well > * {
+#guidelines-content .well,
+#guidelines-content .well > * {
   margin-bottom: 1rem;
 }
 
-#guidelines .well {
+#guidelines-content .well {
   align-items: center;
   background-color: var(--sl-color-neutral-0);
   border-radius: var(--sl-border-radius-small);
@@ -1815,10 +1761,6 @@ sl-card.dark-header::part(header) {
 
 sl-card.gray-header::part(header) {
   background: var(--ts-color-neutral-200);
-}
-
-sl-card.small-footer::part(footer) {
-  padding: 1rem 0;
 }
 
 .docsify-pagination-container {

--- a/docs/assets/styles/docs.css
+++ b/docs/assets/styles/docs.css
@@ -695,10 +695,6 @@ table td p:last-child {
   width: 100%;
 }
 
-/* .table-scroll code {
-  white-space: nowrap;
-} */
-
 th.table-name,
 th.table-event-detail {
   min-width: 15ch;

--- a/docs/assets/styles/docs.css
+++ b/docs/assets/styles/docs.css
@@ -661,12 +661,14 @@ table tr {
 table th {
   font-weight: var(--sl-font-weight-semibold);
   text-align: left;
+  vertical-align: top;
 }
 
 table td,
 table th {
+  vertical-align: top;
   line-height: var(--sl-line-height-normal);
-  padding: 1rem 1rem;
+  padding: 0.75rem 1rem 0.75rem 0;
 }
 
 table th p:first-child,
@@ -682,20 +684,36 @@ table td p:last-child {
 .table-scroll {
   max-width: 100%;
   overflow-x: auto;
+  font-size: var(--sl-font-size-small);
 }
 
-.table-scroll code {
-  white-space: nowrap;
+.table-scroll td p {
+  margin-block-end: 0.25rem;
 }
+
+.table-scroll table {
+  width: 100%;
+}
+
+/* .table-scroll code {
+  white-space: nowrap;
+} */
 
 th.table-name,
 th.table-event-detail {
   min-width: 15ch;
 }
 
+td.table-name code.prop {
+  font-size: var(--sl-font-size-x-small);
+  font-weight: var(--sl-font-weight-bold);
+  padding: var(--sl-spacing-2x-small) var(--sl-spacing-x-small);
+  color: var(--sl-color-primary-700);
+  background-color: var(--sl-color-primary-100);
+}
+
 th.table-description {
   min-width: 50ch !important;
-  max-width: 70ch;
 }
 
 /* Code blocks */

--- a/docs/assets/styles/docs.css
+++ b/docs/assets/styles/docs.css
@@ -708,10 +708,6 @@ td.table-name code.prop {
   background-color: var(--sl-color-primary-100);
 }
 
-th.table-description {
-  min-width: 50ch !important;
-}
-
 /* Code blocks */
 pre {
   position: relative;

--- a/docs/assets/styles/docs.css
+++ b/docs/assets/styles/docs.css
@@ -921,10 +921,6 @@ pre:hover .copy-code-button,
   margin-top: calc(-0.5 * var(--docs-content-vertical-spacing));
 }
 
-.callout a {
-  color: inherit;
-}
-
 /* Guidelines */
 
 #guidelines-content {

--- a/docs/pages/components/button.md
+++ b/docs/pages/components/button.md
@@ -65,14 +65,14 @@ Use the `size` attribute to change a button's size.
 <sl-button size="small">Small</sl-button>
 <sl-button size="medium">Medium</sl-button>
 <sl-button size="large">Large</sl-button>
-<sl-button size="x-large">Extra Large</sl-button>
+<sl-button size="x-large">Extra large</sl-button>
 ```
 
 ```pug:slim
 sl-button size="small" Small
 sl-button size="medium" Medium
 sl-button size="large" Large
-sl-button size="x-large" Extra Large
+sl-button size="x-large" Extra large
 ```
 
 ```jsx:react
@@ -83,7 +83,7 @@ const App = () => (
     <SlButton size="small">Small</SlButton>
     <SlButton size="medium">Medium</SlButton>
     <SlButton size="large">Large</SlButton>
-    <SlButton size="x-large">Extra Large</SlButton>
+    <SlButton size="x-large">Extra large</SlButton>
   </>
 );
 ```
@@ -139,14 +139,14 @@ Use the `square` attribute to give buttons a rounded-rectangle shape.
 <sl-button size="small" square>Small</sl-button>
 <sl-button size="medium" square>Medium</sl-button>
 <sl-button size="large" square>Large</sl-button>
-<sl-button size="x-large" square>Extra Large</sl-button>
+<sl-button size="x-large" square>Extra large</sl-button>
 ```
 
 ```pug:slim
 sl-button size="small" square="true" Small
 sl-button size="medium" square="true" Medium
 sl-button size="large" square="true" Large
-sl-button size="x-large" square="true" Extra Large
+sl-button size="x-large" square="true" Extra large
 ```
 
 ```jsx:react
@@ -164,7 +164,7 @@ const App = () => (
       Large
     </SlButton>
     <SlButton size="x-large" square>
-      Extra Large
+      Extra large
     </SlButton>
   </>
 );
@@ -309,14 +309,14 @@ As expected, buttons can be given a custom width by setting the `width` attribut
 <sl-button variant="default" size="small" style="width: 100%; margin-bottom: 1rem;">Small</sl-button>
 <sl-button variant="default" size="medium" style="width: 100%; margin-bottom: 1rem;">Medium</sl-button>
 <sl-button variant="default" size="large" style="width: 100%; margin-bottom: 1rem;">Large</sl-button>
-<sl-button variant="default" size="x-large" style="width: 100%;">Extra Large</sl-button>
+<sl-button variant="default" size="x-large" style="width: 100%;">Extra large</sl-button>
 ```
 
 ```pug:slim
 sl-button variant="default" size="small" style="width: 100%; margin-bottom: 1rem;" Small
 sl-button variant="default" size="medium" style="width: 100%; margin-bottom: 1rem;" Medium
 sl-button variant="default" size="large" style="width: 100%; margin-bottom: 1rem;" Large
-sl-button variant="default" size="x-large" style="width: 100%;" Extra Large
+sl-button variant="default" size="x-large" style="width: 100%;" Extra large
 ```
 
 {% raw %}
@@ -336,7 +336,7 @@ const App = () => (
       Large
     </SlButton>
     <SlButton variant="default" size="x-large" style={{ width: '100%' }}>
-      Extra Large
+      Extra large
     </SlButton>
   </>
 );
@@ -525,14 +525,14 @@ Use the `caret` attribute to add a dropdown indicator when a button will trigger
 <sl-button size="small" caret>Small</sl-button>
 <sl-button size="medium" caret>Medium</sl-button>
 <sl-button size="large" caret>Large</sl-button>
-<sl-button size="x-large" caret>Extra Large</sl-button>
+<sl-button size="x-large" caret>Extra large</sl-button>
 ```
 
 ```pug:slim
 sl-button size="small" caret="true" Small
 sl-button size="medium" caret="true" Medium
 sl-button size="large" caret="true" Large
-sl-button size="x-large" caret="true" Extra Large
+sl-button size="x-large" caret="true" Extra large
 ```
 
 ```jsx:react

--- a/docs/pages/components/button.md
+++ b/docs/pages/components/button.md
@@ -227,19 +227,32 @@ const App = () => (
 
 ### Text Buttons
 
-Use the `text` variant to create text buttons that share the same size as regular buttons but don't have backgrounds or borders.
+Use the `text` variant to create a low-emphasis plain text button that looks more like body copy. Note that `text` buttons have **no backgrounds, borders, or padding**.
+
+:::warning
+**Note:** Don't use `text` buttons in size `large` or `x-large`. There is no visible difference between the `text` button's `medium` and `large` sizes, and the `x-large` size gives too mich emphasis to the button. Please check with the design team before using these size options.
+:::
 
 ```html:preview
-<sl-button variant="text" size="small">Text</sl-button>
-<sl-button variant="text" size="medium">Text</sl-button>
-<sl-button variant="text" size="large">Text</sl-button>
-<sl-button variant="text" size="x-large">Text</sl-button>
+<sl-button variant="text" size="small" href="/assets/images/wordmark.svg" download="shoelace.svg">
+  <sl-icon slot="prefix" library="fa" name="arrow-down-to-bracket"></sl-icon>
+  Download statement</sl-button>
+<br/>
+<br/>
+<sl-button variant="text" size="medium" href="https://example.com/" target="_blank">Open statement
+  <sl-icon slot="suffix" library="fa" name="arrow-up-right-from-square"></sl-icon>
+</sl-button>
 ```
 
 ```pug:slim
-sl-button variant="text" size="small" Text
-sl-button variant="text" size="medium" Text
-sl-button variant="text" size="large" Text
+sl-button variant="text" size="small" href="/assets/images/wordmark.svg" download="shoelace.svg"
+  sl-icon slot="prefix" library="fa" name="arrow-down-to-bracket"
+  | Text
+br
+br
+sl-button variant="text" size="medium" href="https://example.com/" target="_blank"
+  | Text
+  sl-icon slot="suffix" library="fa" name="arrow-up-right-from-square"
 ```
 
 ```jsx:react
@@ -251,9 +264,6 @@ const App = () => (
       Text
     </SlButton>
     <SlButton variant="text" size="medium">
-      Text
-    </SlButton>
-    <SlButton variant="text" size="large">
       Text
     </SlButton>
   </>

--- a/docs/pages/components/dialog.md
+++ b/docs/pages/components/dialog.md
@@ -281,12 +281,12 @@ const App = () => {
 ```
 
 :::tip
-**Match a dialog’s variant to specific buttons and icons:**
-| Dialog variant | Button variant | Icon name |
-| ----------------------- | -------------- | ---------------------- |
-| `warning` | `warning` | `exclamation-triangle` |
-| `default` confirmation | `primary` | `exclamation-circle` |
-| `default` informational | `primary` | `info-circle` |
+**For each dialog type, use a specific dialog variant, button variant, and header icon:**
+| Dialog type | Dialog variant | Button variant | Header icon |
+| ------------ | ----------- | -------------- | ---------------------- |
+| informational | `default` | `primary` | `info-circle` |
+| default confirmation | `default` | `primary` | `exclamation-circle` |
+| warning confirmation | `warning` | `warning` | `exclamation-triangle` |
 :::
 
 ### Announcement Dialog

--- a/docs/pages/components/dialog.md
+++ b/docs/pages/components/dialog.md
@@ -123,10 +123,6 @@ Use this pattern for confirmation dialogs, when asking people to confirm that th
 
 Set the dialog variant (`default` or `warning`) to apply the right color theme to the icon: `default` for confirmation of neutral actions (like submitting a form), and `warning` for confirmation of destructive actions (like canceling or deleting something).
 
-:::warning
-**Note:** For `warning` confirmation dialogs, always use the `warning` button for the dialog's primary action and the icon `exclamation-triangle`. For `default` confirmation dialogs, use the `primary` button and the icon `exclamation-circle`. For `default` informational dialogs, use the icon `info-circle`.
-:::
-
 ```html:preview
 <sl-dialog label="More about vesting" class="dialog-default-info" variant="default">
   <sl-icon library="fa" name="info-circle" slot="header-icon"></sl-icon>
@@ -186,13 +182,23 @@ Set the dialog variant (`default` or `warning`) to apply the right color theme t
 ```
 
 ```pug:slim
+sl-dialog label="More about vesting" class="dialog-default-info" variant="default"
+  sl-icon library="fa" name="info-circle" slot="header-icon"
+  div[class="ts-heading-7"] What is vesting?
+  div[style="margin-top: .75rem;"] Vesting refers to the process by which an employee gains ownership rights over employer-provided stock or stock options over a specified period of time.
+  div[style="margin-top: .75rem;"] This is often contingent upon meeting certain conditions such as continued employment or achieving performance milestones.
+
+sl-button Open default informational dialog
+br
+br
+
 sl-dialog label="Submit request?" class="dialog-default" variant="default"
   sl-icon library="fa" name="exclamation-circle" slot="header-icon"
   | If you need to, you can cancel this request after submitting it.
   sl-button slot="footer" variant="default" Cancel
   sl-button slot="footer" variant="primary" Submit request
 
-sl-button Open default confirmation
+sl-button Open default confirmation dialog
 br
 br
 
@@ -202,17 +208,22 @@ sl-dialog label="Cancel request?" class="dialog-warning" variant="warning"
   sl-button slot="footer" variant="default" Keep request
   sl-button slot="footer" variant="warning" Cancel request
 
-sl-button Open warning confirmation
+sl-button Open warning confirmation dialog
 
-script.
+javascript:
   document.addEventListener('DOMContentLoaded', () => {
-    const dialogDefault = document.querySelector('.dialog-default');
-    const openDialogDefault = dialogDefault.nextElementSibling;
-    const footerButtonsDefault = dialogDefault.querySelectorAll('sl-button[slot="footer"]');
+    const dialogDefaultInfo = document.querySelector('.dialog-default-info');
+    const openDialogDefaultInfo = dialogDefaultInfo.nextElementSibling;
 
-    openDialogDefault.addEventListener('click', () => dialogDefault.show());
+    openDialogDefaultInfo.addEventListener('click', () => dialogDefaultInfo.show());
+
+    const dialogDefaultConfirm = document.querySelector('.dialog-default-confirm');
+    const openDialogDefaultConfirm = dialogDefaultConfirm.nextElementSibling;
+    const footerButtonsDefault = dialogDefaultConfirm.querySelectorAll('sl-button[slot="footer"]');
+
+    openDialogDefaultConfirm.addEventListener('click', () => dialogDefaultConfirm.show());
     footerButtonsDefault.forEach(button => {
-      button.addEventListener('click', () => dialogDefault.hide());
+      button.addEventListener('click', () => dialogDefaultConfirm.hide());
     });
 
     const dialogWarning = document.querySelector('.dialog-warning');
@@ -268,6 +279,15 @@ const App = () => {
   );
 };
 ```
+
+:::tip
+**Match a dialog’s variant to specific buttons and icons:**
+| Dialog variant | Button variant | Icon name |
+| ----------------------- | -------------- | ---------------------- |
+| `warning` | `warning` | `exclamation-triangle` |
+| `default` confirmation | `primary` | `exclamation-circle` |
+| `default` informational | `primary` | `info-circle` |
+:::
 
 ### Announcement Dialog
 
@@ -374,6 +394,14 @@ Use the `size` property to set a dialog's width.
 
 <sl-button>Open small dialog</sl-button>
 
+<sl-dialog label="Medium dialog" class="dialog-medium" size="medium">
+  <sl-icon library="fa" name="exclamation-circle" slot="header-icon"></sl-icon>
+  This is a medium dialog. Medium is the dialog’s default size.
+  <sl-button slot="footer" variant="primary">Close</sl-button>
+</sl-dialog>
+
+<sl-button>Open medium dialog</sl-button>
+
 <sl-dialog label="Large dialog" class="dialog-large" size="large">
   <sl-icon library="fa" name="exclamation-circle" slot="header-icon"></sl-icon>
   This is a large dialog.
@@ -389,6 +417,13 @@ Use the `size` property to set a dialog's width.
 
   openButtonSmallDialog.addEventListener('click', () => dialogSmall.show());
   closeButtonSmallDialog.addEventListener('click', () => dialogSmall.hide());
+
+  const dialogMedium = document.querySelector('.dialog-medium');
+  const openButtonMediumDialog = dialogMedium.nextElementSibling;
+  const closeButtonMediumDialog = dialogMedium.querySelector('sl-button[slot="footer"]');
+
+  openButtonMediumDialog.addEventListener('click', () => dialogMedium.show());
+  closeButtonMediumDialog.addEventListener('click', () => dialogMedium.hide());
 
   const dialogLarge = document.querySelector('.dialog-large');
   const openButtonLargeDialog = dialogLarge.nextElementSibling;
@@ -406,27 +441,40 @@ sl-dialog(label="Small dialog" class="dialog-small" size="small")
 
 sl-button Open small dialog
 
+sl-dialog(label="Medium dialog" class="dialog-medium" size="medium")
+  | This is a medium dialog. Medium is the dialog’s default size.
+  sl-button(slot="footer" variant="primary") Close
+
+sl-button Open medium dialog
+
 sl-dialog(label="Large dialog" class="dialog-large" size="large")
   | This is a large dialog.
   sl-button(slot="footer" variant="primary") Close
 
 sl-button Open large dialog
 
-script
+javascript:
   document.addEventListener('DOMContentLoaded', () => {
-    const dialogSmall = document.querySelector('.dialog-small');
-    const openButtonSmallDialog = document.querySelector('sl-button:nth-of-type(1)');
-    const closeButtonSmallDialog = document.querySelector('.dialog-small sl-button[slot="footer"]');
+  const dialogSmall = document.querySelector('.dialog-small');
+  const openButtonSmallDialog = dialogSmall.nextElementSibling;
+  const closeButtonSmallDialog = dialogSmall.querySelector('sl-button[slot="footer"]');
 
-    openButtonSmallDialog.addEventListener('click', () => dialogSmall.show());
-    closeButtonSmallDialog.addEventListener('click', () => dialogSmall.hide());
+  openButtonSmallDialog.addEventListener('click', () => dialogSmall.show());
+  closeButtonSmallDialog.addEventListener('click', () => dialogSmall.hide());
 
-    const dialogLarge = document.querySelector('.dialog-large');
-    const openButtonLargeDialog = document.querySelector('sl-button:nth-of-type(2)');
-    const closeButtonLargeDialog = document.querySelector('.dialog-large sl-button[slot="footer"]');
+  const dialogMedium = document.querySelector('.dialog-medium');
+  const openButtonMediumDialog = dialogMedium.nextElementSibling;
+  const closeButtonMediumDialog = dialogMedium.querySelector('sl-button[slot="footer"]');
 
-    openButtonLargeDialog.addEventListener('click', () => dialogLarge.show());
-    closeButtonLargeDialog.addEventListener('click', () => dialogLarge.hide());
+  openButtonMediumDialog.addEventListener('click', () => dialogMedium.show());
+  closeButtonMediumDialog.addEventListener('click', () => dialogMedium.hide());
+
+  const dialogLarge = document.querySelector('.dialog-large');
+  const openButtonLargeDialog = dialogLarge.nextElementSibling;
+  const closeButtonLargeDialog = dialogLarge.querySelector('sl-button[slot="footer"]');
+
+  openButtonLargeDialog.addEventListener('click', () => dialogLarge.show());
+  closeButtonLargeDialog.addEventListener('click', () => dialogLarge.hide());
   });
 ```
 
@@ -640,6 +688,91 @@ const App = () => {
       </SlDialog>
 
       <SlButton onClick={() => setOpen(true)}>Open Dialog</SlButton>
+    </>
+  );
+};
+```
+
+### Dialog with No Footer
+
+Footer buttons are optional. Omit passing any buttons to the `footer` slot to create a dialog with no footer.
+
+```html:preview
+<sl-dialog label="More about vesting" class="dialog-no-footer" variant="default">
+  <sl-icon library="fa" name="info-circle" slot="header-icon"></sl-icon>
+  <div class="ts-heading-7">What is vesting?</div>
+  <div style="margin-top: .75rem;">Vesting refers to the process by which an employee gains ownership rights over employer-provided stock or stock options over a specified period of time.</div>
+  <div style="margin-top: .75rem;">This is often contingent upon meeting certain conditions such as continued employment or achieving performance milestones.</div>
+</sl-dialog>
+
+<sl-button variant="primary">Open dialog with no footer</sl-button>
+
+<script>
+  const dialogNoFooter = document.querySelector('.dialog-no-footer');
+  const openDialogNoFooter = dialogNoFooter.nextElementSibling;
+
+  openDialogNoFooter.addEventListener('click', () => dialogNoFooter.show());
+</script>
+```
+
+```pug:slim
+sl-dialog label="More about vesting" class="dialog-default-info" variant="default"
+  sl-icon library="fa" name="info-circle" slot="header-icon"
+  div[class="ts-heading-7"] What is vesting?
+  div[style="margin-top: .75rem;"] Vesting refers to the process by which an employee gains ownership rights over employer-provided stock or stock options over a specified period of time.
+  div[style="margin-top: .75rem;"] This is often contingent upon meeting certain conditions such as continued employment or achieving performance milestones.
+
+sl-button Open dialog with no footer
+br
+br
+
+javascript:
+  document.addEventListener('DOMContentLoaded', () => {
+    const dialogNoFooter = document.querySelector('.dialog-no-footer');
+    const openDialogNoFooter = dialogNoFooter.nextElementSibling;
+
+    openDialogNoFooter.addEventListener('click', () => dialogNoFooter.show());
+  });
+```
+
+```jsx:react
+import { useState } from 'react';
+import SlButton from '@teamshares/shoelace/dist/react/button';
+import SlDialog from '@teamshares/shoelace/dist/react/dialog';
+import SlIcon from '@teamshares/shoelace/dist/react/icon';
+
+const App = () => {
+  const [dialogDefaultOpen, setDialogDefaultOpen] = useState(false);
+  const [dialogWarningOpen, setDialogWarningOpen] = useState(false);
+
+  const toggleDialogDefault = () => setDialogDefaultOpen(!dialogDefaultOpen);
+  const toggleDialogWarning = () => setDialogWarningOpen(!dialogWarningOpen);
+
+  return (
+    <>
+      <SlDialog label="Submit request?" class="dialog-default" variant="default" open={dialogDefaultOpen}>
+        <SlIcon library="fa" name="circle-info" slot="header-icon" />
+        If you need to, you'll be able to cancel this request after submitting it.
+        <SlButton slot="footer" variant="default" onClick={toggleDialogDefault}>
+          Cancel
+        </SlButton>
+        <SlButton slot="footer" variant="primary" onClick={toggleDialogDefault}>
+          Submit request
+        </SlButton>
+      </SlDialog>
+      <SlButton onClick={toggleDialogDefault}>Open default dialog</SlButton>
+
+      <SlDialog label="Cancel request?" class="dialog-warning" variant="warning" open={dialogWarningOpen}>
+        <SlIcon library="fa" name="exclamation-triangle" slot="header-icon" />
+        You can't undo this action. You'll need to create a new request.
+        <SlButton slot="footer" variant="default" onClick={toggleDialogWarning}>
+          Keep request
+        </SlButton>
+        <SlButton slot="footer" variant="warning" onClick={toggleDialogWarning}>
+          Cancel request
+        </SlButton>
+      </SlDialog>
+      <SlButton onClick={toggleDialogWarning}>Open warning dialog</SlButton>
     </>
   );
 };

--- a/docs/pages/components/radio.md
+++ b/docs/pages/components/radio.md
@@ -172,7 +172,7 @@ Add the `contained` attribute to the [Radio Group](/components/radio-group) to d
 
 ```html:preview
 <sl-radio-group label="What would you like to do?" name="a" value="issue_shares" contained>
-  <sl-radio value="issue_shares" description="Awards company shares to an employee" >Issue shares</sl-radio>
+  <sl-radio value="issue_shares" description="Awards company shares to an employee">Issue shares</sl-radio>
   <sl-radio value="employee_buyback" description="Buys back vested shares from departing employee owners">Employee buyback</sl-radio>
   <sl-radio value="cancel_certificate" disabled>Cancel a certificate
     <div slot="description">Declares certificate to be <em>null and void</em></div>

--- a/docs/pages/teamshares/changelog.md
+++ b/docs/pages/teamshares/changelog.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2.1.3
+
+- Fix `sl-checkbox` and `sl-radio` bug where a `contained` checkbox or radio had a hover state even when disabled
+- Fix padding cascade bug for `sl-dialog` body for `announcement` variant
+- Fix `sl-button` bug where a disabled link (`a`) button still opens the `href` link
+- Misc doc site improvements
+  - Update props tables to be more readable with no scrolling
+  - Add "no footer" and default width examples to `sl-dialog` docs
+  - Fix bug where Event names are hidden when `SLIM` preview is selected
+
 ## 2.1.2
 
 - Fix to fix spacing for `sl-checkbox` when nested in `sl-checkbox-group` with Simple Form (`ts_form_for`)

--- a/docs/pages/teamshares/changelog.md
+++ b/docs/pages/teamshares/changelog.md
@@ -9,6 +9,7 @@
   - Update props tables to be more readable with no scrolling
   - Add "no footer" and default width examples to `sl-dialog` docs
   - Fix bug where Event names are hidden when `SLIM` preview is selected
+  - Fix bug where icon doesn't display for component properties where `reflect` is `true`
 
 ## 2.1.2
 

--- a/docs/pages/teamshares/changelog.md
+++ b/docs/pages/teamshares/changelog.md
@@ -1,7 +1,14 @@
+---
+meta:
+  title: Changelog
+---
+
 # Changelog
 
-## 2.1.3
+## 2.2.0
 
+- Update `text` variant of `sl-button` to strip all padding so that it aligns better with other elements on the screen
+- Add Link page for documentation of default link style and link button options
 - Fix `sl-checkbox` and `sl-radio` bug where a `contained` checkbox or radio had a hover state even when disabled
 - Fix padding cascade bug for `sl-dialog` body for `announcement` variant
 - Fix `sl-button` bug where a disabled link (`a`) button still opens the `href` link
@@ -10,6 +17,7 @@
   - Add "no footer" and default width examples to `sl-dialog` docs
   - Fix bug where Event names are hidden when `SLIM` preview is selected
   - Fix bug where icon doesn't display for component properties where `reflect` is `true`
+  - Fix bug where some pages don't have a page title showing in the sidebar
 
 ## 2.1.2
 

--- a/docs/pages/teamshares/content.md
+++ b/docs/pages/teamshares/content.md
@@ -13,7 +13,7 @@ meta:
 ### Writing for Teamshares
 
   <div class="grid-cards-2-col">
-  <sl-card class="small-footer">
+  <sl-card>
     <img
     slot="image"
     src="/assets/teamshares/images/notion-links.svg"
@@ -22,7 +22,7 @@ meta:
     />
     <h4 style="margin: 0; display: flex; align-items: flex-start;">Writing and Communicating for Teamshares<sl-icon library="fa" name="lock" style="margin-left: .5em; color: #2e333c;"></sl-icon></h4>
       <p class="ts-body-2 ts-text-subdued" style="margin-bottom: 0;">Login required</p>
-    <div slot="footer" style="margin: 0; padding: 0;">
+    <div slot="footer">
       <sl-button
         variant="text"
         href="https://www.notion.so/teamshares/Writing-and-Communicating-for-Teamshares-599d6c1c65474306aee5b69d0734d8ec?pvs=4"
@@ -38,7 +38,7 @@ meta:
 
   <p>These are some guidelines specific to writing in our digital products and interfaces. More coming soon!</p>
   <h3>Capitalization</h3>
-  <div id="guidelines">
+  <div id="guidelines-content">
 
 :::tip
 **Do**
@@ -69,7 +69,7 @@ meta:
   </div>
 
   <h3>Quotation marks & apostrophes</h3>
-  <div id="guidelines">
+  <div id="guidelines-content">
 
 :::tip
 **Do**

--- a/docs/pages/teamshares/contributing.md
+++ b/docs/pages/teamshares/contributing.md
@@ -48,7 +48,10 @@ Unless you're one of the core DS engineers, most of what you'll be doing in Shoe
 
 Once you're happy with your changes, you can push your changes up to a branch and make a PR for review. (If you don't know what this means or how to do it, you probably shouldn't be editing the code directly.)
 
-!> **Do not push your changes directly into the `next` branch!**
+:::warning
+**Do not push your changes directly to the main Shoelace repo’s `next` branch!**
+When you open a PR, Github will set the base repository to `shoelace-style/shoelace` by default. Be sure to manually reset the base repository for your PR to `teamshares/shoelace`.
+:::
 
 ## Connecting to a local Teamshares app
 

--- a/docs/pages/teamshares/contributing.md
+++ b/docs/pages/teamshares/contributing.md
@@ -1,3 +1,8 @@
+---
+meta:
+  title: Contributing
+---
+
 # Contributing
 
 > The Teamshares Design System is owned by all of us and relies on contributions from all the teams. Thank you in advance for your input!

--- a/docs/pages/teamshares/link.md
+++ b/docs/pages/teamshares/link.md
@@ -15,11 +15,7 @@ meta:
 
 ### Default Link Style
 
-Use the class `ts-text-link` to apply the default Teamshares Design System link style to text. For link text on a dark background, use `ts-text-link-light`.
-
-:::tip
-Use the default link style for link text that appears alongside regular body text, as the visible underline will make it clear that the link text is interactive.
-:::
+Use `class="ts-text-link"` to apply the default Teamshares Design System link style to text. For link text on a dark background, use `ts-text-link-light`.
 
 ```html:preview
 <div class="ts-body-1">
@@ -51,13 +47,11 @@ Use the default link style for link text that appears alongside regular body tex
 
 ### Link Button, `variant="text"`
 
-Set the `href` attribute on `sl-button` to make the component render an `<a>` under the hood. This gives you all the default link behavior the browser provides (e.g. [[CMD/CTRL/SHIFT]] + [[CLICK]]) and exposes the `target` and `download` attributes.
+**For text link styling:** Use `variant="text"` on `sl-button` to display a low-emphasis plain text button. Note that `text` buttons have **no backgrounds, borders, or padding**.
 
-Use `variant="text"` on `sl-button` to display a low-emphasis plain text button that looks more like body copy. Note that `text` buttons have **no backgrounds, borders, or padding**.
+**To render a hypertext link with `<sl-button>`:** Set the `href` attribute on `sl-button` to make the component render an `<a>` under the hood. This gives you all the default link behavior the browser provides (e.g. [[CMD/CTRL/SHIFT]] + [[CLICK]]) and exposes the `target` and `download` attributes.
 
-:::tip
-Use this button type only when the context and label make it clear that the text is interactive.
-:::
+See **[Button](/components/button)** for full `sl-button` specs.
 
 ```html:preview
 <sl-button variant="text" size="small" href="/assets/images/wordmark.svg" download="shoelace.svg">
@@ -85,4 +79,54 @@ sl-button variant="text" size="medium" href="https://example.com/" target="_blan
 **Note:** Don't use `text` buttons in size `large` or `x-large`. There is no visible difference between the `text` button's `medium` and `large` sizes, and the `x-large` size gives too mich emphasis to the button. Please check with the design team before using these size options.
 :::
 
-See **[Button](/components/button)** for full `sl-button` specs.
+## Usage
+
+**When to Use the Default Link Style vs the Text Button**
+
+- Use the **default link style** for inline links that appear within a sentence or paragraph. The visible underline helps to differentiate the link text from the plain text.
+
+- Use the **text button** for stand-alone text, when the context and label alone make it clear that the text is interactive.
+
+<div id="guidelines-content">
+
+:::tip
+**Do**
+
+  <div class="well do">
+    <div class="ts-body-2">
+      Teamshares is an <a href="#" class="ts-text-link">employee ownership platform</a> for small business, driven by
+      proprietary software, education, and financial products.
+    </div>
+  </div>
+
+  <div class="well do">
+    <sl-button variant="text" size="medium" href="https://example.com/" target="_blank">Open statement
+      <sl-icon slot="suffix" library="fa" name="arrow-up-right-from-square"></sl-icon>
+    </sl-button>
+  </div>
+
+- Do use the default link style when a link appears inline with plain text.
+- Do use `<sl-button variant="text">` to render a Text Button when the context and label alone make it clear that the text is interactive. For example, when the context is a header menu, or the label includes an action to indicate what will happen when the link is clicked.
+  :::
+
+:::danger
+**Don't**
+
+  <div class="well do">
+    <div class="ts-body-2">
+      Teamshares is an <a href="#" class="ts-text-link" style="text-decoration: none">employee ownership platform</a> for small business, driven by
+      proprietary software, education, and financial products.
+    </div>
+  </div>
+
+  <div class="well do" style="align-items: flex-start;">
+    <h6>Summary of legal agreement</h6>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+    <sl-button variant="text" size="medium" href="https://example.com/" target="_blank">Full legal agreement
+    </sl-button>
+  </div>
+
+- Don’t override the default link style and remove the underline when a link appears inline with plain text. Color alone is not enough to differentiate the link text from plain text.
+- Don’t use `<sl-button variant="text">` to render a Text Button when the context and label alone don’t make it clear that the text is interactive. Either update button label and/or placement, or use the default link style instead.
+:::
+</div>

--- a/docs/pages/teamshares/link.md
+++ b/docs/pages/teamshares/link.md
@@ -1,0 +1,88 @@
+---
+meta:
+  title: Link
+---
+
+# Link
+
+> Links take the user to another screen, or to a specific part of the current screen.
+
+:::tip
+**Note:** There is no link component in the Teamshares Design System, Links can be styled using the default link class (`ts-text-link`) or rendered using the `<sl-button>` component. See details below.
+:::
+
+## Examples
+
+### Default Link Style
+
+Use the class `ts-text-link` to apply the default Teamshares Design System link style to text. For link text on a dark background, use `ts-text-link-light`.
+
+:::tip
+Use the default link style for link text that appears alongside regular body text, as the visible underline will make it clear that the link text is interactive.
+:::
+
+```html:preview
+<div class="ts-body-1">
+  Teamshares is an <a href="#" class="ts-text-link">employee ownership platform</a> for small business, driven by
+  proprietary software, education, and financial products.
+</div>
+<div class="dark-background">
+  <div class="ts-body-1 ts-text-light">
+    Teamshares is an <a href="#" class="ts-text-link-light">employee ownership platform</a> for small business, driven
+    by proprietary software, education, and financial products.
+  </div>
+</div>
+```
+
+```pug:slim
+.ts-body-1
+  | Teamshares is an
+  a.ts-text-link href="#"
+    | employee ownership platform
+  | for small business, driven by proprietary software, education, and financial products.
+
+.dark-background
+  .ts-body-1.ts-text-light
+    | Teamshares is an
+    a.ts-text-link-light href="#"
+      | employee ownership platform
+    | for small business, driven by proprietary software, education, and financial products.
+```
+
+### Link Button, `variant="text"`
+
+Set the `href` attribute on `sl-button` to make the component render an `<a>` under the hood. This gives you all the default link behavior the browser provides (e.g. [[CMD/CTRL/SHIFT]] + [[CLICK]]) and exposes the `target` and `download` attributes.
+
+Use `variant="text"` on `sl-button` to display a low-emphasis plain text button that looks more like body copy. Note that `text` buttons have **no backgrounds, borders, or padding**.
+
+:::tip
+Use this button type only when the context and label make it clear that the text is interactive.
+:::
+
+```html:preview
+<sl-button variant="text" size="small" href="/assets/images/wordmark.svg" download="shoelace.svg">
+  <sl-icon slot="prefix" library="fa" name="arrow-down-to-bracket"></sl-icon>
+  Download statement</sl-button>
+<br/>
+<br/>
+<sl-button variant="text" size="medium" href="https://example.com/" target="_blank">Open statement
+  <sl-icon slot="suffix" library="fa" name="arrow-up-right-from-square"></sl-icon>
+</sl-button>
+```
+
+```pug:slim
+sl-button variant="text" size="small" href="/assets/images/wordmark.svg" download="shoelace.svg"
+  sl-icon slot="prefix" library="fa" name="arrow-down-to-bracket"
+  | Text
+br
+br
+sl-button variant="text" size="medium" href="https://example.com/" target="_blank"
+  | Text
+  sl-icon slot="suffix" library="fa" name="arrow-up-right-from-square"
+```
+
+:::warning
+**Note:** Don't use `text` buttons in size `large` or `x-large`. There is no visible difference between the `text` button's `medium` and `large` sizes, and the `x-large` size gives too mich emphasis to the button. Please check with the design team before using these size options.
+:::
+
+See **[Button](/components/button)** for full `sl-button` specs.

--- a/docs/pages/teamshares/link.md
+++ b/docs/pages/teamshares/link.md
@@ -8,7 +8,7 @@ meta:
 > Links take the user to another screen, or to a specific part of the current screen.
 
 :::tip
-**Note:** There is no link component in the Teamshares Design System, Links can be styled using the default link class (`ts-text-link`) or rendered using the `<sl-button>` component. See details below.
+**Note:** There is no link component in the Teamshares Design System. Links can be styled using the default link class (`ts-text-link`) or rendered using the `<sl-button>` component. See details below.
 :::
 
 ## Examples

--- a/docs/pages/teamshares/logo-assets.md
+++ b/docs/pages/teamshares/logo-assets.md
@@ -194,7 +194,7 @@ meta:
   ## Brand assets
   ### Brand Book
   <div class="grid-cards-3-col">
-  <sl-card class="small-footer">
+  <sl-card>
     <img
     slot="image"
     src="/assets/teamshares/images/brand-book.svg"
@@ -217,7 +217,7 @@ meta:
 ### Templates
 
    <div class="grid-cards-3-col">
-   <sl-card class="small-footer">
+   <sl-card>
      <img
      slot="image"
      src="/assets/teamshares/images/g-suite-links.svg"
@@ -236,7 +236,7 @@ meta:
        </sl-button>
      </div>
    </sl-card>
-   <sl-card class="small-footer">
+   <sl-card>
      <img
      slot="image"
      src="/assets/teamshares/images/g-suite-links.svg"
@@ -255,7 +255,7 @@ meta:
        </sl-button>
      </div>
    </sl-card>
-   <sl-card class="small-footer">
+   <sl-card>
      <img
      slot="image"
      src="/assets/teamshares/images/g-suite-links.svg"
@@ -274,7 +274,7 @@ meta:
        </sl-button>
      </div>
    </sl-card>
-   <sl-card class="small-footer">
+   <sl-card>
      <img
      slot="image"
      src="/assets/teamshares/images/g-suite-links.svg"

--- a/docs/pages/teamshares/recipes/cypress.md
+++ b/docs/pages/teamshares/recipes/cypress.md
@@ -1,17 +1,11 @@
 ---
 meta:
-  title: Shoelace and Cypress
+  title: Shoelace & Cypress
 ---
 
-# Shoelace and Cypress
+# Shoelace & Cypress
 
-<sl-breadcrumb class="component-header">
-  <sl-breadcrumb-item href="/teamshares/recipes/">
-    <sl-icon slot="prefix" library="fa" name="square-list"></sl-icon>
-    Recipes
-  </sl-breadcrumb-item>
-  <sl-breadcrumb-item>Cypress</sl-breadcrumb-item>
-</sl-breadcrumb>
+> Tips for testing Shoelace components with Cypress
 
 ## TL;DR:
 

--- a/docs/pages/teamshares/recipes/protips.md
+++ b/docs/pages/teamshares/recipes/protips.md
@@ -1,17 +1,11 @@
 ---
 meta:
-  title: Protips
+  title: Shoelace Protips
 ---
 
 # Shoelace Protips
 
-<sl-breadcrumb class="component-header">
-  <sl-breadcrumb-item href="/teamshares/recipes/">
-    <sl-icon slot="prefix" library="fa" name="square-list"></sl-icon>
-    Recipes
-  </sl-breadcrumb-item>
-  <sl-breadcrumb-item>Protips</sl-breadcrumb-item>
-</sl-breadcrumb>
+> General tips for using Shoelace components
 
 ## Conditional attributes
 

--- a/docs/pages/teamshares/recipes/rails-ujs.md
+++ b/docs/pages/teamshares/recipes/rails-ujs.md
@@ -1,17 +1,11 @@
 ---
 meta:
-  title: Shoelace and Rails UJS
+  title: Shoelace & Rails UJS
 ---
 
-# Shoelace and Rails UJS
+# Shoelace & Rails UJS
 
-<sl-breadcrumb class="component-header">
-  <sl-breadcrumb-item href="/teamshares/recipes/">
-    <sl-icon slot="prefix" library="fa" name="square-list"></sl-icon>
-    Recipes
-  </sl-breadcrumb-item>
-  <sl-breadcrumb-item>Rails UJS</sl-breadcrumb-item>
-</sl-breadcrumb>
+> Tips for using Shoelace components in Rails
 
 ## TL;DR:
 
@@ -36,7 +30,7 @@ sl-button[
 sl-button href="some_path" Regular link button
 ```
 
-### Detailed explanation
+## Detailed explanation
 
 For the most part, Shoelace components function like regular html elements, including tha ability to add the `data-` attributes used by Rails to inject functionality. Where that breaks down is when Rails expects only a certain subset of elements to have those attributes. One example of this is UJS's handling of button clicks, which, by default, only detects HTML `<button>` elements. `<sl-button>` does contain a `<button>` element (or an `<a>` tag if it's a link button), but those are hidden in the shadow dom, where UJS can't find them.
 
@@ -97,7 +91,7 @@ sl-button[
 
 Note that UJS expects the URL for a button with `data-remote` to be set in the `data` attributes rather than the `href` we would normally use. (You can still set the `href`, but it won't do anything.) For regular link buttons
 
-### A useful way to debug
+## A useful way to debug
 
 Rails provides a `delegate` method that allows you to intercept events emitted by elements matching a selector. This is very useful for seeing which elements are dispatching which events.
 

--- a/docs/pages/teamshares/view-components/wrapping.md
+++ b/docs/pages/teamshares/view-components/wrapping.md
@@ -1,4 +1,11 @@
-# View Component wrapping
+---
+meta:
+  title: View Components
+---
+
+# View Components
+
+## View Component Wrapping
 
 > TL;DR: If you want to use the auto-generated Stimulus controllers and encapsulated styling for your View Components, you need to:
 >

--- a/docs/pages/tokens/ts-typography.md
+++ b/docs/pages/tokens/ts-typography.md
@@ -12,7 +12,7 @@ meta:
 ### Applying the styles
 
 <div class="panel-content">
-  <div>Styles can be applied using a <code>.ts-<em>{style-name}</em></code> class. The classes are composed with Tailwind utility classes and are defined in this <a href="https://github.com/teamshares/shared-ui/blob/main/scss/includes/_typography.scss" class="ts-text-link" target="_blank">_typography.scss</a> file.</div>
+  <div>Styles can be applied using a <code>.ts-<em>{style-name}</em></code> class. The classes are composed with Tailwind utility classes and are defined in this <a href="https://github.com/teamshares/design-system/blob/main/scss/core-includes/_typography.scss" class="ts-text-link" target="_blank">_typography.scss</a> file.</div>
 </div>
 
 ```html:preview

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamshares/shoelace",
   "description": "The Teamshares flavor of a forward-thinking library of web components.",
-  "version": "2.1.3",
+  "version": "2.2.0",
   "upstreamVersion": "2.14.0",
   "homepage": "https://github.com/teamshares/shoelace",
   "author": "Cory LaViska",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamshares/shoelace",
   "description": "The Teamshares flavor of a forward-thinking library of web components.",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "upstreamVersion": "2.14.0",
   "homepage": "https://github.com/teamshares/shoelace",
   "author": "Cory LaViska",

--- a/src/components/button/button.styles.ts
+++ b/src/components/button/button.styles.ts
@@ -12,6 +12,16 @@ export default css`
     cursor: not-allowed;
   }
 
+  :host([variant='text'][size='small']) {
+    line-height: 1rem;
+    height: 1rem;
+  }
+
+  :host([variant='text'][size='medium']) {
+    line-height: 1.25rem;
+    height: 1.25rem;
+  }
+
   .button {
     display: inline-flex;
     align-items: stretch;
@@ -349,6 +359,44 @@ export default css`
     background-color: transparent;
     border-color: transparent;
     color: var(--sl-color-primary-900);
+  }
+
+  .button--has-label.button--small.button--text:not(.button--has-prefix) .button__label,
+  .button--has-label.button--medium.button--text:not(.button--has-prefix) .button__label,
+  .button--has-label.button--large.button--text:not(.button--has-prefix) .button__label,
+  .button--has-label.button--x-large.button--text:not(.button--has-prefix) .button__label {
+    padding-left: 0;
+  }
+
+  .button--has-label.button--small.button--text:not(.button--has-suffix) .button__label,
+  .button--has-label.button--medium.button--text:not(.button--has-suffix) .button__label,
+  .button--has-label.button--large.button--text:not(.button--has-suffix) .button__label,
+  .button--has-label.button--x-large.button--text:not(.button--has-suffix) .button__label {
+    padding-right: 0;
+  }
+
+  .button--has-label.button--small.button--text.button--has-prefix,
+  .button--has-label.button--medium.button--text.button--has-prefix,
+  .button--has-label.button--large.button--text.button--has-prefix,
+  .button--has-label.button--x-large.button--text.button--has-prefix {
+    padding-inline-start: 0;
+  }
+
+  .button--has-label.button--small.button--text.button--has-suffix,
+  .button--has-label.button--medium.button--text.button--has-suffix,
+  .button--has-label.button--large.button--text.button--has-suffix,
+  .button--has-label.button--x-large.button--text.button--has-suffix {
+    padding-inline-end: 0;
+  }
+
+  .button--has-label.button--small.button--text,
+  .button--has-label.button--medium.button--text,
+  .button--has-label.button--large.button--text,
+  .button--has-label.button--x-large.button--text {
+    min-height: fit-content;
+    height: fit-content;
+    line-height: 1;
+    border-radius: 0;
   }
 
   /*

--- a/src/components/button/button.styles.ts
+++ b/src/components/button/button.styles.ts
@@ -8,6 +8,10 @@ export default css`
     cursor: pointer;
   }
 
+  :host([href][disabled]) {
+    cursor: not-allowed;
+  }
+
   .button {
     display: inline-flex;
     align-items: stretch;
@@ -47,6 +51,10 @@ export default css`
   .button--disabled {
     opacity: 0.5;
     cursor: not-allowed;
+  }
+
+  a.button--disabled {
+    pointer-events: none;
   }
 
   /* When disabled, prevent mouse events from bubbling up from children */

--- a/src/components/checkbox/checkbox.styles.ts
+++ b/src/components/checkbox/checkbox.styles.ts
@@ -169,8 +169,8 @@ export default css`
     height: 100%;
   }
 
-  .checkbox--contained:hover,
-  .checkbox--contained.checkbox--checked:hover {
+  :not(.checkbox--disabled).checkbox--contained:hover,
+  :not(.checkbox--disabled).checkbox--contained.checkbox--checked:hover {
     background-color: var(--sl-color-blue-50);
     transition: var(--sl-transition-medium) all;
   }

--- a/src/components/dialog/dialog.styles.ts
+++ b/src/components/dialog/dialog.styles.ts
@@ -199,8 +199,8 @@ export default css`
     padding: var(--body-spacing);
   }
 
-  .dialog--has-header-icon .dialog--small .dialog__body,
-  .dialog--has-header-icon .dialog__body {
+  .dialog--has-header-icon:not(.dialog--announcement) .dialog--small .dialog__body,
+  .dialog--has-header-icon:not(.dialog--announcement) .dialog__body {
     padding: var(--sl-spacing-x-small) var(--ts-spacing-large) var(--sl-spacing-x-small) var(--ts-spacing-5x-large);
   }
 
@@ -267,9 +267,13 @@ export default css`
       max-height: 80vh;
     }
 
-    .dialog--has-header-icon .dialog__body {
+    .dialog--has-header-icon:not(.dialog--announcement) .dialog__body {
       text-align: center;
       padding: var(--body-spacing);
+    }
+
+    .dialog:not(.dialog--has-footer) .dialog__body {
+      padding-bottom: var(--sl-spacing-3x-large);
     }
 
     .dialog__body {

--- a/src/components/radio/radio.styles.ts
+++ b/src/components/radio/radio.styles.ts
@@ -134,8 +134,8 @@ export default css`
     height: 100%;
   }
 
-  .radio--contained:hover,
-  .radio--contained.radio--checked:hover {
+  :not(.radio--disabled).radio--contained:hover,
+  :not(.radio--disabled).radio--contained.radio--checked:hover {
     background-color: var(--sl-color-blue-50);
     transition: var(--sl-transition-medium) all;
   }


### PR DESCRIPTION
## What's in this PR
- Update `text` variant of `sl-button` to strip all padding so that it aligns better with other elements on the screen ([Link in review app](https://shoelace-kdloz39o7-teamshares.vercel.app/components/button#text-buttons))
- Add Link page for documentation of default link style and link button options ([Link in review app](https://shoelace-kdloz39o7-teamshares.vercel.app/teamshares/link))
- Fix `sl-checkbox` and `sl-radio` bug where a `contained` checkbox or radio had a hover state even when disabled ([Link in review app](https://shoelace-kdloz39o7-teamshares.vercel.app/components/checkbox#contained))
- Fix padding cascade bug for `sl-dialog` body for `announcement` variant ([Link in review app](https://shoelace-kdloz39o7-teamshares.vercel.app/components/dialog#announcement-dialog))
- Fix `sl-button` bug where a disabled link (`a`) button still opens the `href` link ([Link in review app](https://shoelace-jc5m8xsbk-teamshares.vercel.app/components/button#link-buttons))
- Misc doc site improvements
  - Update props tables to be more readable with no scrolling
  - Add "no footer" and default width examples to `sl-dialog` docs
  - Fix bug where Event names are hidden when `SLIM` preview is selected
  - Fix bug where icon doesn't display for component properties where `reflect` is `true`

---

### Screenshots of props table update

**Old props table**
Full table isn't visible without horizontal scroll
<img width="866" alt="Screenshot 2024-07-17 at 14 32 44" src="https://github.com/user-attachments/assets/dd9c382e-36da-49ac-9b10-770f3c8be52b">

**Updated props table**
Updated styling & layout so that no scrolling is needed to see the full table
<img width="859" alt="Screenshot 2024-07-17 at 14 44 24" src="https://github.com/user-attachments/assets/a55c502f-1e55-4a2d-b160-d49af66184eb">

