### PR TITLE
Figma Code Connect + Docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,10 @@
 _site
 .cache
 .DS_Store
+.env
 cdn
 dist
 docs/assets/images/sprite.svg
 node_modules
 src/react
-.vscode/settings.json
 .vscode/settings.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,5 +13,6 @@
   },
   "[nunjucks]": {
     "editor.defaultFormatter": "okitavera.vscode-nunjucks-formatter"
-  }
+  },
+  "typescript.validate.enable": false
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,6 +13,5 @@
   },
   "[nunjucks]": {
     "editor.defaultFormatter": "okitavera.vscode-nunjucks-formatter"
-  },
-  "typescript.validate.enable": false
+  }
 }

--- a/docs/_includes/component.njk
+++ b/docs/_includes/component.njk
@@ -80,6 +80,13 @@
     <h2>Usage</h2>
     <div id="guidelines-content">{{ guidelines | markdown | safe }}</div>
   {% endif %}
+  {# Testing #}
+  {% if
+  testing %}
+    <h2>Testing</h2>
+    <div id="testing-content">{{ testing | markdown | safe }}</div>
+  {% endif %}
+
   {# Importing #}
   {# <h2>Importing</h2>
   <p>

--- a/docs/_includes/component.njk
+++ b/docs/_includes/component.njk
@@ -259,6 +259,7 @@
         <tr>
           <th class="table-name" data-flavor="html">Name</th>
           <th class="table-name" data-flavor="slim">Name</th>
+          <th class="table-name" data-flavor="simple-form">Name</th>
           <th class="table-name" data-flavor="react">React Event</th>
           <th class="table-description">Details</th>
         </tr>
@@ -270,6 +271,9 @@
               <code class="nowrap">{{ event.name }}</code>
             </td>
             <td data-flavor="slim">
+              <code class="nowrap">{{ event.name }}</code>
+            </td>
+            <td data-flavor="simple-form">
               <code class="nowrap">{{ event.name }}</code>
             </td>
             <td data-flavor="react">

--- a/docs/_includes/component.njk
+++ b/docs/_includes/component.njk
@@ -62,7 +62,7 @@
     <h1>{{ component.name | classNameToComponentName }}</h1>
 
     <div class="component-header__tag">
-      <code>&lt;{{ component.tagName }}&gt; | {{ component.name }}</code>
+      <code>{{ component.tagName }}</code>
     </div>
   </header>
 

--- a/docs/_includes/default.njk
+++ b/docs/_includes/default.njk
@@ -152,7 +152,7 @@
 
       <button class="search-box" type="button" title="Press / to search" aria-label="Search" data-plugin="search">
         <sl-icon library="fa" name="search"></sl-icon>
-        <span>Search</span>
+        <span>Type / to search</span>
       </button>
 
       <nav>{% include 'sidebar.njk' %}</nav>

--- a/docs/_utilities/code-previews.cjs
+++ b/docs/_utilities/code-previews.cjs
@@ -25,6 +25,9 @@ module.exports = function (doc, options) {
     }
     const adjacentPre = pre.nextElementSibling?.tagName.toLowerCase() === 'pre' ? pre.nextElementSibling : null;
     const slimCode = adjacentPre?.querySelector('code[class$="slim"]');
+    const secondAdjacentPre =
+      adjacentPre?.nextElementSibling?.tagName.toLowerCase() === 'pre' ? adjacentPre.nextElementSibling : null;
+    const simpleFormCode = secondAdjacentPre?.querySelector('code[class$="simple-form"]');
     const sourceGroupId = `code-preview-source-group-${count}`;
     const isExpanded = code.getAttribute('class').includes(':expanded');
     const noCodePen = code.getAttribute('class').includes(':no-codepen');
@@ -48,6 +51,15 @@ module.exports = function (doc, options) {
         Slim
       </button>
     `;
+
+    const simpleFormButton = `
+    <button type="button"
+      title="Show Simple Form code"
+      class="code-preview__button code-preview__button--simple-form"
+    >
+      Simple Form
+    </button>
+  `;
 
     const codePenButton = `
       <button type="button" class="code-preview__button code-preview__button--codepen" title="Edit on CodePen">
@@ -89,6 +101,16 @@ module.exports = function (doc, options) {
           `
               : ''
           }
+
+          ${
+            simpleFormCode
+              ? `
+            <div class="code-preview__source code-preview__source--simple-form" data-flavor="simple-form">
+              <pre><code class="language-js">${escapeHtml(simpleFormCode.textContent)}</code></pre>
+            </div>
+          `
+              : ''
+          }          
         </div>
 
         <div class="code-preview__buttons">
@@ -113,6 +135,8 @@ module.exports = function (doc, options) {
 
           ${slimCode ? ` ${htmlButton} ${slimButton} ` : ''}
 
+          ${simpleFormCode ? simpleFormButton : ''}
+
           ${noCodePen ? '' : codePenButton}
         </div>
       </div>
@@ -123,6 +147,10 @@ module.exports = function (doc, options) {
 
     if (adjacentPre) {
       adjacentPre.remove();
+    }
+
+    if (secondAdjacentPre) {
+      secondAdjacentPre.remove();
     }
   });
 

--- a/docs/_utilities/code-previews.cjs
+++ b/docs/_utilities/code-previews.cjs
@@ -57,7 +57,7 @@ module.exports = function (doc, options) {
       title="Show Simple Form code"
       class="code-preview__button code-preview__button--simple-form"
     >
-      Simple Form
+      TS Form
     </button>
   `;
 

--- a/docs/assets/scripts/code-previews.js
+++ b/docs/assets/scripts/code-previews.js
@@ -140,7 +140,7 @@
       setFlavor('slim');
       toggleSource(codeBlock, true);
     } else if (button?.classList.contains('code-preview__button--simple-form')) {
-      // Show Slim
+      // Show SimpleForm
       setFlavor('simple-form');
       toggleSource(codeBlock, true);
     } else if (button?.classList.contains('code-preview__toggle')) {

--- a/docs/assets/scripts/code-previews.js
+++ b/docs/assets/scripts/code-previews.js
@@ -41,12 +41,13 @@
   }
 
   function setFlavor(newFlavor) {
-    flavor = ['html', 'slim'].includes(newFlavor) ? newFlavor : 'html';
+    flavor = ['html', 'slim', 'simple-form'].includes(newFlavor) ? newFlavor : 'html';
     sessionStorage.setItem('flavor', flavor);
 
     // Set the flavor class on the body
     document.documentElement.classList.toggle('flavor-html', flavor === 'html');
     document.documentElement.classList.toggle('flavor-slim', flavor === 'slim');
+    document.documentElement.classList.toggle('flavor-simple-form', flavor === 'simple-form');
   }
 
   function syncFlavor() {
@@ -60,6 +61,12 @@
 
     document.querySelectorAll('.code-preview__button--slim').forEach(preview => {
       if (flavor === 'slim') {
+        preview.classList.add('code-preview__button--selected');
+      }
+    });
+
+    document.querySelectorAll('.code-preview__button--simple-form').forEach(preview => {
+      if (flavor === 'simple-form') {
         preview.classList.add('code-preview__button--selected');
       }
     });
@@ -132,6 +139,10 @@
       // Show Slim
       setFlavor('slim');
       toggleSource(codeBlock, true);
+    } else if (button?.classList.contains('code-preview__button--simple-form')) {
+      // Show Slim
+      setFlavor('simple-form');
+      toggleSource(codeBlock, true);
     } else if (button?.classList.contains('code-preview__toggle')) {
       // Toggle source
       toggleSource(codeBlock);
@@ -148,6 +159,10 @@
       cb.querySelector('.code-preview__button--slim')?.classList.toggle(
         'code-preview__button--selected',
         flavor === 'slim'
+      );
+      cb.querySelector('.code-preview__button--simple-form')?.classList.toggle(
+        'code-preview__button--selected',
+        flavor === 'simple-form'
       );
     });
   });

--- a/docs/assets/scripts/code-previews.js
+++ b/docs/assets/scripts/code-previews.js
@@ -176,7 +176,7 @@
       const jsTemplate =
         `import { registerExternalLibraries } from 'https://esm.sh/@${org}/shoelace@${shoelaceVersion}/${cdndir}/utilities/icon-library';\n` +
         `registerExternalLibraries();\n` +
-        `import tokens from "https://esm.sh/@${org}/shoelace@${shoelaceVersion}/${npmdir}/styles/tokens.json" assert { type: "json" };\n` +
+        `import tokens from "https://esm.sh/@${org}/shoelace@${shoelaceVersion}/${npmdir}/styles/tokens.json" with { type: "json" };\n` +
         `\n` +
         `// Configure Tailwind so we can prototype with TS custom colors\n` +
         `tailwind.config = { theme: { extend: tokens } };\n`;

--- a/docs/assets/styles/code-previews.css
+++ b/docs/assets/styles/code-previews.css
@@ -218,3 +218,7 @@
 .flavor-slim [data-flavor]:not([data-flavor='slim']) {
   display: none;
 }
+
+.flavor-simple-form [data-flavor]:not([data-flavor='simple-form']) {
+  display: none;
+}

--- a/docs/assets/styles/docs.css
+++ b/docs/assets/styles/docs.css
@@ -2049,6 +2049,16 @@ div.token-style {
   padding: 0 0 1rem;
 }
 
+#border-radius-grid div.token-style--header > div:first-child,
+#border-radius-grid div.token-style > div:first-child {
+  grid-column: span 2;
+}
+
+#spacing-grid div.token-style--header > div:last-child,
+#spacing-grid div.token-style > div:last-child {
+  grid-column: span 2;
+}
+
 div.text-specs div,
 div.token-style div {
   font-size: var(--ts-font-sm);

--- a/docs/assets/styles/docs.css
+++ b/docs/assets/styles/docs.css
@@ -715,10 +715,10 @@ td.table-name code.prop,
 
 .cy-table-desc + div > table > tbody tr:first-child,
 .cy-table-desc + div > table > tbody tr:nth-child(5),
-.cy-table-desc + div > table > tbody tr:nth-child(9),
-.cy-table-desc + div > table > tbody tr:nth-child(13),
-.cy-table-desc + div > table > tbody tr:nth-child(16),
-.cy-table-desc + div > table > tbody tr:nth-child(19) {
+.cy-table-desc + div > table > tbody tr:nth-child(7),
+.cy-table-desc + div > table > tbody tr:nth-child(11),
+.cy-table-desc + div > table > tbody tr:nth-child(14),
+.cy-table-desc + div > table > tbody tr:nth-child(17) {
   border-top: 2px solid var(--sl-color-neutral-300);
 }
 

--- a/docs/assets/styles/docs.css
+++ b/docs/assets/styles/docs.css
@@ -501,9 +501,9 @@ code {
   padding: 0.125rem 0.5rem;
 }
 
-.sl-theme-dark code {
+/* .sl-theme-dark code {
   background-color: rgba(255 255 255 / 0.03);
-}
+} */
 
 kbd {
   background: var(--sl-color-neutral-100);

--- a/docs/assets/styles/docs.css
+++ b/docs/assets/styles/docs.css
@@ -2049,14 +2049,9 @@ div.token-style {
   padding: 0 0 1rem;
 }
 
-#border-radius-grid div.token-style--header > div:first-child,
-#border-radius-grid div.token-style > div:first-child {
-  grid-column: span 2;
-}
-
-#spacing-grid div.token-style--header > div:last-child,
-#spacing-grid div.token-style > div:last-child {
-  grid-column: span 2;
+#three-col-grid div.token-style--header,
+#three-col-grid div.token-style {
+  grid-template-columns: repeat(3, 1fr);
 }
 
 div.text-specs div,

--- a/docs/assets/styles/docs.css
+++ b/docs/assets/styles/docs.css
@@ -700,12 +700,26 @@ th.table-event-detail {
   min-width: 15ch;
 }
 
-td.table-name code.prop {
+td.table-name code.prop,
+.cy-table-desc + div > table td:nth-child(2) span {
   font-size: var(--sl-font-size-x-small);
   font-weight: var(--sl-font-weight-bold);
   padding: var(--sl-spacing-2x-small) var(--sl-spacing-x-small);
   color: var(--sl-color-primary-700);
   background-color: var(--sl-color-primary-100);
+}
+
+.cy-table-desc {
+  padding-bottom: var(--sl-spacing-large);
+}
+
+.cy-table-desc + div > table > tbody tr:first-child,
+.cy-table-desc + div > table > tbody tr:nth-child(5),
+.cy-table-desc + div > table > tbody tr:nth-child(9),
+.cy-table-desc + div > table > tbody tr:nth-child(13),
+.cy-table-desc + div > table > tbody tr:nth-child(16),
+.cy-table-desc + div > table > tbody tr:nth-child(19) {
+  border-top: 2px solid var(--sl-color-neutral-300);
 }
 
 /* Code blocks */

--- a/docs/pages/components/alert.md
+++ b/docs/pages/components/alert.md
@@ -59,7 +59,7 @@ guidelines: |
 ```
 
 ```pug:slim
-sl-alert open="true"
+sl-alert open=true
   sl-icon slot="icon" library="fa" name="fas-circle-info"
   div slot="header" This is the alert header
   | This is the alert message. Keep it simple!
@@ -118,24 +118,24 @@ Set the `variant` attribute to change the alert's variant.
 ```
 
 ```pug:slim
-sl-alert variant="primary" open="true"
+sl-alert variant="primary" open=true
   sl-icon slot="icon" library="fa" name="fas-circle-info"
   div slot="header" We’ve simplified your login experience!
   | You can now log in to both apps with one set of credentials.
 br
-sl-alert variant="success" open="true"
+sl-alert variant="success" open=true
   sl-icon slot="icon" library="fa" name="fas-circle-check"
   div slot="header" Request approved
   |  This request was approved on April 25, 2024.
 br
-sl-alert variant="warning" open="true"
+sl-alert variant="warning" open=true
   sl-icon slot="icon" library="fa" name="fas-triangle-exclamation"
   div slot="header" This view is currently hidden from shareholders
   | Go to
   a class="ts-text-link" href="#" Company settings
   | to edit the visibility of this page.
 br
-sl-alert variant="danger" open="true"
+sl-alert variant="danger" open=true
   sl-icon slot="icon" library="fa" name="fas-circle-exclamation"
   div slot="header" Your payment is past due
   | To avoid late fees, pay your minimum amount due today.
@@ -198,7 +198,7 @@ Add the `closable` attribute to show a close button that will hide the alert.
 ```
 
 ```pug:slim
-sl-alert.alert-closable variant="primary" open="true" closable="true"
+sl-alert.alert-closable variant="primary" open=true closable=true
   sl-icon slot="icon" library="fa" name="fas-circle-info"
   | You can close this alert any time!
 
@@ -239,7 +239,7 @@ Icons are optional. Simply omit the `icon` slot if you don't want them.
 ```
 
 ```pug:slim
-sl-alert variant="primary" open="true"  Nothing fancy here, just a simple alert.
+sl-alert variant="primary" open=true  Nothing fancy here, just a simple alert.
 ```
 
 ```jsx:react
@@ -284,7 +284,7 @@ Set the `duration` attribute to automatically hide an alert after a period of ti
 ```pug:slim
 div.alert-duration
   sl-button variant="primary" Show Alert
-  sl-alert variant="primary" duration="3000" closable="true"
+  sl-alert variant="primary" duration="3000" closable=true
     sl-icon slot="icon" library="fa" name="fas-circle-info"
     | This alert will automatically hide itself after three seconds, unless you interact with it.
 
@@ -382,15 +382,15 @@ div.alert-toast
   sl-button variant="success" Success
   sl-button variant="warning" Warning
   sl-button variant="danger" Danger
-  sl-alert variant="primary" duration="3000" closable="true"
+  sl-alert variant="primary" duration="3000" closable=true
     sl-icon slot="icon" library="fa" name="fas-circle-info"
     div slot="header" We’ve simplified your login experience!
     | You can now log in to both apps with one set of credentials.
-  sl-alert variant="success" duration="3000" closable="true"
+  sl-alert variant="success" duration="3000" closable=true
     sl-icon slot="icon" library="fa" name="fas-circle-check"
     div slot="header" Request submitted
     | Your request to issue 1,000 shares to Grace Hopper has been submitted.
-  sl-alert variant="danger" duration="3000" closable="true"
+  sl-alert variant="danger" duration="3000" closable=true
     sl-icon slot="icon" library="fa" name="fas-circle-exclamation"
     div slot="header" Your settings couldn’t be updated
     | Please

--- a/docs/pages/components/alert.md
+++ b/docs/pages/components/alert.md
@@ -3,6 +3,8 @@ meta:
   title: Alert
   description: Alerts are used to display important messages inline or as toast notifications.
 layout: component
+unusedProperties: |
+  - Variant `neutral`
 guidelines: |
   **Using Icons in Alerts**
 
@@ -33,6 +35,15 @@ guidelines: |
 
   - Do keep the message as short as possible
   - Alert messages could contain plain text or a bulleted list, or even a button
+
+  **Inline Alerts**
+  - By default an Alert should appear inline and take up the full width of the parent container
+  - Inline alerts should generally not be dismissible
+
+  **Toast Alerts**
+  - The toast variant has a max-width of 416px
+  - Toasts should appear on the bottom-right of the screen
+  - Toasts should generally be dismissible
 ---
 
 ## Examples

--- a/docs/pages/components/alert.md
+++ b/docs/pages/components/alert.md
@@ -6,7 +6,7 @@ layout: component
 unusedProperties: |
   - Variant `neutral`
 guidelines: |
-  **Using Icons in Alerts**
+  ### Icons in Alerts
 
   :::tip 
   **Do**
@@ -24,23 +24,23 @@ guidelines: |
   - If you have a strong use case for using a one-off icon, check with the design team
   :::
 
-  **Using Headers in Alerts**
+  ### Headers in Alerts
 
   - Do include a header (using <code>slot="header"</code>) in the alert
   - Do keep the header short and scannable
   - Do use sentence case for headers
   - Don't use a a period in the header, even if it's a complete sentence
 
-  **The Alert Message**
+  ### Alert Message
 
   - Do keep the message as short as possible
   - Alert messages could contain plain text or a bulleted list, or even a button
 
-  **Inline Alerts**
+  ### Inline Alerts
   - By default an Alert should appear inline and take up the full width of the parent container
   - Inline alerts should generally not be dismissible
 
-  **Toast Alerts**
+  ### Toast Alerts
   - The toast variant has a max-width of 416px
   - Toasts should appear on the bottom-right of the screen
   - Toasts should generally be dismissible

--- a/docs/pages/components/badge.md
+++ b/docs/pages/components/badge.md
@@ -27,11 +27,11 @@ unusedProperties: |
 The badge is designed to be used for displaying number counts. Pass a number to the badge using the `value` property. Numbers greater than 99 will be displayed as `99+`.
 
 ```html:preview
-<sl-badge value=1999></sl-badge>
+<sl-badge value="1999"></sl-badge>
 ```
 
 ```pug:slim
-sl-badge value=1999
+sl-badge value="1999"
 ```
 
 ```jsx:react
@@ -45,17 +45,17 @@ const App = () => <SlBadge value={1999}></SlBadge>;
 Set the `variant` attribute to change the badge's variant. We currently have just 2 variants in the Teamshares Design System: `red` (default) and `gray`. You can also use the semantic variants `danger` (same as `red`) and `neutral` (same as `gray`).
 
 ```html:preview
-<sl-badge value=10></sl-badge>
-<sl-badge variant="danger" value=4></sl-badge>
-<sl-badge variant="gray" value=10></sl-badge>
-<sl-badge variant="neutral" value=4></sl-badge>
+<sl-badge value="10"></sl-badge>
+<sl-badge variant="danger" value="4"></sl-badge>
+<sl-badge variant="gray" value="10"></sl-badge>
+<sl-badge variant="neutral" value="4"></sl-badge>
 ```
 
 ```pug:slim
-sl-badge value=10
-sl-badge variant="danger" value=4
-sl-badge variant="gray" value=10
-sl-badge variant="neutral" value=4
+sl-badge value="10"
+sl-badge variant="danger" value="4"
+sl-badge variant="gray" value="10"
+sl-badge variant="neutral" value="4"
 ```
 
 ```jsx:react
@@ -80,13 +80,13 @@ Use the `square` attribute to give badges a rounded-rectangle shape.
 :::
 
 ```html:preview
-<sl-badge square value=11></sl-badge>
-<sl-badge variant="neutral" square value=11></sl-badge>
+<sl-badge square value="11"></sl-badge>
+<sl-badge variant="neutral" square value="11"></sl-badge>
 ```
 
 ```pug:slim
-sl-badge square="true" value=11
-sl-badge variant="neutral" square="true" value=11
+sl-badge square="true" value="11"
+sl-badge variant="neutral" square="true" value="11"
 ```
 
 ```jsx:react
@@ -135,8 +135,8 @@ Use the `pulse` attribute to draw attention to the badge with a subtle animation
 
 ```html:preview
 <div class="badge-pulse">
-  <sl-badge pulse value=1></sl-badge>
-  <sl-badge variant="neutral" pulse value=1></sl-badge>
+  <sl-badge pulse value="1"></sl-badge>
+  <sl-badge variant="neutral" pulse value="1"></sl-badge>
 </div>
 
 <style>
@@ -148,8 +148,8 @@ Use the `pulse` attribute to draw attention to the badge with a subtle animation
 
 ```pug:slim
 div.badge-pulse
-  sl-badge pulse="true" value=1
-  sl-badge variant="neutral" pulse="true" value=1
+  sl-badge pulse="true" value="1"
+  sl-badge variant="neutral" pulse="true" value="1"
 
 css:
   .badge-pulse sl-badge:not(:last-of-type) {
@@ -185,22 +185,22 @@ One of the most common use cases for badges is attaching them to buttons. To mak
 ```html:preview
 <sl-button>
   Requests
-  <sl-badge variant="neutral" value=1920></sl-badge>
+  <sl-badge variant="neutral" value="1920"></sl-badge>
 </sl-button>
 
 <sl-button style="margin-inline-start: 1rem;">
   Errors
-  <sl-badge value=6></sl-badge>
+  <sl-badge value="6"></sl-badge>
 </sl-button>
 ```
 
 ```pug:slim
 sl-button
   | Requests
-  sl-badge variant="neutral" value=1920
+  sl-badge variant="neutral" value="1920"
 sl-button style="margin-inline-start: 1rem;"
   | Errors
-  sl-badge value=6
+  sl-badge value="6"
 ```
 
 {% raw %}
@@ -233,10 +233,10 @@ Use badges in tabs to show counts of items.
 ```html:preview
 <sl-tab-group>
   <sl-tab slot="nav" panel="emails">Emails
-    <sl-badge value=1200>
+    <sl-badge value="1200">
   </sl-tab>
   <sl-tab slot="nav" panel="notes">Notes
-    <sl-badge value=10>
+    <sl-badge value="10">
   </sl-tab>
 
   <sl-tab-panel name="emails">You have 1,200 unread emails.</sl-tab-panel>
@@ -247,9 +247,9 @@ Use badges in tabs to show counts of items.
 ```pug:slim
 sl-tab-group
   sl-tab slot="nav" panel="emails" Emails
-    sl-badge value=1200
+    sl-badge value="1200"
   sl-tab slot="nav" panel="notes" Notes
-    sl-badge value=10
+    sl-badge value="10"
   sl-tab-panel name="emails" You have 1,200 unread emails.
   sl-tab-panel name="notes" You have 10 unread notes.
 ```
@@ -261,8 +261,8 @@ When including badges in menu items, use the `suffix` slot to make sure they're 
 ```html:preview
 <sl-menu style="max-width: 240px;">
   <sl-menu-label>Messages</sl-menu-label>
-  <sl-menu-item>Comments <sl-badge slot="suffix" variant="neutral" value=4></sl-badge></sl-menu-item>
-  <sl-menu-item>Replies <sl-badge slot="suffix" variant="neutral" value=12></sl-badge></sl-menu-item>
+  <sl-menu-item>Comments <sl-badge slot="suffix" variant="neutral" value="4"></sl-badge></sl-menu-item>
+  <sl-menu-item>Replies <sl-badge slot="suffix" variant="neutral" value="12"></sl-badge></sl-menu-item>
 </sl-menu>
 ```
 
@@ -270,9 +270,9 @@ When including badges in menu items, use the `suffix` slot to make sure they're 
 sl-menu style="max-width: 240px;"
   sl-menu-label Messages
   sl-menu-item Comments
-    sl-badge slot="suffix" variant="neutral" value=4
+    sl-badge slot="suffix" variant="neutral" value="4"
   sl-menu-item Replies
-    sl-badge slot="suffix" variant="neutral" value=12
+    sl-badge slot="suffix" variant="neutral" value="12"
 ```
 
 {% raw %}

--- a/docs/pages/components/badge.md
+++ b/docs/pages/components/badge.md
@@ -85,8 +85,8 @@ Use the `square` attribute to give badges a rounded-rectangle shape.
 ```
 
 ```pug:slim
-sl-badge square="true" value="11"
-sl-badge variant="neutral" square="true" value="11"
+sl-badge square=true value="11"
+sl-badge variant="neutral" square=true value="11"
 ```
 
 ```jsx:react
@@ -148,8 +148,8 @@ Use the `pulse` attribute to draw attention to the badge with a subtle animation
 
 ```pug:slim
 div.badge-pulse
-  sl-badge pulse="true" value="1"
-  sl-badge variant="neutral" pulse="true" value="1"
+  sl-badge pulse=true value="1"
+  sl-badge variant="neutral" pulse=true value="1"
 
 css:
   .badge-pulse sl-badge:not(:last-of-type) {

--- a/docs/pages/components/badge.md
+++ b/docs/pages/components/badge.md
@@ -4,15 +4,15 @@ meta:
   description: Badges are used to draw attention and display counts.
 layout: component
 guidelines: |
-  **Badge Types & Basics**
+  ### Badge Types
   - Use the badge variant `danger` to grab people's attention
   - Use the variant `neutral` for simple counts that don't require people's immediate attention
 
-  **When to Use a Badge**
+  ### When to Use a Badge
   - Use a badge to display a count of items that people need to be aware of
   - Don't use a badge for text content
 
-  **When to Use a Different Component**
+  ### When to Use Something Else
   - Use a [tag](/components/tag) instead if you need a status indicator or some other label that displays words instead of numbers
 
 unusedProperties: |

--- a/docs/pages/components/breadcrumb.md
+++ b/docs/pages/components/breadcrumb.md
@@ -299,7 +299,7 @@ sl-breadcrumb
     sl-dropdown slot="suffix"
       sl-icon-button slot="trigger" library="fa" label="More options" name="ellipsis"
       sl-menu
-        sl-menu-item type="checkbox" checked="true" Web Design
+        sl-menu-item type="checkbox" checked=true Web Design
         sl-menu-item type="checkbox" Web Development
         sl-menu-item type="checkbox" Marketing
 ```

--- a/docs/pages/components/button-group.md
+++ b/docs/pages/components/button-group.md
@@ -273,21 +273,21 @@ Pill buttons are supported through the button's `pill` attribute.
 
 ```pug:slim
 sl-button-group label="Alignment"
-  sl-button size="small" pill="true" Left
-  sl-button size="small" pill="true" Center
-  sl-button size="small" pill="true" Right
+  sl-button size="small" pill=true Left
+  sl-button size="small" pill=true Center
+  sl-button size="small" pill=true Right
 br
 br
 sl-button-group label="Alignment"
-  sl-button size="medium" pill="true" Left
-  sl-button size="medium" pill="true" Center
-  sl-button size="medium" pill="true" Right
+  sl-button size="medium" pill=true Left
+  sl-button size="medium" pill=true Center
+  sl-button size="medium" pill=true Right
 br
 br
 sl-button-group label="Alignment"
-  sl-button size="large" pill="true" Left
-  sl-button size="large" pill="true" Center
-  sl-button size="large" pill="true" Right
+  sl-button size="large" pill=true Left
+  sl-button size="large" pill=true Center
+  sl-button size="large" pill=true Right
 ```
 
 ```jsx:react
@@ -365,7 +365,7 @@ sl-button-group label="Example Button Group"
   sl-button Button
   sl-button Button
   sl-dropdown
-    sl-button slot="trigger" caret="true" Dropdown
+    sl-button slot="trigger" caret=true Dropdown
     sl-menu
       sl-menu-item Item 1
       sl-menu-item Item 2
@@ -421,7 +421,7 @@ Create a split button using a button and a dropdown. Use a [visually hidden](/co
 sl-button-group label="Example Button Group"
   sl-button variant="primary" Save
   sl-dropdown placement="bottom-end"
-    sl-button.no-pad-l slot="trigger" variant="primary" caret="true"
+    sl-button.no-pad-l slot="trigger" variant="primary" caret=true
       sl-visually-hidden More options
     sl-menu
       sl-menu-item Save

--- a/docs/pages/components/button.md
+++ b/docs/pages/components/button.md
@@ -100,10 +100,10 @@ Use the `outline` attribute to draw outlined buttons with transparent background
 ```
 
 ```pug:slim
-sl-button variant="default" outline="true" Default
-sl-button variant="primary" outline="true" Primary
-sl-button variant="warning" outline="true" Warning
-sl-button variant="danger" outline="true" Danger
+sl-button variant="default" outline=true Default
+sl-button variant="primary" outline=true Primary
+sl-button variant="warning" outline=true Warning
+sl-button variant="danger" outline=true Danger
 ```
 
 ```jsx:react
@@ -143,10 +143,10 @@ Use the `square` attribute to give buttons a rounded-rectangle shape.
 ```
 
 ```pug:slim
-sl-button size="small" square="true" Small
-sl-button size="medium" square="true" Medium
-sl-button size="large" square="true" Large
-sl-button size="x-large" square="true" Extra large
+sl-button size="small" square=true Small
+sl-button size="medium" square=true Medium
+sl-button size="large" square=true Large
+sl-button size="x-large" square=true Extra large
 ```
 
 ```jsx:react
@@ -193,13 +193,13 @@ Use the `circle` attribute to create circular icon buttons. When this attribute 
 ```
 
 ```pug:slim
-sl-button variant="default" size="small" circle="true"
+sl-button variant="default" size="small" circle=true
   sl-icon library="fa" name="fas-ellipsis-vertical" label="More options"
-sl-button variant="default" size="medium" circle="true"
+sl-button variant="default" size="medium" circle=true
   sl-icon library="fa" name="fas-ellipsis-vertical" label="More options"
-sl-button variant="default" size="large" circle="true"
+sl-button variant="default" size="large" circle=true
   sl-icon library="fa" name="fas-ellipsis-vertical" label="More options"
-sl-button variant="default" size="x-large" circle="true"
+sl-button variant="default" size="x-large" circle=true
   sl-icon library="fa" name="fas-ellipsis-vertical" label="More options"
 ```
 
@@ -285,7 +285,7 @@ It's often helpful to have a button that works like a link. This is possible by 
 sl-button href="https://example.com/" Link
 sl-button href="https://example.com/" target="_blank" New Window
 sl-button href="/assets/images/wordmark.svg" download="shoelace.svg" Download
-sl-button href="https://example.com/" disabled="true" Disabled
+sl-button href="https://example.com/" disabled=true Disabled
 ```
 
 ```jsx:react
@@ -539,10 +539,10 @@ Use the `caret` attribute to add a dropdown indicator when a button will trigger
 ```
 
 ```pug:slim
-sl-button size="small" caret="true" Small
-sl-button size="medium" caret="true" Medium
-sl-button size="large" caret="true" Large
-sl-button size="x-large" caret="true" Extra large
+sl-button size="small" caret=true Small
+sl-button size="medium" caret=true Medium
+sl-button size="large" caret=true Large
+sl-button size="x-large" caret=true Extra large
 ```
 
 ```jsx:react
@@ -578,10 +578,10 @@ Use the `loading` attribute to make a button busy. The width will remain the sam
 ```
 
 ```pug:slim
-sl-button variant="default" loading="true" Default
-sl-button variant="primary" loading="true" Primary
-sl-button variant="warning" loading="true" Warning
-sl-button variant="danger" loading="true" Danger
+sl-button variant="default" loading=true Default
+sl-button variant="primary" loading=true Primary
+sl-button variant="warning" loading=true Warning
+sl-button variant="danger" loading=true Danger
 ```
 
 ```jsx:react
@@ -617,10 +617,10 @@ Use the `disabled` attribute to disable a button.
 ```
 
 ```pug:slim
-sl-button variant="default" disabled="true" Default
-sl-button variant="primary" disabled="true" Primary
-sl-button variant="warning" disabled="true" Warning
-sl-button variant="danger" disabled="true" Danger
+sl-button variant="default" disabled=true Default
+sl-button variant="primary" disabled=true Primary
+sl-button variant="warning" disabled=true Warning
+sl-button variant="danger" disabled=true Danger
 ```
 
 ```jsx:react

--- a/docs/pages/components/card.md
+++ b/docs/pages/components/card.md
@@ -53,7 +53,7 @@ sl-card.card-overview
   br
   small 6 weeks old
   div slot="footer"
-    sl-button variant="primary" pill="true" More Info
+    sl-button variant="primary" pill=true More Info
     sl-rating
 
 css:

--- a/docs/pages/components/carousel-item.md
+++ b/docs/pages/components/carousel-item.md
@@ -45,7 +45,7 @@ layout: component
 ```
 
 ```pug:slim
-sl-carousel pagination="true"
+sl-carousel pagination=true
   sl-carousel-item
     img alt="The sun shines on the mountains and trees - Photo by Adam Kool on Unsplash" src="/assets/examples/carousel/mountains.jpg"
   sl-carousel-item

--- a/docs/pages/components/carousel.md
+++ b/docs/pages/components/carousel.md
@@ -45,7 +45,7 @@ layout: component
 ```
 
 ```pug:slim
-sl-carousel pagination="true" navigation="true" mouse-dragging="true" loop="true"
+sl-carousel pagination=true navigation=true mouse-dragging=true loop=true
   sl-carousel-item
     img alt="The sun shines on the mountains and trees (by Adam Kool on Unsplash)" src="/assets/examples/carousel/mountains.jpg"
   sl-carousel-item
@@ -140,7 +140,7 @@ Use the `pagination` attribute to show the total number of slides and the curren
 ```
 
 ```pug:slim
-sl-carousel pagination="true"
+sl-carousel pagination=true
   sl-carousel-item
     img alt="The sun shines on the mountains and trees (by Adam Kool on Unsplash)" src="/assets/examples/carousel/mountains.jpg"
   sl-carousel-item
@@ -233,7 +233,7 @@ Use the `navigation` attribute to show previous and next buttons.
 ```
 
 ```pug:slim
-sl-carousel navigation="true"
+sl-carousel navigation=true
   sl-carousel-item
     img alt="The sun shines on the mountains and trees (by Adam Kool on Unsplash)" src="/assets/examples/carousel/mountains.jpg"
   sl-carousel-item
@@ -326,7 +326,7 @@ By default, the carousel will not advanced beyond the first and last slides. You
 ```
 
 ```pug:slim
-sl-carousel loop="true" navigation="true" pagination="true"
+sl-carousel loop=true navigation=true pagination=true
   sl-carousel-item
     img alt="The sun shines on the mountains and trees (by Adam Kool on Unsplash)" src="/assets/examples/carousel/mountains.jpg"
   sl-carousel-item
@@ -419,7 +419,7 @@ The carousel will automatically advance when the `autoplay` attribute is used. T
 ```
 
 ```pug:slim
-sl-carousel autoplay="true" loop="true" pagination="true"
+sl-carousel autoplay=true loop=true pagination=true
   sl-carousel-item
     img alt="The sun shines on the mountains and trees (by Adam Kool on Unsplash)" src="/assets/examples/carousel/mountains.jpg"
   sl-carousel-item
@@ -531,7 +531,7 @@ This example is best demonstrated using a mouse. Try clicking and dragging the s
 
 ```pug:slim
 div class="mouse-dragging"
-  sl-carousel pagination="true"
+  sl-carousel pagination=true
     sl-carousel-item
       img alt="The sun shines on the mountains and trees (by Adam Kool on Unsplash)" src="/assets/examples/carousel/mountains.jpg"
     sl-carousel-item
@@ -626,7 +626,7 @@ The `slides-per-page` attribute makes it possible to display multiple slides at 
 ```
 
 ```pug:slim
-sl-carousel navigation="true" pagination="true" slides-per-page="2" slides-per-move="2"
+sl-carousel navigation=true pagination=true slides-per-page="2" slides-per-move="2"
   sl-carousel-item style="background: var(--sl-color-red-200);" Slide 1
   sl-carousel-item style="background: var(--sl-color-orange-200);" Slide 2
   sl-carousel-item style="background: var(--sl-color-yellow-200);" Slide 3
@@ -728,7 +728,7 @@ The content of the carousel can be changed by adding or removing carousel items.
 ```
 
 ```pug:slim
-sl-carousel class="dynamic-carousel" pagination="true" navigation="true"
+sl-carousel class="dynamic-carousel" pagination=true navigation=true
   sl-carousel-item style="background: var(--sl-color-red-200)" Slide 1
   sl-carousel-item style="background: var(--sl-color-orange-200)" Slide 2
   sl-carousel-item style="background: var(--sl-color-yellow-200)" Slide 3
@@ -907,7 +907,7 @@ Setting the `orientation` attribute to `vertical` will render the carousel in a 
 ```
 
 ```pug:slim
-sl-carousel class="vertical" pagination="true" orientation="vertical"
+sl-carousel class="vertical" pagination=true orientation="vertical"
   sl-carousel-item
     img alt="The sun shines on the mountains and trees (by Adam Kool on Unsplash)" src="/assets/examples/carousel/mountains.jpg"
   sl-carousel-item
@@ -1056,7 +1056,7 @@ Use the `--aspect-ratio` custom property to customize the size of the carousel's
 ```
 
 ```pug:slim
-sl-carousel class="aspect-ratio" navigation="true" pagination="true" style="--aspect-ratio: 3/2;"
+sl-carousel class="aspect-ratio" navigation=true pagination=true style="--aspect-ratio: 3/2;"
   sl-carousel-item
     img alt="The sun shines on the mountains and trees (by Adam Kool on Unsplash)" src="/assets/examples/carousel/mountains.jpg"
   sl-carousel-item
@@ -1193,7 +1193,7 @@ Use the `--scroll-hint` custom property to add inline padding in horizontal caro
 ```
 
 ```pug:slim
-sl-carousel class="scroll-hint" pagination="true" style="--scroll-hint: 10%;"
+sl-carousel class="scroll-hint" pagination=true style="--scroll-hint: 10%;"
   sl-carousel-item
     img alt="The sun shines on the mountains and trees (by Adam Kool on Unsplash)" src="/assets/examples/carousel/mountains.jpg"
   sl-carousel-item
@@ -1375,7 +1375,7 @@ The carousel has a robust API that makes it possible to extend and customize. Th
 ```
 
 ```pug:slim
-sl-carousel class="carousel-thumbnails" navigation="true" loop="true"
+sl-carousel class="carousel-thumbnails" navigation=true loop=true
   sl-carousel-item
     img alt="The sun shines on the mountains and trees (by Adam Kool on Unsplash)" src="/assets/examples/carousel/mountains.jpg"
   sl-carousel-item

--- a/docs/pages/components/checkbox-group.md
+++ b/docs/pages/components/checkbox-group.md
@@ -24,20 +24,32 @@ testing: |
 
    To test `<sl-checkbox-group>`, add the `data-test-id` attribute directly to the component. To test checkbox items in the group, add `data-test-id` to each item:
 
-  ```
+  ```pug:slim
     sl-checkbox-group[
       label="Checkbox group text"
       name="input-name"
       data-test-id="checkbox-group-test"
     ] 
-      sl-checkbox value="option-1" data-test-id="item-test-1" Option 1
-      sl-checkbox value="option-2" data-test-id="item-test-2" Option 2
-      sl-checkbox value="option-3" data-test-id="item-test-3" Option 3
+      sl-checkbox[
+        value="option-1"
+        data-test-id="item-test-1"
+      ] 
+        | Option 1
+      sl-checkbox[
+        value="option-2" 
+        data-test-id="item-test-2"
+      ] 
+        | Option 2
+      sl-checkbox[
+        value="option-3" 
+        data-test-id="item-test-3"
+      ] 
+        | Option 3
   ```
 
   To test `<sl-checkbox-group>` implemented with `ts_form_for`, add `data-test-id` to `wrapper_html`. To test checkbox items in the group, add `data-test-id` to each item in the collection array:
 
-  ```
+  ```js
       = ts_form_for ... do |f|
         = f.input :input_name,
           as: :check_boxes,
@@ -57,22 +69,22 @@ testing: |
   **Cypress commands for `<sl-checkbox-group>`**
 
   To **check** any checkbox in the checkbox group:
-  ```
+  ```js
     cy.slCheckboxCheck(`[data-test-id="item-test-1"]`);
   ```
 
   To **uncheck** any checkbox in a checkbox group:
-  ```
+  ```js
     cy.slCheckboxUncheck(`[data-test-id="item-test-1"]`);
   ```
 
   To verify the checkbox group's value, that certain items **are checked**:
-  ```
+  ```js
     cy.slCheckboxGroupValue(`[data-test-id="checkbox-group-test"]`, ["option-1", "option-2"]);
   ```
 
   To verify the checkbox group's value, that certain items **are NOT checked**:
-  ```
+  ```js
     cy.get(`[data-test-id="checkbox-group-test"]`).should("not.have.value", "option-3");
   ```
 ---
@@ -99,11 +111,9 @@ sl-checkbox-group[
   sl-checkbox value="initiate-outbound" Initiate outbound transfers
   sl-checkbox value="approve-outbound" Approve outbound transfers
   sl-checkbox value="export" Export transactions
+```
 
- /*
-  When rendering with ts_form_for
-*/
-
+```js:simple-form
 = ts_form_for ... do |f|
   = f.input :a,
     as: :check_boxes,
@@ -149,11 +159,9 @@ sl-checkbox-group[
   sl-checkbox value="initiate-outbound" Initiate outbound transfers
   sl-checkbox value="approve-outbound" Approve outbound transfers
   sl-checkbox value="export" Export transactions
+```
 
- /*
-  When rendering with ts_form_for
-*/
-
+```js:simple-form
 = ts_form_for ... do |f|
   = f.input :a,
     as: :check_boxes,
@@ -207,11 +215,9 @@ sl-checkbox-group[
   sl-checkbox value="initiate-outbound" Initiate outbound transfers
   sl-checkbox value="approve-outbound" Approve outbound transfers
   sl-checkbox value="export" Export transactions
+```
 
-/*
-  When rendering with ts_form_for
-*/
-
+```js:simple-form
 = ts_form_for ... do |f|
   = f.input :a,
     as: :check_boxes,
@@ -277,10 +283,20 @@ sl-checkbox-group[
   sl-checkbox value="manage-transfers" Manage transfers
   sl-checkbox value="export" Export transactions
 
-/*
-  When rendering with ts_form_for
-*/
+css:
+sl-checkbox-group[id="permissions"] {
+  container-type: inline-size;
+  container-name: permissions;
+}
 
+@container permissions (max-width: 400px) {
+  sl-checkbox-group[id="permissions"]::part(form-control-input) {
+    flex-direction: column;
+  }
+}
+```
+
+```js:simple-form
 = ts_form_for ... do |f|
   = f.input :a,
     as: :check_boxes,
@@ -293,18 +309,6 @@ sl-checkbox-group[
       horizontal: true,
       id: "permissions",
     }
-
-css:
-  sl-checkbox-group[id="permissions"] {
-    container-type: inline-size;
-    container-name: permissions;
-  }
-
-  @container permissions (max-width: 400px) {
-    sl-checkbox-group[id="permissions"]::part(form-control-input) {
-      flex-direction: column;
-    }
-  }
 ```
 
 ```jsx:react
@@ -361,11 +365,9 @@ sl-checkbox-group[
 ]
   sl-checkbox value="initiate-outbound" Initiate outbound transfers
   sl-checkbox value="approve-outbound" Approve outbound transfers
+```
 
- /*
-  When rendering with ts_form_for
-*/
-
+```js:simple-form
 = ts_form_for ... do |f|
   = f.input :a,
     as: :check_boxes,
@@ -430,7 +432,9 @@ sl-checkbox-group[
   sl-checkbox value="initiate-outbound" Initiate outbound transfers
   sl-checkbox value="approve-outbound" Approve outbound transfers
   sl-checkbox value="export" disabled="true" Export transactions
+```
 
+```js:simple-form
 /*
   When rendering `sl-checkbox-group` with ts_form_for, pass additional
   attributes such as `disabled` and `description` as extra items
@@ -521,26 +525,6 @@ form.validation
   ]
     | Submit
 
-/*
-  When rendering with ts_form_for
-*/
-
-= ts_form_for ... do |f|
-  = f.input :a,
-    as: :check_boxes,
-    label: "Select at least one option",
-    collection: [
-      ["Option 1", "1"],
-      ["Option 2", "2"],
-      ["Option 3", "3"],
-    ],
-    wrapper_html: {
-      required: true,
-    }
-  br
-  // ts_form_for automatically sets the form's submit button to variant="primary"
-  = f.submit "Submit"
-
 javascript:
   const form = document.querySelector(.validation);
 
@@ -554,6 +538,24 @@ javascript:
       alert(All fields are valid!);
     });
   });
+```
+
+```js:simple-form
+= ts_form_for ... do |f|
+  = f.input :a,
+    as: :check_boxes,
+    label: "Select at least one option",
+    collection: [
+      ["Option 1", "1"],
+      ["Option 2", "2"],
+      ["Option 3", "3"],
+    ],
+    wrapper_html: {
+      required: true,
+    }
+
+// ts_form_for automatically sets the form's submit button to variant="primary"
+= f.submit "Submit"
 ```
 
 ```jsx:react

--- a/docs/pages/components/checkbox-group.md
+++ b/docs/pages/components/checkbox-group.md
@@ -22,7 +22,7 @@ testing: |
 
   **Adding `data-test-id` to a component**
 
-   To test `<sl-checkbox-group>`, add the `data-test-id` attribute directly to the component. To test checkbox items in the group, add `data-test-id` to each item:
+   To test `sl-checkbox-group`, add the `data-test-id` attribute directly to the component. To test checkbox items in the group, add `data-test-id` to each item:
 
   ```pug:slim
     sl-checkbox-group[
@@ -47,7 +47,7 @@ testing: |
         | Option 3
   ```
 
-  To test `<sl-checkbox-group>` implemented with `ts_form_for`, add `data-test-id` to `wrapper_html`. To test checkbox items in the group, add `data-test-id` to each item in the collection array:
+  To test `sl-checkbox-group` implemented with `ts_form_for`, add `data-test-id` to `wrapper_html`. To test checkbox items in the group, add `data-test-id` to each item in the collection array:
 
   ```js
       = ts_form_for ... do |f|
@@ -61,12 +61,12 @@ testing: |
           ],
           wrapper_html: { 
             data: { 
-              "test_id": "checkbox-group-test"
+              test_id: "checkbox-group-test"
             }
           }
   ```
 
-  **Cypress commands for `<sl-checkbox-group>`**
+  **Cypress commands for `sl-checkbox-group`**
 
   To **check** any checkbox in the checkbox group:
   ```js

--- a/docs/pages/components/checkbox-group.md
+++ b/docs/pages/components/checkbox-group.md
@@ -6,17 +6,75 @@ layout: component
 unusedProperties: |
   - Sizes `small`, `large`
 guidelines: |
-  **When to Use a Checkbox Group**
+  ### When to Use a Checkbox Group
   - When you want people to **choose one or more** options from a list
   - When presenting **fewer than 7** options
   - If letting people **see all their options** right away (without an additional click) is a priority
 
-  **When to Use a Different Component**
+  ### When to Use Something Else
   - **Use a [radio group](/components/radio-group) instead** if presenting fewer than 5 to 7 options and you want to let people choose **just one** option
   - **Use a multi-select [select](/components/select) instead** if presenting more than 7 options or there isn't enough room to present all the options
 
-  **Labels, Help Text, Etc.**
+  ### Labels, Help Text, Etc.
   - For additional guidelines on checkbox and checkbox group **labels**, **help text**, and the  **label tooltip**, refer to the [Input component usage guidelines](/components/input/#usage-guidelines)
+testing: |
+  ### With Cypress
+
+  **Adding `data-test-id` to a component**
+
+   To test `<sl-checkbox-group>`, add the `data-test-id` attribute directly to the component. To test checkbox items in the group, add `data-test-id` to each item:
+
+  ```
+    sl-checkbox-group[
+      label="Checkbox group text"
+      name="input-name"
+      data-test-id="checkbox-group-test"
+    ] 
+      sl-checkbox value="option-1" data-test-id="item-test-1" Option 1
+      sl-checkbox value="option-2" data-test-id="item-test-2" Option 2
+      sl-checkbox value="option-3" data-test-id="item-test-3" Option 3
+  ```
+
+  To test `<sl-checkbox-group>` implemented with `ts_form_for`, add `data-test-id` to `wrapper_html`. To test checkbox items in the group, add `data-test-id` to each item in the collection array:
+
+  ```
+      = ts_form_for ... do |f|
+        = f.input :input_name,
+          as: :check_boxes,
+          label: "Checkbox group text",
+          collection: [
+            ["Option 1", :option-1, data: { test_id: "item-test-1" }],
+            ["Option 2", :option-2, data: { test_id: "item-test-2" }],
+            ["Option 3", :option-3, data: { test_id: "item-test-3" }],
+          ],
+          wrapper_html: { 
+            data: { 
+              "test_id": "checkbox-group-test"
+            }
+          }
+  ```
+
+  **Cypress commands for `<sl-checkbox-group>`**
+
+  To **check** any checkbox in the checkbox group:
+  ```
+    cy.slCheckboxCheck(`[data-test-id="item-test-1"]`);
+  ```
+
+  To **uncheck** any checkbox in a checkbox group:
+  ```
+    cy.slCheckboxUncheck(`[data-test-id="item-test-1"]`);
+  ```
+
+  To verify the checkbox group's value, that certain items **are checked**:
+  ```
+    cy.slCheckboxGroupValue(`[data-test-id="checkbox-group-test"]`, ["option-1", "option-2"]);
+  ```
+
+  To verify the checkbox group's value, that certain items **are NOT checked**:
+  ```
+    cy.get(`[data-test-id="checkbox-group-test"]`).should("not.have.value", "option-3");
+  ```
 ---
 
 ## Examples

--- a/docs/pages/components/checkbox-group.md
+++ b/docs/pages/components/checkbox-group.md
@@ -349,7 +349,7 @@ sl-checkbox-group[
   name="a"
   label="Financial products permissions"
   help-text="Outbound transfers require separate initiators and approvers"
-  contained="true"
+  contained=true
 ]
   sl-checkbox value="initiate-outbound" Initiate outbound transfers
   sl-checkbox value="approve-outbound" Approve outbound transfers
@@ -360,8 +360,8 @@ sl-checkbox-group[
   name="b"
   label="Financial products permissions"
   help-text="Outbound transfers require separate initiators and approvers"
-  contained="true"
-  horizontal="true"
+  contained=true
+  horizontal=true
 ]
   sl-checkbox value="initiate-outbound" Initiate outbound transfers
   sl-checkbox value="approve-outbound" Approve outbound transfers
@@ -431,7 +431,7 @@ sl-checkbox-group[
 ]
   sl-checkbox value="initiate-outbound" Initiate outbound transfers
   sl-checkbox value="approve-outbound" Approve outbound transfers
-  sl-checkbox value="export" disabled="true" Export transactions
+  sl-checkbox value="export" disabled=true Export transactions
 ```
 
 ```js:simple-form
@@ -513,7 +513,7 @@ form.validation
   sl-radio-group[
     name="a"
     label="Select at least one option"
-    required="true"
+    required=true
   ]
     sl-radio value="1" Option 1
     sl-radio value="2" Option 2
@@ -636,7 +636,7 @@ Use the `setCustomValidity()` method to set a custom validation message. This wi
 
 ```pug:slim
 form.validation
-  sl-radio-group name="a" label="Select the third option" required="true"
+  sl-radio-group name="a" label="Select the third option" required=true
     sl-radio value="1" You can optionally choose me
     sl-radio value="2" I'm optional too
     sl-radio value="3" You must choose me

--- a/docs/pages/components/checkbox.md
+++ b/docs/pages/components/checkbox.md
@@ -13,7 +13,7 @@ testing: |
 
   **Adding `data-test-id` to a component**
 
-   To test `<sl-checkbox>`, add the `data-test-id` attribute directly to the component:
+   To test `sl-checkbox`, add the `data-test-id` attribute directly to the component:
 
   ```pug:slim
     sl-checkbox[
@@ -22,7 +22,7 @@ testing: |
       | Checkbox test
   ```
 
-  To test `<sl-checkbox>` implemented with `ts_form_for`, add `data-test-id` to `input_html`:
+  To test `sl-checkbox` implemented with `ts_form_for`, add `data-test-id` to `input_html`:
 
   ```js
       = ts_form_for ... do |f|
@@ -31,12 +31,12 @@ testing: |
           input_html: { 
             label: "Checkbox text",
             data: { 
-              "test_id": "checkbox-test"
+              test_id: "checkbox-test"
             }
           }
   ```
 
-  **Cypress commands for `<sl-checkbox>`**
+  **Cypress commands for `sl-checkbox`**
 
   To **check** the checkbox:
   ```js

--- a/docs/pages/components/checkbox.md
+++ b/docs/pages/components/checkbox.md
@@ -8,6 +8,55 @@ unusedProperties: |
   - Boolean `indeterminate`
 guidelines: |
   - Refer to the [Checkbox Group component general guidelines](/components/checkbox-group/#usage-guidelines)
+testing: |
+  ### With Cypress
+
+  **Adding `data-test-id` to a component**
+
+   To test `<sl-checkbox>`, add the `data-test-id` attribute directly to the component:
+
+  ```
+    sl-checkbox[
+      data-test-id="checkbox-test"
+    ] 
+      | Checkbox test
+  ```
+
+  To test `<sl-checkbox>` implemented with `ts_form_for`, add `data-test-id` to `input_html`:
+
+  ```
+      = ts_form_for ... do |f|
+        = f.input :input_name,
+          as: :boolean,
+          input_html: { 
+            label: "Checkbox text",
+            data: { 
+              "test_id": "checkbox-test"
+            }
+          }
+  ```
+
+  **Cypress commands for `<sl-checkbox>`**
+
+  To **check** the checkbox:
+  ```
+    cy.slCheckboxCheck(`[data-test-id="checkbox-test"]`);
+  ```
+
+  To **uncheck** the checkbox:
+  ```
+    cy.slCheckboxUncheck(`[data-test-id="checkbox-test"]`);
+  ```
+
+  To verify the checkbox **is checked**:
+  ```
+    cy.get(`[data-test-id="checkbox-test"]`).should("have.prop", "checked", true);
+  ```
+
+  To verify the checkbox **is NOT checked**:
+  ```
+    cy.get(`[data-test-id="checkbox-test"]`).should("have.prop", "checked", false);
+  ```
 ---
 
 ## Examples

--- a/docs/pages/components/checkbox.md
+++ b/docs/pages/components/checkbox.md
@@ -15,7 +15,7 @@ testing: |
 
    To test `<sl-checkbox>`, add the `data-test-id` attribute directly to the component:
 
-  ```
+  ```pug:slim
     sl-checkbox[
       data-test-id="checkbox-test"
     ] 
@@ -24,7 +24,7 @@ testing: |
 
   To test `<sl-checkbox>` implemented with `ts_form_for`, add `data-test-id` to `input_html`:
 
-  ```
+  ```js
       = ts_form_for ... do |f|
         = f.input :input_name,
           as: :boolean,
@@ -39,22 +39,22 @@ testing: |
   **Cypress commands for `<sl-checkbox>`**
 
   To **check** the checkbox:
-  ```
+  ```js
     cy.slCheckboxCheck(`[data-test-id="checkbox-test"]`);
   ```
 
   To **uncheck** the checkbox:
-  ```
+  ```js
     cy.slCheckboxUncheck(`[data-test-id="checkbox-test"]`);
   ```
 
   To verify the checkbox **is checked**:
-  ```
+  ```js
     cy.get(`[data-test-id="checkbox-test"]`).should("have.prop", "checked", true);
   ```
 
   To verify the checkbox **is NOT checked**:
-  ```
+  ```js
     cy.get(`[data-test-id="checkbox-test"]`).should("have.prop", "checked", false);
   ```
 ---
@@ -69,11 +69,9 @@ testing: |
 
 ```pug:slim
 sl-checkbox Financial products access
+```
 
-/*
-  When rendering with ts_form_for
-*/
-
+```js:simple-form
 = ts_form_for ... do |f|
   = f.input :access,
     as: :boolean,
@@ -101,18 +99,19 @@ Add descriptive help text to individual checkbox items with the `description` at
 ```
 
 ```pug:slim
-sl-checkbox description="Grants access to cash account and charge card features" Financial products access
+sl-checkbox[
+  description="Grants access to cash account and charge card features"
+]
+  | Financial products access
+```
 
-/*
-  When rendering with ts_form_for
-*/
-
+```js:simple-form
 = ts_form_for ... do |f|
   = f.input :access,
     as: :boolean,
     input_html: {
       label: "Financial products access",
-      description: "Grants access to cash account and charge card features",
+      description: "Grants access to cash account and charge card features"
     }
 ```
 
@@ -155,7 +154,9 @@ sl-checkbox-group[
   | Approve outbound transfers
   sl-checkbox description="Applies to both cash account and charge card" disabled
   | Export transactions
+```
 
+```js:simple-form
 /*
   When rendering `sl-checkbox-group` with ts_form_for, pass additional
   attributes such as `disabled` and `description` as extra items
@@ -246,11 +247,6 @@ Use the `selected-content` slot to display additional content (such as an input 
 ```
 
 ```pug:slim
-/*
-  NOTE: `ts_form_for` doesn't support slots. The `selected-content` slot
-  cannot be used for checkboxes rendered with `ts_form_for`.
-*/
-
 sl-checkbox[
   style="width:100%"
   contained="true"
@@ -271,6 +267,13 @@ css:
     font-weight: normal;
     color: #6D7176;
   }
+```
+
+```js:simple-form
+/*
+  NOTE: `ts_form_for` doesn't support slots. The `selected-content` slot
+  cannot be used for checkboxes rendered with `ts_form_for`.
+*/
 ```
 
 ```jsx:react
@@ -301,11 +304,9 @@ Use the `checked` attribute to activate the checkbox.
 
 ```pug:slim
 sl-checkbox checked="true" Financial products access
+```
 
-/*
-  When rendering with ts_form_for
-*/
-
+```js:simple-form
 = ts_form_for ... do |f|
   = f.input :access,
     as: :boolean,
@@ -335,11 +336,9 @@ The `indeterminate` option for a checkbox is currently not part of the Teamshare
 
 ```pug:slim
 sl-checkbox indeterminate="true" Indeterminate
+```
 
-/*
-  When rendering with ts_form_for
-*/
-
+```js:simple-form
 = ts_form_for ... do |f|
   = f.input :access,
     as: :boolean,
@@ -365,11 +364,9 @@ Use the `disabled` attribute to disable the checkbox.
 
 ```pug:slim
 sl-checkbox disabled="true" Disabled
+```
 
-/*
-  When rendering with ts_form_for
-*/
-
+```js:simple-form
 = ts_form_for ... do |f|
   = f.input :access,
     as: :boolean,

--- a/docs/pages/components/checkbox.md
+++ b/docs/pages/components/checkbox.md
@@ -139,14 +139,14 @@ Add the `contained` attribute to draw a card-like container around a checkbox. A
 ```pug:slim
 sl-checkbox[
   description="Grants access to cash account and charge card features"
-  contained="true"
+  contained=true
 ]
   | Financial products access
 br
 br
 sl-checkbox-group[
   label="Financial products permissions"
-  contained="true"
+  contained=true
 ]
   sl-checkbox description="Requires separate initiators and approvers"
   | Initiate outbound transfers
@@ -249,7 +249,7 @@ Use the `selected-content` slot to display additional content (such as an input 
 ```pug:slim
 sl-checkbox[
   style="width:100%"
-  contained="true"
+  contained=true
 ]
   | Grant financial products access
   div slot="selected-content"
@@ -258,8 +258,8 @@ sl-checkbox[
       style="width: 280px;"
       label="Mobile number"
       type="tel"
-      required="true"
-      optional-icon="true"
+      required=true
+      optional-icon=true
     ]
 css:
     sl-checkbox::part(selected-content) {
@@ -303,7 +303,7 @@ Use the `checked` attribute to activate the checkbox.
 ```
 
 ```pug:slim
-sl-checkbox checked="true" Financial products access
+sl-checkbox checked=true Financial products access
 ```
 
 ```js:simple-form
@@ -335,7 +335,7 @@ The `indeterminate` option for a checkbox is currently not part of the Teamshare
 ```
 
 ```pug:slim
-sl-checkbox indeterminate="true" Indeterminate
+sl-checkbox indeterminate=true Indeterminate
 ```
 
 ```js:simple-form
@@ -363,7 +363,7 @@ Use the `disabled` attribute to disable the checkbox.
 ```
 
 ```pug:slim
-sl-checkbox disabled="true" Disabled
+sl-checkbox disabled=true Disabled
 ```
 
 ```js:simple-form

--- a/docs/pages/components/color-picker.md
+++ b/docs/pages/components/color-picker.md
@@ -52,7 +52,7 @@ Use the `opacity` attribute to enable the opacity slider. When this is enabled, 
 ```
 
 ```pug:slim
-sl-color-picker value="#f5a623ff" opacity="true" label="Select a color"
+sl-color-picker value="#f5a623ff" opacity=true label="Select a color"
 ```
 
 ```jsx:react
@@ -163,7 +163,7 @@ The color picker can be rendered inline instead of in a dropdown using the `inli
 ```
 
 ```pug:slim
-sl-color-picker inline="true" label="Select a color"
+sl-color-picker inline=true label="Select a color"
 ```
 
 ```jsx:react

--- a/docs/pages/components/details.md
+++ b/docs/pages/components/details.md
@@ -73,7 +73,7 @@ Use the `disable` attribute to prevent the details from expanding.
 ```
 
 ```pug:slim
-sl-details summary="Disabled" disabled="true"
+sl-details summary="Disabled" disabled=true
   | Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
   | aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
 ```
@@ -229,7 +229,7 @@ Details are designed to function independently, but you can simulate a group or 
 
 ```pug:slim
 .details-group-example
-  sl-details summary="First" open="true"
+  sl-details summary="First" open=true
     |  Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
   sl-details summary="Second"
     |  Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.

--- a/docs/pages/components/dialog.md
+++ b/docs/pages/components/dialog.md
@@ -4,23 +4,30 @@ meta:
   description: 'Dialogs, also called "modals", appear above the page and require the user''s immediate attention.'
 layout: component
 guidelines: |
-  **Dialog Headers**
+  ### Dialog Headers
 
   - Keep headers **short** and **succinct**
   - Use **sentence case**
   - **Don't** wrap headers to multiple lines
-  - To prevent wrapping, keep header text short. If the shortened text still wraps, try using a larger dialog width.
+    - To prevent wrapping, keep header text short. If the shortened text still wraps, try using a larger dialog width.
 
-  **Confirmation Dialogs**
+  ### Confirmation Dialogs
 
-  - **Header** should restate the action you are asking people to confirm
-  - **Header** should end with a question mark
-  - **Header** and **body** text should **not** ask "Are you sure..."
-  - **Body** should tell people the impact of the action they are about to take
-  - **Body** should **not** say "You are about to..."
-  - **Body** shouldn't just repeat the header
-  - **Primary button** should restate the action, either repeating the header or a shortened form of the header
-  - **Primary button** should **not** use ambiguous words like "Confirm" or "Okay"
+  **Header text should...**
+
+  - Restate the action you are asking people to confirm
+  - End with a question mark
+  - **Not** ask "Are you sure...?"
+
+  **Body text should...**
+  - Tell people the impact of the action they are about to take
+  - **Not** just repeat the header
+  - **Not** ask "Are you sure...?"
+  - **Not** say "You are about to..."
+
+  **Dialog's primary button text should...**
+  - Restate the action, either repeating the header or a shortened form of the header
+  - **Not** use ambiguous words like "Confirm" or "Okay"
 
   :::tip
   **Do**

--- a/docs/pages/components/dialog.md
+++ b/docs/pages/components/dialog.md
@@ -979,7 +979,7 @@ Wen presenting a dialog with an input, `autofocus` should be added to the input 
 sl-dialog label="Grant access?" class="dialog-focus"
   sl-icon library="fa" name="exclamation-circle" slot="header-icon"
   p style="margin: 0 0 1rem" To grant this user access to financial products, enter a mobile number to be used for login verification.
-  sl-input autofocus="true" label="Mobile number" type="tel" optional-icon="true" required="true"
+  sl-input autofocus=true label="Mobile number" type="tel" optional-icon=true required=true
   sl-button slot="footer" variant="default" Cancel
   sl-button slot="footer" variant="primary" Grant access
 sl-button Open form dialog

--- a/docs/pages/components/divider.md
+++ b/docs/pages/components/divider.md
@@ -49,8 +49,12 @@ const App = () => <SlDivider style={{ '--width': '4px' }} />;
 
 Use the `--color` custom property to change the color of the divider.
 
+:::warning
+**Note:** In general, you shouldn't need to do this. Please consult the design team before implementing a custom color for the divider, so that the team can determine whether the existing pattern should be updated.
+:::
+
 ```html:preview
-<sl-divider style="--color: tomato;"></sl-divider>
+<sl-divider style="--color: var(--sl-color-teal-300);"></sl-divider>
 ```
 
 ```pug:slim

--- a/docs/pages/components/divider.md
+++ b/docs/pages/components/divider.md
@@ -123,9 +123,9 @@ Add the `vertical` attribute to draw the divider in a vertical orientation. The 
 ```pug:slim
 div style="display: flex; align-items: center; height: 2rem;"
   | First
-  sl-divider vertical="true"
+  sl-divider vertical=true
   | Middle
-  sl-divider vertical="true"
+  sl-divider vertical=true
   | Last
 ```
 

--- a/docs/pages/components/drawer.md
+++ b/docs/pages/components/drawer.md
@@ -12,7 +12,8 @@ layout: component
 ```html:preview
 <sl-drawer label="Drawer" class="drawer-overview">
   Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-  <sl-button slot="footer" variant="primary">Close</sl-button>
+  <sl-button slot="footer" variant="default">Close</sl-button>
+  <sl-button slot="footer" variant="primary">Submit</sl-button>
 </sl-drawer>
 
 <sl-button>Open Drawer</sl-button>

--- a/docs/pages/components/drawer.md
+++ b/docs/pages/components/drawer.md
@@ -12,45 +12,17 @@ layout: component
 ```html:preview
 <sl-drawer label="Drawer" class="drawer-overview">
   Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-  <sl-button slot="footer" variant="default">Close</sl-button>
-  <sl-button slot="footer" variant="primary">Submit</sl-button>
+  <sl-button slot="footer" variant="primary">Close</sl-button>
 </sl-drawer>
 
 <sl-button>Open Drawer</sl-button>
 
-<sl-dropdown>
-  <div slot="trigger"><sl-button caret>Dropdown</sl-button></div>
-  <sl-menu>
-    <sl-menu-item class="open-link">Open drawer</sl-menu-item>
-    <sl-menu-item>Dropdown Item 2</sl-menu-item>
-    <sl-menu-item>Dropdown Item 3</sl-menu-item>
-    <sl-divider></sl-divider>
-    <sl-menu-item type="checkbox" checked>Checkbox</sl-menu-item>
-    <sl-menu-item disabled>Disabled</sl-menu-item>
-    <sl-divider></sl-divider>
-    <sl-menu-item>
-      Prefix
-      <sl-icon slot="prefix" name="gift"></sl-icon>
-    </sl-menu-item>
-    <sl-menu-item>
-      Suffix Icon
-      <sl-icon slot="suffix" name="heart"></sl-icon>
-    </sl-menu-item>
-  </sl-menu>
-</sl-dropdown>
-
 <script>
   const drawer = document.querySelector('.drawer-overview');
-  // const openButton = drawer.nextElementSibling;
-  const openButton = document.querySelector('.open-link');
+  const openButton = drawer.nextElementSibling;
   const closeButton = drawer.querySelector('sl-button[variant="primary"]');
-  const dropdown = document.querySelector('sl-dropdown');
 
-  openButton.addEventListener('click', (event) => {
-    // event.stopPropagation();
-    drawer.show();
-    // dropdown.hide();
-    });
+  openButton.addEventListener('click', () => drawer.show());
   closeButton.addEventListener('click', () => drawer.hide());
 
 </script>
@@ -368,6 +340,72 @@ const App = () => {
 ```
 
 {% endraw %}
+
+### Opening from Dropdown Menu
+
+When opening a drawer from a `sl-dropdown` menu item triggered by a `sl-button`, wrap the button in a `div` and add `slot="trigger"` to the `div` rather than the button to prevent the drawer from skipping when opening.
+
+```html:preview
+<sl-drawer label="Drawer" class="drawer-overview">
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+  <sl-button slot="footer" variant="primary">Close</sl-button>
+</sl-drawer>
+
+<sl-dropdown>
+  <div slot="trigger"><sl-button caret>Dropdown</sl-button></div>
+  <sl-menu>
+    <sl-menu-item class="open-link">Open drawer</sl-menu-item>
+  </sl-menu>
+</sl-dropdown>
+
+<script>
+  const drawer = document.querySelector('.drawer-overview');
+  const openButton = document.querySelector('.open-link');
+  const closeButton = drawer.querySelector('sl-button[variant="primary"]');
+
+  openButton.addEventListener('click', (event) => drawer.show());
+  closeButton.addEventListener('click', () => drawer.hide());
+
+</script>
+```
+
+```pug:slim
+sl-drawer.drawer-overview label="Drawer"
+  | Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+  sl-button slot="footer" variant="primary" Close
+sl-button Open Drawer
+
+javascript:
+  const drawer = document.querySelector(.drawer-overview);
+  const openButton = drawer.nextElementSibling;
+  const closeButton = drawer.querySelector(sl-button[variant=primary]);
+
+  openButton.addEventListener(click, () => drawer.show());
+  closeButton.addEventListener(click, () => drawer.hide());
+```
+
+```jsx:react
+import { useState } from 'react';
+import SlButton from '@teamshares/shoelace/dist/react/button';
+import SlDrawer from '@teamshares/shoelace/dist/react/drawer';
+
+const App = () => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <SlDrawer label="Drawer" open={open} onSlAfterHide={() => setOpen(false)}>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+        <SlButton slot="footer" variant="primary" onClick={() => setOpen(false)}>
+          Close
+        </SlButton>
+      </SlDrawer>
+
+      <SlButton onClick={() => setOpen(true)}>Open Drawer</SlButton>
+    </>
+  );
+};
+```
 
 ### Custom Size
 

--- a/docs/pages/components/drawer.md
+++ b/docs/pages/components/drawer.md
@@ -18,13 +18,41 @@ layout: component
 
 <sl-button>Open Drawer</sl-button>
 
+<sl-dropdown>
+  <div slot="trigger"><sl-button caret>Dropdown</sl-button></div>
+  <sl-menu>
+    <sl-menu-item class="open-link">Open drawer</sl-menu-item>
+    <sl-menu-item>Dropdown Item 2</sl-menu-item>
+    <sl-menu-item>Dropdown Item 3</sl-menu-item>
+    <sl-divider></sl-divider>
+    <sl-menu-item type="checkbox" checked>Checkbox</sl-menu-item>
+    <sl-menu-item disabled>Disabled</sl-menu-item>
+    <sl-divider></sl-divider>
+    <sl-menu-item>
+      Prefix
+      <sl-icon slot="prefix" name="gift"></sl-icon>
+    </sl-menu-item>
+    <sl-menu-item>
+      Suffix Icon
+      <sl-icon slot="suffix" name="heart"></sl-icon>
+    </sl-menu-item>
+  </sl-menu>
+</sl-dropdown>
+
 <script>
   const drawer = document.querySelector('.drawer-overview');
-  const openButton = drawer.nextElementSibling;
+  // const openButton = drawer.nextElementSibling;
+  const openButton = document.querySelector('.open-link');
   const closeButton = drawer.querySelector('sl-button[variant="primary"]');
+  const dropdown = document.querySelector('sl-dropdown');
 
-  openButton.addEventListener('click', () => drawer.show());
+  openButton.addEventListener('click', (event) => {
+    // event.stopPropagation();
+    drawer.show();
+    // dropdown.hide();
+    });
   closeButton.addEventListener('click', () => drawer.hide());
+
 </script>
 ```
 

--- a/docs/pages/components/drawer.md
+++ b/docs/pages/components/drawer.md
@@ -279,7 +279,7 @@ Unlike normal drawers, contained drawers are not modal. This means they do not s
 ```pug:slim
 div style="position: relative; border: solid 2px var(--sl-panel-border-color); height: 300px; padding: 1rem; margin-bottom: 1rem;"
   | The drawer will be contained to this box. This content won't shift or be affected in any way when the drawer opens.
-  sl-drawer.drawer-contained label="Drawer" contained="true" style="--size: 50%;"
+  sl-drawer.drawer-contained label="Drawer" contained=true style="--size: 50%;"
     | Lorem ipsum dolor sit amet, consectetur adipiscing elit.
     sl-button slot="footer" variant="primary"
       | Close
@@ -662,7 +662,7 @@ By default, the drawer's panel will gain focus when opened. This allows a subseq
 
 ```pug:slim
 sl-drawer.drawer-focus label="Drawer"
-  sl-input autofocus="true" placeholder="I will have focus when the drawer is opened"
+  sl-input autofocus=true placeholder="I will have focus when the drawer is opened"
   sl-button slot="footer" variant="primary" Close
 sl-button Open Drawer
 

--- a/docs/pages/components/drawer.md
+++ b/docs/pages/components/drawer.md
@@ -373,11 +373,16 @@ When opening a drawer from a `sl-dropdown` menu item triggered by a `sl-button`,
 sl-drawer.drawer-overview label="Drawer"
   | Lorem ipsum dolor sit amet, consectetur adipiscing elit.
   sl-button slot="footer" variant="primary" Close
-sl-button Open Drawer
+
+sl-dropdown
+  div slot="trigger"
+    sl-button caret=true Dropdown
+    sl-menu
+      sl-menu-item.open-link Open drawer
 
 javascript:
   const drawer = document.querySelector(.drawer-overview);
-  const openButton = drawer.nextElementSibling;
+  const openButton = drawer.querySelector(.open-link);
   const closeButton = drawer.querySelector(sl-button[variant=primary]);
 
   openButton.addEventListener(click, () => drawer.show());

--- a/docs/pages/components/dropdown.md
+++ b/docs/pages/components/dropdown.md
@@ -38,14 +38,14 @@ Dropdowns are designed to work well with [menus](/components/menu) to provide a 
 
 ```pug:slim
 sl-dropdown
-  sl-button slot="trigger" caret="true" Dropdown
+  sl-button slot="trigger" caret=true Dropdown
   sl-menu
     sl-menu-item Dropdown Item 1
     sl-menu-item Dropdown Item 2
     sl-menu-item Dropdown Item 3
     sl-divider
-    sl-menu-item type="checkbox" checked="true" Checkbox
-    sl-menu-item disabled="true" Disabled
+    sl-menu-item type="checkbox" checked=true Checkbox
+    sl-menu-item disabled=true Disabled
     sl-divider
     sl-menu-item
       | Prefix
@@ -121,7 +121,7 @@ When dropdowns are used with [menus](/components/menu), you can listen for the [
 ```pug:slim
 div.dropdown-selection
   sl-dropdown
-    sl-button slot="trigger" caret="true" Edit
+    sl-button slot="trigger" caret=true Edit
     sl-menu
       sl-menu-item value="cut" Cut
       sl-menu-item value="copy" Copy
@@ -193,7 +193,7 @@ Alternatively, you can listen for the `click` event on individual menu items. No
 ```pug:slim
 div.dropdown-selection-alt
   sl-dropdown
-    sl-button slot="trigger" caret="true" Edit
+    sl-button slot="trigger" caret=true Edit
     sl-menu
       sl-menu-item value="cut" Cut
       sl-menu-item value="copy" Copy
@@ -264,7 +264,7 @@ The preferred placement of the dropdown can be set with the `placement` attribut
 
 ```pug:slim
 sl-dropdown placement="top-start"
-  sl-button slot="trigger" caret="true" Edit
+  sl-button slot="trigger" caret=true Edit
   sl-menu
     sl-menu-item Cut
     sl-menu-item Copy
@@ -318,7 +318,7 @@ The distance from the panel to the trigger can be customized using the `distance
 
 ```pug:slim
 sl-dropdown distance="30"
-  sl-button slot="trigger" caret="true" Edit
+  sl-button slot="trigger" caret=true Edit
   sl-menu
     sl-menu-item Cut
     sl-menu-item Copy
@@ -372,7 +372,7 @@ The offset of the panel along the trigger can be customized using the `skidding`
 
 ```pug:slim
 sl-dropdown skidding="30"
-  sl-button slot="trigger" caret="true" Edit
+  sl-button slot="trigger" caret=true Edit
   sl-menu
     sl-menu-item Cut
     sl-menu-item Copy
@@ -534,13 +534,13 @@ Dropdown panels will be clipped if they're inside a container that has `overflow
 ```pug:slim
 div.dropdown-hoist
   sl-dropdown
-    sl-button slot="trigger" caret="true" No Hoist
+    sl-button slot="trigger" caret=true No Hoist
     sl-menu
       sl-menu-item Item 1
       sl-menu-item Item 2
       sl-menu-item Item 3
-  sl-dropdown hoist="true"
-    sl-button slot="trigger" caret="true" Hoist
+  sl-dropdown hoist=true
+    sl-button slot="trigger" caret=true Hoist
     sl-menu
       sl-menu-item Item 1
       sl-menu-item Item 2

--- a/docs/pages/components/icon-button.md
+++ b/docs/pages/components/icon-button.md
@@ -189,7 +189,7 @@ Use the `disabled` attribute to disable the icon button.
 ```
 
 ```pug:slim
-sl-icon-button name="cog-6-tooth" label="Settings" disabled="true"
+sl-icon-button name="cog-6-tooth" label="Settings" disabled=true
 ```
 
 ```jsx:react

--- a/docs/pages/components/icon.md
+++ b/docs/pages/components/icon.md
@@ -123,10 +123,10 @@ li This is a Font Awesome icon: sl-icon library="fa" name="thumbs-up"
     </sl-select>
   </div>
   <br/>
-  <sl-details open="true" summary="Icon results">
+  <sl-details open=true summary="Icon results">
     <div class="icon-list"></div>
   </sl-details>
-  <input type="text" class="icon-copy-input" aria-hidden="true" tabindex="-1">
+  <input type="text" class="icon-copy-input" aria-hidden=true tabindex="-1">
 </div> -->
 
 ## Examples

--- a/docs/pages/components/input.md
+++ b/docs/pages/components/input.md
@@ -119,7 +119,7 @@ testing: |
     cy.slInputType(`[data-test-id="input-test"]`, "Your text here");
   ```
 
-  To **get the input's value** (note the matcher `"have.value"`):
+  To **check the input's value** (note the matcher `"have.value"`):
   ```js
     cy.get(`[data-test-id="input-test"]`).should("have.value", "Your text here");
   ```

--- a/docs/pages/components/input.md
+++ b/docs/pages/components/input.md
@@ -92,7 +92,7 @@ testing: |
 
    To test `<sl-input>`, add the `data-test-id` attribute directly to the component:
 
-  ```
+  ```pug:slim
     sl-input[
       label="Name"
       data-test-id="input-test"
@@ -101,7 +101,7 @@ testing: |
 
   To test `<sl-input>` implemented with `ts_form_for`, add `data-test-id` to `input_html`:
 
-  ```
+  ```js
     = ts_form_for ... do |f|
       = f.input :input_name, 
         input_html: { 
@@ -115,22 +115,22 @@ testing: |
   **Cypress commands for `<sl-input>`**
 
   To **type** in the input:
-  ```
+  ```js
     cy.slInputType(`[data-test-id="input-test"]`, "Your text here");
   ```
 
   To **get the input's value** (note the matcher `"have.value"`):
-  ```
+  ```js
     cy.get(`[data-test-id="input-test"]`).should("have.value", "Your text here");
   ```
 
   To **focus** on the input:
-  ```
+  ```js
     cy.slFocus(`[data-test-id="input-test"]`);
   ```
 
   To **clear** the input:
-  ```
+  ```js
     cy.slClear(`[data-test-id="input-test"]`);
   ```
 ---
@@ -147,11 +147,9 @@ Use the `label` attribute to give the input an accessible label.
 
 ```pug:slim
 sl-input label="Name"
+```
 
-/*
-  When rendering with ts_form_for
-*/
-
+```js:simple-form
 = ts_form_for ... do |f|
   = f.input :name,
     input_html: {
@@ -193,12 +191,12 @@ sl-input label="Previous legal names"
     strong full
     | names, separated by a
     strong semicolon
+```
 
+```js:simple-form
 /*
-  When rendering with ts_form_for
   — NOTE: Slots are not supported with ts_form_for —
 */
-
 = ts_form_for ... do |f|
   = f.input :name,
     input_html: {
@@ -232,11 +230,9 @@ sl-input[
   label-tooltip="Names previously used on official government documents, such as passport, driver license, or ID card"
   help-text="List full names, separated by a semicolon"
 ]
+```
 
-/*
-  When rendering with ts_form_for
-*/
-
+```js:simple-form
 = ts_form_for ... do |f|
   = f.input :name,
     input_html: {
@@ -285,12 +281,12 @@ sl-input[
   div slot="context-note"
     strong $10,000.29
     | available
+```
 
+```js:simple-form
 /*
-  When rendering with ts_form_for
   — NOTE: Slots are not supported with ts_form_for —
 */
-
 = ts_form_for ... do |f|
   = f.input :currency,
     input_html: {
@@ -340,11 +336,9 @@ sl-input[
   value="I can be cleared!"
   clearable="true"
 ]
+```
 
-/*
-  When rendering with ts_form_for
-*/
-
+```js:simple-form
 = ts_form_for ... do |f|
   = f.input :clearable_input,
     input_html: {
@@ -374,11 +368,9 @@ sl-input[
   label="Password"
   password-toggle="true"
 ]
+```
 
-/*
-  When rendering with ts_form_for
-*/
-
+```js:simple-form
 = ts_form_for ... do |f|
   = f.input :password_toggle,
     input_html: {
@@ -425,11 +417,9 @@ sl-input[
   label="Disabled input"
   disabled="true"
 ]
+```
 
-/*
-  When rendering with ts_form_for
-*/
-
+```js:simple-form
 = ts_form_for ... do |f|
   = f.input :disabled_input,
     input_html: {
@@ -465,11 +455,9 @@ sl-input[
   label="Large input"
   size="large"
 ]
+```
 
-/*
-  When rendering with ts_form_for
-*/
-
+```js:simple-form
 = ts_form_for ... do |f|
   = f.input :medium_input,
     input_html: {
@@ -521,11 +509,9 @@ sl-input[
   size="large"
   pill="true"
 ]
+```
 
-/*
-  When rendering with ts_form_for
-*/
-
+```js:simple-form
 = ts_form_for ... do |f|
   = f.input :medium_pill,
     input_html: {
@@ -590,12 +576,6 @@ The `type` attribute controls the type of input the browser renders. As shown in
 ```
 
 ```pug:slim
-/*
-  When rendering with ts_form_for
-  — NOTE: Slots are not supported with ts_form_for —
-  — Attributes can be passed to `input_html`
-*/
-
 sl-input[
   type="currency"
   label="Input type: Currency"
@@ -687,6 +667,13 @@ sl-input[
 br
 ```
 
+```js:simple-form
+/*
+  — NOTE: Slots are not supported with ts_form_for —
+  — Attributes can be passed to `input_html`
+*/
+```
+
 ```jsx:react
 import SlInput from '@teamshares/shoelace/dist/react/input';
 
@@ -739,13 +726,6 @@ Follow these general guidelines when adding prefix and suffix icons to the input
 ```
 
 ```pug:slim
-/*
-  NOTE: `ts_form_for` doesn't support slots. Prefix and suffix icons
-  cannot be added when rendering `sl-input` with `ts_form_for`. However,
-  the `optional-icon` attribute can be set to `true` to display default icons
-  for input types `currency`, `email`, `tel`, and `search`.
-*/
-
 sl-input label="Prefix icon example: DO"
   sl-icon[
     name="rocket-launch"
@@ -783,6 +763,15 @@ sl-input[
     style="font-size: 1.25rem;"
     slot="prefix"
   ]
+```
+
+```js:simple-form
+/*
+  NOTE: `ts_form_for` doesn't support slots. Prefix and suffix icons
+  cannot be added when rendering `sl-input` with `ts_form_for`. However,
+  the `optional-icon` attribute can be set to `true` to display default icons
+  for input types `currency`, `email`, `tel`, and `search`.
+*/
 ```
 
 ```jsx:react
@@ -864,10 +853,33 @@ sl-textarea.label-on-left[
   help-text="Tell us something about yourself"
 ]
 
-/*
-  When rendering with ts_form_for
-*/
+css:
+  .label-on-left {
+    --label-width: 3.75rem;
+    --gap-width: 1rem;
+  }
 
+  .label-on-left + .label-on-left {
+    margin-top: var(--sl-spacing-medium);
+  }
+
+  .label-on-left::part(form-control) {
+    display: grid;
+    grid: auto / var(--label-width) 1fr;
+    gap: var(--sl-spacing-3x-small) var(--gap-width);
+    align-items: center;
+  }
+
+  .label-on-left::part(form-control-label) {
+    text-align: right;
+  }
+
+  .label-on-left::part(form-control-help-text) {
+    grid-column-start: 2;
+  }
+```
+
+```js:simple-form
 = ts_form_for ... do |f|
   = f.input :name,
     input_html: {

--- a/docs/pages/components/input.md
+++ b/docs/pages/components/input.md
@@ -334,7 +334,7 @@ Add the `clearable` attribute to add a clear button when the input has content.
 sl-input[
   label="Clearable input"
   value="I can be cleared!"
-  clearable="true"
+  clearable=true
 ]
 ```
 
@@ -366,7 +366,7 @@ Add the `password-toggle` attribute to add a toggle button that will show the pa
 sl-input[
   type="password"
   label="Password"
-  password-toggle="true"
+  password-toggle=true
 ]
 ```
 
@@ -395,7 +395,7 @@ Add the `filled` attribute to draw a filled input.
 ```
 
 ```pug:slim
-sl-input placeholder="Type something" filled="true"
+sl-input placeholder="Type something" filled=true
 ```
 
 ```jsx:react
@@ -415,7 +415,7 @@ Use the `disabled` attribute to disable an input.
 ```pug:slim
 sl-input[
   label="Disabled input"
-  disabled="true"
+  disabled=true
 ]
 ```
 
@@ -501,13 +501,13 @@ Use the `pill` attribute to give inputs rounded edges.
 ```pug:slim
 sl-input[
   label="Medium pill"
-  pill="true"
+  pill=true
 ]
 br
 sl-input[
   label="Large pill"
   size="large"
-  pill="true"
+  pill=true
 ]
 ```
 
@@ -612,7 +612,7 @@ br
 sl-input[
   type="email"
   label="Input type: Email, with icon"
-  optional-icon="true"
+  optional-icon=true
 ]
   div[slot="help-text"]
     | Use the
@@ -630,7 +630,7 @@ br
 sl-input[
   type="tel"
   label="Input type: Tel, with icon"
-  optional-icon="true"
+  optional-icon=true
 ]
   div[slot="help-text"]
     | Use the
@@ -646,7 +646,7 @@ br
 sl-input[
   type="number"
   label="Input type: Number, no spin buttons"
-  no-spin-buttons="true"
+  no-spin-buttons=true
 ]
   div[slot="help-text"]
     | Use the
@@ -657,7 +657,7 @@ br
 sl-input[
   type="search"
   label="Input type: Search"
-  clearable="true"
+  clearable=true
 ]
   div[slot="help-text"]
     | Has a search icon by default. Use the

--- a/docs/pages/components/input.md
+++ b/docs/pages/components/input.md
@@ -7,7 +7,7 @@ unusedProperties: |
   - Size `small`
   - Booleans `filled`, `pill`
 guidelines: |
-  **Labels**
+  ### Labels
 
   - **Always** have a label 
   - Use **sentence case** for labels
@@ -35,7 +35,7 @@ guidelines: |
   - Don't end with punctuation unless the label is a complete sentence
   :::
 
-  **Help Text**
+  ### Help Text
 
   - Keep help text **concise and useful** -- make every word count!
   - Use a period only if help text includes more than one complete sentence
@@ -55,7 +55,7 @@ guidelines: |
   :::
 
 
-  **Placeholder Text**
+  ### Placeholder Text
 
   - **Don't use placeholder text**, for the following reasons:
     - Placeholder text is easy to mistake for an input that's already filled in
@@ -68,7 +68,7 @@ guidelines: |
   **Do**
   <div style="padding: 0 0 .5rem;"><sl-input type="password" label="Password" help-text="Password must be at least 8 characters and include at least 1 number and 1 capital letter" password-toggle></sl-input></div>
 
-  - Do use a label and help text to guide peple
+  - Do use a label and help text to guide people
   :::
 
   :::danger 
@@ -78,13 +78,61 @@ guidelines: |
   - Don't use placeholder text
   :::
 
-  **Help Text, Label Tooltip, or Context Note?**
+  ### Help Text, Label Tooltip, or Context Note?
 
   - Use **Help Text** to communicate instructions or requirements for filling in the input without errors
   - Use the **Label Tooltip** to provide helpful but non-essential instructions or examples to guide people when filling in the input. People might choose not to view the tooltip content, so don't put any essential information there.
   - Use the **Context Note** to provide secondary contextual data, especially dynamic data, that would help people when filling in the input
   - Help text is generally the best way to add hints or instructions to help people fill in the input for most use cases
   - If you think you need to use the Label Tooltip or Context Note, first consider whether the same information would work as help text if it were shorter or presented differently
+testing: |
+  ### With Cypress
+
+  **Adding `data-test-id` to a component**
+
+   To test `<sl-input>`, add the `data-test-id` attribute directly to the component:
+
+  ```
+    sl-input[
+      label="Name"
+      data-test-id="input-test"
+    ]
+  ```
+
+  To test `<sl-input>` implemented with `ts_form_for`, add `data-test-id` to `input_html`:
+
+  ```
+    = ts_form_for ... do |f|
+      = f.input :input_name, 
+        input_html: { 
+          label: "Name",
+          data: { 
+            "test_id": "input-test"
+          } 
+        }
+  ```
+
+  **Cypress commands for `<sl-input>`**
+
+  To **type** in the input:
+  ```
+    cy.slInputType(`[data-test-id="input-test"]`, "Your text here");
+  ```
+
+  To **get the input's value** (note the matcher `"have.value"`):
+  ```
+    cy.get(`[data-test-id="input-test"]`).should("have.value", "Your text here");
+  ```
+
+  To **focus** on the input:
+  ```
+    cy.slFocus(`[data-test-id="input-test"]`);
+  ```
+
+  To **clear** the input:
+  ```
+    cy.slClear(`[data-test-id="input-test"]`);
+  ```
 ---
 
 ## Examples

--- a/docs/pages/components/input.md
+++ b/docs/pages/components/input.md
@@ -90,7 +90,7 @@ testing: |
 
   **Adding `data-test-id` to a component**
 
-   To test `<sl-input>`, add the `data-test-id` attribute directly to the component:
+   To test `sl-input`, add the `data-test-id` attribute directly to the component:
 
   ```pug:slim
     sl-input[
@@ -99,7 +99,7 @@ testing: |
     ]
   ```
 
-  To test `<sl-input>` implemented with `ts_form_for`, add `data-test-id` to `input_html`:
+  To test `sl-input` implemented with `ts_form_for`, add `data-test-id` to `input_html`:
 
   ```js
     = ts_form_for ... do |f|
@@ -107,12 +107,12 @@ testing: |
         input_html: { 
           label: "Name",
           data: { 
-            "test_id": "input-test"
+            test_id: "input-test"
           } 
         }
   ```
 
-  **Cypress commands for `<sl-input>`**
+  **Cypress commands for `sl-input`**
 
   To **type** in the input:
   ```js

--- a/docs/pages/components/menu-item.md
+++ b/docs/pages/components/menu-item.md
@@ -39,8 +39,8 @@ sl-menu style="max-width: 200px;"
   sl-menu-item Option 2
   sl-menu-item Option 3
   sl-divider
-  sl-menu-item type="checkbox" checked="true" Checkbox
-  sl-menu-item disabled="true" Disabled
+  sl-menu-item type="checkbox" checked=true Checkbox
+  sl-menu-item disabled=true Disabled
   sl-divider
   sl-menu-item
     | Prefix icon
@@ -98,7 +98,7 @@ Add the `disabled` attribute to disable a menu item so it cannot be selected.
 ```pug:slim
 sl-menu style="max-width: 200px;"
   sl-menu-item Option 1
-  sl-menu-item disabled="true" Option 2
+  sl-menu-item disabled=true Option 2
   sl-menu-item Option 3
 ```
 
@@ -173,7 +173,7 @@ sl-menu style="max-width: 240px;"
   sl-menu-item
     sl-icon slot="prefix" library="fa" name="fal-gear"
     | Settings
-    sl-badge slot="suffix" variant="primary" pill="true" 12
+    sl-badge slot="suffix" variant="primary" pill=true 12
   sl-divider
   sl-menu-item
     sl-icon slot="prefix" library="fa" name="fal-arrow-right-from-bracket"
@@ -231,7 +231,7 @@ Use the `loading` attribute to indicate that a menu item is busy. Like a disable
 ```pug:slim
 sl-menu style="max-width: 200px;"
   sl-menu-item Option 1
-  sl-menu-item loading="true" Option 2
+  sl-menu-item loading=true Option 2
   sl-menu-item Option 3
 ```
 
@@ -269,7 +269,7 @@ Checkbox menu items are visually indistinguishable from regular menu items. Thei
 ```pug:slim
 sl-menu style="max-width: 200px;"
   sl-menu-item type="checkbox" Autosave
-  sl-menu-item type="checkbox" checked="true" Check spelling
+  sl-menu-item type="checkbox" checked=true Check spelling
   sl-menu-item type="checkbox" Word wrap
 ```
 

--- a/docs/pages/components/menu.md
+++ b/docs/pages/components/menu.md
@@ -4,7 +4,7 @@ meta:
   description: Menus provide a list of options for the user to choose from.
 layout: component
 guidelines: |
-  **Capitalization, Icons Usage**
+  ### Capitalization, Icons
 
   :::tip
   **Do**

--- a/docs/pages/components/mutation-observer.md
+++ b/docs/pages/components/mutation-observer.md
@@ -181,7 +181,7 @@ Use the `child-list` attribute to watch for new child elements that are added or
 
 ```pug:slim
 .mutation-child-list
-  sl-mutation-observer child-list="true"
+  sl-mutation-observer child-list=true
     .buttons
       sl-button variant="primary"
         | Add button

--- a/docs/pages/components/option.md
+++ b/docs/pages/components/option.md
@@ -29,6 +29,20 @@ sl-select label="Select an option"
   sl-option value="option-3" Option 3
 ```
 
+```js:simple-form
+= ts_form_for ... do |f|
+  = f.input :select_one,
+    collection: [
+      ["",""],
+      ["Option 1", "option-1"],
+      ["Option 2", "option-2"],
+      ["Option 3", "option-3"]
+    ],
+    input_html: {
+      label: "Select an option"
+    }
+```
+
 ```jsx:react
 import SlOption from '@teamshares/shoelace/dist/react/option';
 import SlSelect from '@teamshares/shoelace/dist/react/select';
@@ -57,10 +71,24 @@ Use the `disabled` attribute to disable an option and prevent it from being sele
 
 ```pug:slim
 sl-select label="Select an option"
-  sl-option vaue=""
+  sl-option value=""
   sl-option value="option-1" Option 1
-  sl-option value="option-2" disabled="true" Option 2
+  sl-option value="option-2" disabled=true Option 2
   sl-option value="option-3" Option 3
+```
+
+```js:simple-form
+= ts_form_for ... do |f|
+  = f.input :select_one,
+    collection: [
+      ["",""],
+      ["Option 1", "option-1"],
+      ["Option 2", "option-2", disabled=true],
+      ["Option 3", "option-3"]
+    ],
+    input_html: {
+      label: "Select an option"
+    }
 ```
 
 ```jsx:react
@@ -92,6 +120,9 @@ Follow these general guidelines when adding prefix and suffix icons to option it
 
 :::warning
 **Note:** If you find your use case requires a different size or color from the default, bring it up to the Design Team so that we can consider whether the pattern needs to be updated.
+:::
+:::warning
+**Note:** `ts_form_for` doesn't support slots. Custom tags cannot be added when rendering `sl-select` and `sl-option` with `ts_form_for`.
 :::
 
 ```html:preview
@@ -168,4 +199,11 @@ sl-select label="Icon examples: DON'T" help-text="Prefix and suffix icons in thi
     sl-icon slot="prefix" name="fad-comment-dots" style="font-size: 1.25rem; color:mediumpurple;"
     | Chat
     sl-icon slot="suffix" name="fas-badge-check" style="font-size: 1.25rem; color:mediumpurple;"
+```
+
+```js:simple-form
+/*
+  NOTE: `ts_form_for` doesn't support slots. Prefix icons
+  cannot be added when rendering `sl-select` and `sl-option` with `ts_form_for`
+*/
 ```

--- a/docs/pages/components/option.md
+++ b/docs/pages/components/option.md
@@ -3,6 +3,9 @@ meta:
   title: Option
   description: Options define the selectable items within various form controls such as select.
 layout: component
+testing: |
+  ### With Cypress
+  - Options can be tested through their parent component, the Select. See [Select Testing](/components/select/#testing) for details.
 ---
 
 ## Examples

--- a/docs/pages/components/popup.md
+++ b/docs/pages/components/popup.md
@@ -108,7 +108,7 @@ Popup is a low-level utility built specifically for positioning elements. Do not
 
 ```pug:slim
 div.popup-overview
-  sl-popup placement="top" active="true"
+  sl-popup placement="top" active=true
     span slot="anchor"
     div.box
   div.popup-overview-options
@@ -128,7 +128,7 @@ div.popup-overview
     sl-input type="number" name="distance" label="distance" value="0"
     sl-input type="number" name="skidding" label="Skidding" value="0"
   div.popup-overview-options
-    sl-switch name="active" checked="true" Active
+    sl-switch name="active" checked=true Active
     sl-switch name="arrow" Arrow
 
 javascript:
@@ -355,11 +355,11 @@ Popups are inactive and hidden until the `active` attribute is applied. Removing
 
 ```pug:slim
 div.popup-active
-  sl-popup placement="top" active="true"
+  sl-popup placement="top" active=true
     span slot="anchor"
     div.box
   br
-  sl-switch checked="true" Active
+  sl-switch checked=true Active
 
 css:
   .popup-active span[slot=anchor] {
@@ -461,7 +461,7 @@ By default, anchors are slotted into the popup using the `anchor` slot. If your 
 
 ```pug:slim
 span#external-anchor
-sl-popup anchor="external-anchor" placement="top" active="true"
+sl-popup anchor="external-anchor" placement="top" active=true
   div.box
 
 css:
@@ -577,7 +577,7 @@ Since placement is preferred when using `flip`, you can observe the popup's curr
 
 ```pug:slim
 div.popup-placement
-  sl-popup placement="top" active="true"
+  sl-popup placement="top" active=true
     span slot="anchor"
     div.box
   sl-select label="Placement" value="top"
@@ -728,7 +728,7 @@ Use the `distance` attribute to change the distance between the popup and its an
 
 ```pug:slim
 div.popup-distance
-  sl-popup placement="top" distance="0" active="true"
+  sl-popup placement="top" distance="0" active=true
     span slot="anchor"
     div.box
   sl-range min="-50" max="50" step="1" value="0" label="Distance"
@@ -860,7 +860,7 @@ The `skidding` attribute is similar to `distance`, but instead allows you to off
 
 ```pug:slim
 div.popup-skidding
-  sl-popup placement="top" skidding="0" active="true"
+  sl-popup placement="top" skidding="0" active=true
     span slot="anchor"
     div.box
   sl-range min="-50" max="50" step="1" value="0" label="Skidding"
@@ -1039,7 +1039,7 @@ By default, the arrow will be aligned as close to the center of the _anchor_ as 
 
 ```pug:slim
 div.popup-arrow
-  sl-popup placement="top" arrow="true" arrow-placement="anchor" distance="8" active="true"
+  sl-popup placement="top" arrow=true arrow-placement="anchor" distance="8" active=true
     span slot="anchor"
     div.box
   div.popup-arrow-options
@@ -1062,7 +1062,7 @@ div.popup-arrow
       sl-option value="end" end
       sl-option value="center" center
   div.popup-arrow-options
-    sl-switch name="arrow" checked="true" Arrow
+    sl-switch name="arrow" checked=true Arrow
 
   css:
     .popup-arrow sl-popup {
@@ -1269,7 +1269,7 @@ Use the `sync` attribute to make the popup the same width or height as the ancho
 
 ```pug:slim
 div.popup-sync
-  sl-popup placement="top" sync="width" active="true"
+  sl-popup placement="top" sync="width" active=true
     span slot="anchor"
     div.box
   sl-select value="width" label="Sync"
@@ -1425,10 +1425,10 @@ Toggle the switch and scroll the container to see the difference.
 ```pug:slim
 div.popup-strategy
   div.overflow
-    sl-popup placement="top" strategy="fixed" active="true"
+    sl-popup placement="top" strategy="fixed" active=true
       span slot="anchor"
       div.box
-  sl-switch checked="true" Fixed
+  sl-switch checked=true Fixed
 
 css:
   .popup-strategy .overflow {
@@ -1577,11 +1577,11 @@ Scroll the container to see how the popup flips to prevent clipping.
 ```pug:slim
 div.popup-flip
   div.overflow
-    sl-popup placement="top" flip="true" active="true"
+    sl-popup placement="top" flip=true active=true
       span slot="anchor"
       div.box
   br
-  sl-switch checked="true" Flip
+  sl-switch checked=true Flip
 
 css:
   .popup-flip .overflow {
@@ -1716,7 +1716,7 @@ Scroll the container to see how the popup changes it's fallback placement to pre
 ```pug:slim
 div.popup-flip-fallbacks
   div.overflow
-    sl-popup placement="top" flip="true" flip-fallback-placements="right bottom" flip-fallback-strategy="initial" active="true"
+    sl-popup placement="top" flip=true flip-fallback-placements="right bottom" flip-fallback-strategy="initial" active=true
       span slot="anchor"
       div.box
 
@@ -1842,10 +1842,10 @@ Toggle the switch to see the difference.
 ```pug:slim
 div.popup-shift
   div.overflow
-    sl-popup placement="top" shift="true" shift-padding="10" active="true"
+    sl-popup placement="top" shift=true shift-padding="10" active=true
       span slot="anchor"
       div.box
-  sl-switch checked="true" Shift
+  sl-switch checked=true Shift
 
 css:
   .popup-shift .overflow {
@@ -1993,11 +1993,11 @@ Scroll the container to see the popup resize as its available space changes.
 ```pug:slim
 .popup-auto-size
   .overflow
-    sl-popup placement="top" auto-size="both" auto-size-padding="10" active="true"
+    sl-popup placement="top" auto-size="both" auto-size-padding="10" active=true
       span slot="anchor"
       .box
   br
-  sl-switch checked="true"
+  sl-switch checked=true
     | Auto-size
 
 css:

--- a/docs/pages/components/progress-bar.md
+++ b/docs/pages/components/progress-bar.md
@@ -97,9 +97,9 @@ Use the default slot to show a value.
 ```pug:slim
 sl-progress-bar.progress-bar-values value="50" 50%
 br
-sl-button circle="true"
+sl-button circle=true
   sl-icon name="minus" label="Decrease"
-sl-button circle="true"
+sl-button circle=true
   sl-icon name="plus" label="Increase"
 
 javascript:
@@ -163,7 +163,7 @@ The `indeterminate` attribute can be used to inform the user that the operation 
 ```
 
 ```pug:slim
-sl-progress-bar indeterminate="true"
+sl-progress-bar indeterminate=true
 ```
 
 ```jsx:react

--- a/docs/pages/components/progress-ring.md
+++ b/docs/pages/components/progress-ring.md
@@ -155,9 +155,9 @@ Use the default slot to show a label inside the progress ring.
 ```pug:slim
 sl-progress-ring.progress-ring-values value="50" style="margin-bottom: .5rem;" 50%
 br
-sl-button circle="true"
+sl-button circle=true
   sl-icon name="minus" label="Decrease"
-sl-button circle="true"
+sl-button circle=true
   sl-icon name="plus" label="Increase"
 
 javascript:

--- a/docs/pages/components/qr-code.md
+++ b/docs/pages/components/qr-code.md
@@ -45,7 +45,7 @@ QR codes are useful for providing small pieces of information to users who can q
 div.qr-overview
   sl-qr-code value="https://shoelace.style/" label="Scan this code to visit Shoelace on the web!"
   br
-  sl-input maxlength="255" clearable="true" label="Value"
+  sl-input maxlength="255" clearable=true label="Value"
 
 javascript:
   const container = document.querySelector(.qr-overview);

--- a/docs/pages/components/radio-button.md
+++ b/docs/pages/components/radio-button.md
@@ -90,7 +90,7 @@ Use the `disabled` attribute to disable a radio button.
 ```pug:slim
 sl-radio-group label="Select an option" name="a" value="1"
   sl-radio-button value="1" Option 1
-  sl-radio-button value="2" disabled="true" Option 2
+  sl-radio-button value="2" disabled=true Option 2
   sl-radio-button value="3" Option 3
 ```
 
@@ -213,19 +213,19 @@ Use the `pill` attribute to give radio buttons rounded edges.
 
 ```pug:slim
 sl-radio-group label="Select an option" name="a" value="1"
-  sl-radio-button pill="true" size="small" value="1" Option 1
-  sl-radio-button pill="true" size="small" value="2" Option 2
-  sl-radio-button pill="true" size="small" value="3" Option 3
+  sl-radio-button pill=true size="small" value="1" Option 1
+  sl-radio-button pill=true size="small" value="2" Option 2
+  sl-radio-button pill=true size="small" value="3" Option 3
 br
 sl-radio-group label="Select an option" name="a" value="1"
-  sl-radio-button pill="true" size="medium" value="1" Option 1
-  sl-radio-button pill="true" size="medium" value="2" Option 2
-  sl-radio-button pill="true" size="medium" value="3" Option 3
+  sl-radio-button pill=true size="medium" value="1" Option 1
+  sl-radio-button pill=true size="medium" value="2" Option 2
+  sl-radio-button pill=true size="medium" value="3" Option 3
 br
 sl-radio-group label="Select an option" name="a" value="1"
-  sl-radio-button pill="true" size="large" value="1" Option 1
-  sl-radio-button pill="true" size="large" value="2" Option 2
-  sl-radio-button pill="true" size="large" value="3" Option 3
+  sl-radio-button pill=true size="large" value="1" Option 1
+  sl-radio-button pill=true size="large" value="2" Option 2
+  sl-radio-button pill=true size="large" value="3" Option 3
 ```
 
 ```jsx:react

--- a/docs/pages/components/radio-group.md
+++ b/docs/pages/components/radio-group.md
@@ -6,17 +6,71 @@ layout: component
 unusedProperties: |
   - Sizes `small`, `large`
 guidelines: |
-  **When to Use a Radio Group**
+  ### When to Use a Radio Group
   - When you want people to **choose just one** option from a list
   - When presenting **fewer than 7** options
   - If letting people **see all their options** right away (without an additional click) is a priority
 
-  **When to Use a Different Component**
+  ### When to Use Something Else
   - **Use a [checkbox group](/components/checkbox-group) instead** if presenting fewer than 5 to 7 options and you want to let people choose **multiple** options
   - **Use a [select](/components/select) instead** if presenting more than 7 options or there isn't enough room to present all the options
 
-  **Labels, Help Text, Etc.**
+  ### Labels, Help Text, Etc.
   - For additional guidelines on radio and radio group **labels**, **help text**, and the  **label tooltip**, refer to the [Input component usage guidelines](/components/input/#usage-guidelines)
+testing: |
+  ### With Cypress
+
+  **Adding `data-test-id` to a component**
+
+   To test `<sl-radio-group>`, add the `data-test-id` attribute directly to the component. To test radio items in the group, add `data-test-id` to each item:
+
+  ```
+    sl-radio-group[
+      label="Radio group text"
+      name="input-name"
+      value="option-1"
+      data-test-id="radio-group-test"
+    ] 
+      sl-radio value="option-1" data-test-id="item-test-1" Option 1
+      sl-radio value="option-2" data-test-id="item-test-2" Option 2
+      sl-radio value="option-3" data-test-id="item-test-3" Option 3
+  ```
+
+  To test `<sl-radio-group>` implemented with `ts_form_for`, add `data-test-id` to `wrapper_html`. To test radio items in the group, add `data-test-id` to each item in the collection array:
+
+  ```
+      = ts_form_for ... do |f|
+        = f.input :input_name,
+          as: :radio_buttons,
+          label: "Radio group text",
+          collection: [
+            ["Option 1", :option-1, data: { test_id: "item-test-1" }],
+            ["Option 2", :option-2, data: { test_id: "item-test-2" }],
+            ["Option 3", :option-3, data: { test_id: "item-test-3" }],
+          ],
+          wrapper_html: { 
+            data: { 
+              "test_id": "radio-group-test"
+            }
+          }
+  ```
+
+  **Cypress commands for `<sl-radio-group>`**
+
+  To **select** a radio item in the radio group:
+  ```
+    cy.get(`[data-test-id="item-test-1"]`).click();
+  ```
+
+  To verify the radio group's value, that a certain item **is selected**:
+  ```
+    cy.get(`[data-test-id="radio-group-test"]`).should("have.value", 'option-1');
+  ```
+
+  To verify the radio group's value, that a certain item **is NOT selected**:
+  ```
+    cy.get(`[data-test-id="radio-group-test"]`).should("not.have.value", "option-3");
+  ```
 ---
 
 ## Examples

--- a/docs/pages/components/radio-group.md
+++ b/docs/pages/components/radio-group.md
@@ -24,21 +24,33 @@ testing: |
 
    To test `<sl-radio-group>`, add the `data-test-id` attribute directly to the component. To test radio items in the group, add `data-test-id` to each item:
 
-  ```
+  ```pug:slim
     sl-radio-group[
       label="Radio group text"
       name="input-name"
       value="option-1"
       data-test-id="radio-group-test"
     ] 
-      sl-radio value="option-1" data-test-id="item-test-1" Option 1
-      sl-radio value="option-2" data-test-id="item-test-2" Option 2
-      sl-radio value="option-3" data-test-id="item-test-3" Option 3
+      sl-radio[
+        value="option-1"
+        data-test-id="item-test-1"
+      ]
+        | Option 1
+      sl-radio[
+        value="option-2"
+        data-test-id="item-test-2"
+      ] 
+        | Option 2
+      sl-radio[
+        value="option-3" 
+        data-test-id="item-test-3"
+      ] 
+        | Option 3
   ```
 
   To test `<sl-radio-group>` implemented with `ts_form_for`, add `data-test-id` to `wrapper_html`. To test radio items in the group, add `data-test-id` to each item in the collection array:
 
-  ```
+  ```js
       = ts_form_for ... do |f|
         = f.input :input_name,
           as: :radio_buttons,
@@ -58,17 +70,17 @@ testing: |
   **Cypress commands for `<sl-radio-group>`**
 
   To **select** a radio item in the radio group:
-  ```
+  ```js
     cy.get(`[data-test-id="item-test-1"]`).click();
   ```
 
   To verify the radio group's value, that a certain item **is selected**:
-  ```
+  ```js
     cy.get(`[data-test-id="radio-group-test"]`).should("have.value", 'option-1');
   ```
 
   To verify the radio group's value, that a certain item **is NOT selected**:
-  ```
+  ```js
     cy.get(`[data-test-id="radio-group-test"]`).should("not.have.value", "option-3");
   ```
 ---
@@ -96,15 +108,15 @@ sl-radio-group[
   sl-radio value="issue_shares" Issue shares
   sl-radio value="employee_buyback" Employee buyback
   sl-radio value="cancel_certificate" Cancel a certificate
+```
 
+```js:simple-form
 /*
-  When rendering with ts_form_for
   — NOTE: To set default value for initial page load, ensure a value is set
   in the controller's #new action:
 
   e.g. if using `ts_form_for @cap_table_event`, set @cap_table_event = CapTableEvent.new(a: "issue_shares")
 */
-
 = ts_form_for ... do |f|
   = f.input :a,
     as: :radio_buttons,
@@ -172,16 +184,16 @@ sl-radio-group[
   div slot="help-text"
     a href="#" class="ts-text-link" Contact support
     | if you don't see the option you need here
+```
 
+```js:simple-form
 /*
-  When rendering with ts_form_for
   — NOTE: To set default value for initial page load, ensure a value is set
   in the controller's #new action:
   e.g. if using `ts_form_for @cap_table_event`, set @cap_table_event = CapTableEvent.new(a: "issue_shares")
 
   — NOTE: Slots are not supported with ts_form_for —
 */
-
 = ts_form_for ... do |f|
   = f.input :a,
     as: :radio_buttons,
@@ -235,14 +247,14 @@ sl-radio-group[
   sl-radio value="issue_shares" Issue shares
   sl-radio value="employee_buyback" Employee buyback
   sl-radio value="cancel_certificate" Cancel a certificate
+```
 
+```js:simple-form
 /*
-  When rendering with ts_form_for
   — NOTE: To set default value for initial page load, ensure a value is set
   in the controller's #new action:
   e.g. if using `ts_form_for @cap_table_event`, set @cap_table_event = CapTableEvent.new(a: "issue_shares")
 */
-
 = ts_form_for ... do |f|
   = f.input :a,
     as: :radio_buttons,
@@ -310,13 +322,25 @@ sl-radio-group[
   sl-radio value="issue_shares" Issue shares
   sl-radio value="employee_buyback" Employee buyback
 
+css:
+    sl-radio-group[id="question-1"] {
+    container-type: inline-size;
+    container-name: question-1;
+  }
+
+  @container question-1 (max-width: 360px) {
+    sl-radio-group[id="question-1"]:part(form-control-input) {
+      flex-direction: column;
+    }
+  }
+```
+
+```js:simple-form
 /*
-  When rendering with ts_form_for
   — NOTE: To set default value for initial page load, ensure a value is set
   in the controller's #new action:
   e.g. if using `ts_form_for @cap_table_event`, set @cap_table_event = CapTableEvent.new(a: "issue_shares")
 */
-
 = ts_form_for ... do |f|
   = f.input :a,
     as: :radio_buttons,
@@ -329,18 +353,6 @@ sl-radio-group[
       horizontal: true,
       id: "question-1",
     }
-
-css:
-    sl-radio-group[id="question-1"] {
-    container-type: inline-size;
-    container-name: question-1;
-  }
-
-  @container question-1 (max-width: 360px) {
-    sl-radio-group[id="question-1"]:part(form-control-input) {
-      flex-direction: column;
-    }
-  }
 ```
 
 ```jsx:react
@@ -401,14 +413,14 @@ sl-radio-group[
   sl-radio value="issue_shares" Issue shares
   sl-radio value="employee_buyback" Employee buyback
   sl-radio value="cancel_certificate" Cancel a certificate
+```
 
+```js:simple-form
 /*
-  When rendering with ts_form_for
   — NOTE: To set default value for initial page load, ensure a value is set
   in the controller's #new action:
   e.g. if using `ts_form_for @cap_table_event`, set @cap_table_event = CapTableEvent.new(a: "issue_shares")
 */
-
 = ts_form_for ... do |f|
   = f.input :a,
     as: :radio_buttons,
@@ -461,9 +473,6 @@ Shoelace's [radio buttons](/components/radio-button), also commonly called Segme
 :::warning
 **Note:** The Radio Button pattern is being redesigned. Please check with the design team before using this pattern.
 :::
-:::warning
-**Note:** `ts_form_for` doesn't support `sl-radio-button`.
-:::
 
 ```html:preview
 <sl-radio-group label="Select an option" help-text="Select an option that makes you proud." name="a" value="1">
@@ -474,9 +483,6 @@ Shoelace's [radio buttons](/components/radio-button), also commonly called Segme
 ```
 
 ```pug:slim
-/*
-  NOTE: `ts_form_for` doesn't support `sl-radio-button`.
-*/
 sl-radio-group[
   label="Select an option"
   help-text="Select an option that makes you proud."
@@ -486,6 +492,12 @@ sl-radio-group[
   sl-radio-button value="1" Option 1
   sl-radio-button value="2" Option 2
   sl-radio-button value="3" Option 3
+```
+
+```js:simple-form
+/*
+  NOTE: `ts_form_for` doesn't support `sl-radio-button`.
+*/
 ```
 
 ```jsx:react
@@ -522,9 +534,10 @@ sl-radio-group[
   sl-radio value="issue_shares" Issue shares
   sl-radio value="employee_buyback" Employee buyback
   sl-radio value="cancel_certificate" disabled="true" Cancel a certificate
+```
 
+```js:simple-form
 /*
-  When rendering with ts_form_for
   — NOTE: To set default value for initial page load, ensure a value is set
   in the controller's #new action:
   e.g. if using `ts_form_for @cap_table_event`,
@@ -537,7 +550,6 @@ sl-radio-group[
   as the label and the second item as the value, then pass
   any additional array items as attributes on the `sl-radio`.
 */
-
 = ts_form_for ... do |f|
   = f.input :a,
     as: :radio_buttons,
@@ -608,13 +620,19 @@ sl-radio-group.radio-group-size[
   sl-radio value="medium" Medium
   sl-radio value="large" Large
 
+javascript:
+  const radioGroup = document.querySelector('.radio-group-size');
+  radioGroup.addEventListener('sl-change', () => {
+    radioGroup.size = radioGroup.value;
+  });
+```
+
+```js:simple-form
 /*
-  When rendering with ts_form_for
   — NOTE: To set default value for initial page load, ensure a value is set
   in the controller's #new action:
   e.g. if using `ts_form_for @cap_table_event`, set @cap_table_event = CapTableEvent.new(a: "issue_shares")
 */
-
 = ts_form_for ... do |f|
   = f.input :a,
     as: :radio_buttons,
@@ -713,10 +731,22 @@ form.validation
   ]
     | Submit
 
-/*
-  When rendering with ts_form_for
-*/
+javascript:
+  const form = document.querySelector(.validation);
 
+  // Wait for controls to be defined before attaching form listeners
+  await Promise.all([
+    customElements.whenDefined('sl-radio-group'),
+  ]).then(() => {
+    // Handle form submit
+    form.addEventListener(submit, event => {
+      event.preventDefault();
+      alert(All fields are valid!);
+    });
+  });
+```
+
+```js:simple-form
 = ts_form_for ... do |f|
   = f.input :a,
     as: :radio_buttons,
@@ -732,20 +762,6 @@ form.validation
   br
   // ts_form_for automatically sets the form's submit button to variant="primary"
   = f.submit "Submit"
-
-javascript:
-  const form = document.querySelector(.validation);
-
-  // Wait for controls to be defined before attaching form listeners
-  await Promise.all([
-    customElements.whenDefined('sl-radio-group'),
-  ]).then(() => {
-    // Handle form submit
-    form.addEventListener(submit, event => {
-      event.preventDefault();
-      alert(All fields are valid!);
-    });
-  });
 ```
 
 ```jsx:react

--- a/docs/pages/components/radio-group.md
+++ b/docs/pages/components/radio-group.md
@@ -22,7 +22,7 @@ testing: |
 
   **Adding `data-test-id` to a component**
 
-   To test `<sl-radio-group>`, add the `data-test-id` attribute directly to the component. To test radio items in the group, add `data-test-id` to each item:
+   To test `sl-radio-group`, add the `data-test-id` attribute directly to the component. To test radio items in the group, add `data-test-id` to each item:
 
   ```pug:slim
     sl-radio-group[
@@ -48,7 +48,7 @@ testing: |
         | Option 3
   ```
 
-  To test `<sl-radio-group>` implemented with `ts_form_for`, add `data-test-id` to `wrapper_html`. To test radio items in the group, add `data-test-id` to each item in the collection array:
+  To test `sl-radio-group` implemented with `ts_form_for`, add `data-test-id` to `wrapper_html`. To test radio items in the group, add `data-test-id` to each item in the collection array:
 
   ```js
       = ts_form_for ... do |f|
@@ -62,12 +62,12 @@ testing: |
           ],
           wrapper_html: { 
             data: { 
-              "test_id": "radio-group-test"
+              test_id: "radio-group-test"
             }
           }
   ```
 
-  **Cypress commands for `<sl-radio-group>`**
+  **Cypress commands for `sl-radio-group`**
 
   To **select** a radio item in the radio group:
   ```js

--- a/docs/pages/components/radio-group.md
+++ b/docs/pages/components/radio-group.md
@@ -317,7 +317,7 @@ sl-radio-group[
   label="What would you like to do?"
   name="a"
   value="issue_shares"
-  horizontal="true"
+  horizontal=true
 ]
   sl-radio value="issue_shares" Issue shares
   sl-radio value="employee_buyback" Employee buyback
@@ -395,7 +395,7 @@ sl-radio-group[
   name="a"
   value="issue_shares"
   help-text="Contact support if you don't see the option you need here"
-  contained="true"
+  contained=true
 ]
   sl-radio value="issue_shares" Issue shares
   sl-radio value="employee_buyback" Employee buyback
@@ -407,8 +407,8 @@ sl-radio-group[
   name="b"
   value="issue_shares"
   help-text="Contact support if you don't see the option you need here"
-  horizontal="true"
-  contained="true"
+  horizontal=true
+  contained=true
 ]
   sl-radio value="issue_shares" Issue shares
   sl-radio value="employee_buyback" Employee buyback
@@ -533,7 +533,7 @@ sl-radio-group[
 ]
   sl-radio value="issue_shares" Issue shares
   sl-radio value="employee_buyback" Employee buyback
-  sl-radio value="cancel_certificate" disabled="true" Cancel a certificate
+  sl-radio value="cancel_certificate" disabled=true Cancel a certificate
 ```
 
 ```js:simple-form
@@ -719,7 +719,7 @@ form.validation
   sl-radio-group[
     label="Select an option"
     name="a"
-    required="true"
+    required=true
   ]
     sl-radio value="1" Option 1
     sl-radio value="2" Option 2

--- a/docs/pages/components/radio.md
+++ b/docs/pages/components/radio.md
@@ -7,6 +7,9 @@ unusedProperties: |
   - Sizes `small`, `large`
 guidelines: |
   - Refer to the [Radio Group component general guidelines](/components/radio-group/#usage-guidelines)
+testing: |
+  ### With Cypress
+  - Radios can be tested through their parent radio group. See [Radio Group Testing](/components/radio-group/#testing) for details.
 ---
 
 ## Examples

--- a/docs/pages/components/radio.md
+++ b/docs/pages/components/radio.md
@@ -188,7 +188,7 @@ sl-radio-group[
   label="What would you like to do?"
   name="a"
   value="issue_shares"
-  contained="true"
+  contained=true
 ]
   sl-radio[
     value="issue_shares"
@@ -202,7 +202,7 @@ sl-radio-group[
     | Employee buyback
   sl-radio[
     value="cancel_certificate"
-    disabled="true"
+    disabled=true
   ]
     | Cancel a certificate
     div slot="description" Declares certificate to be
@@ -313,7 +313,7 @@ sl-radio-group[
   label="Select your payment amount"
   name="a"
   value="statement-balance"
-  contained="true"
+  contained=true
 ]
   sl-radio[
     value="statement-balance"
@@ -450,7 +450,7 @@ sl-radio-group[
 ]
   sl-radio value="issue_shares" Issue shares
   sl-radio value="employee_buyback" Employee buyback
-  sl-radio value="cancel_certificate" disabled="true" Cancel a certificate
+  sl-radio value="cancel_certificate" disabled=true Cancel a certificate
 ```
 
 ```js:simple-form

--- a/docs/pages/components/radio.md
+++ b/docs/pages/components/radio.md
@@ -36,14 +36,14 @@ sl-radio-group[
   sl-radio value="issue_shares" Issue shares
   sl-radio value="employee_buyback" Employee buyback
   sl-radio value="cancel_certificate" Cancel a certificate
+```
 
+```js:simple-form
 /*
-  When rendering with ts_form_for
   — NOTE: To set default value for initial page load, ensure a value is set
   in the controller's #new action:
   e.g. if using `ts_form_for @cap_table_event`, set @cap_table_event = CapTableEvent.new(a: "issue_shares")
 */
-
 = ts_form_for ... do |f|
   = f.input :a,
     as: :radio_buttons,
@@ -111,9 +111,10 @@ sl-radio-group[
     | Cancel a certificate
     div slot="description" Declares certificate to be
       em null and void
+```
 
+```js:simple-form
 /*
-  When rendering with ts_form_for
   — NOTE: To set default value for initial page load, ensure a value is set
   in the controller's #new action:
   e.g. if using `ts_form_for @cap_table_event`,
@@ -129,7 +130,6 @@ sl-radio-group[
   as the label and the second item as the value, then pass
   any additional array items as attributes on the `sl-radio`.
 */
-
 = ts_form_for ... do |f|
   = f.input :a,
     as: :radio_buttons,
@@ -207,9 +207,10 @@ sl-radio-group[
     | Cancel a certificate
     div slot="description" Declares certificate to be
       em null and void
+```
 
+```js:simple-form
 /*
-  When rendering with ts_form_for
   — NOTE: To set default value for initial page load, ensure a value is set
   in the controller's #new action:
   e.g. if using `ts_form_for @cap_table_event`,
@@ -225,7 +226,6 @@ sl-radio-group[
   as the label and the second item as the value, then pass
   any additional array items as attributes on the `sl-radio`.
 */
-
 = ts_form_for ... do |f|
   = f.input :a,
     as: :radio_buttons,
@@ -309,11 +309,6 @@ Use the `selected-content` slot to display additional content (such as an input 
 ```
 
 ```pug:slim
-/*
-  NOTE: `ts_form_for` doesn't support slots. The `selected-content` slot
-  cannot be used for radio groups rendered with `ts_form_for`.
-*/
-
 sl-radio-group[
   label="Select your payment amount"
   name="a"
@@ -349,6 +344,13 @@ css:
     font-weight: normal;
     color: #6D7176;
   }
+```
+
+```js:simple-form
+/*
+  NOTE: `ts_form_for` doesn't support slots. The `selected-content` slot
+  cannot be used for radio groups rendered with `ts_form_for`.
+*/
 ```
 
 ```jsx:react
@@ -396,14 +398,14 @@ sl-radio-group[
   sl-radio value="issue_shares" Issue shares
   sl-radio value="employee_buyback" Employee buyback
   sl-radio value="cancel_certificate" Cancel a certificate
+```
 
+```js:simple-form
 /*
-  When rendering with ts_form_for
   — NOTE: To set default value for initial page load, ensure a value is set
   in the controller's #new action:
   e.g. if using `ts_form_for @cap_table_event`, set @cap_table_event = CapTableEvent.new(a: "issue_shares")
 */
-
 = ts_form_for ... do |f|
   = f.input :a,
     as: :radio_buttons,
@@ -449,9 +451,10 @@ sl-radio-group[
   sl-radio value="issue_shares" Issue shares
   sl-radio value="employee_buyback" Employee buyback
   sl-radio value="cancel_certificate" disabled="true" Cancel a certificate
+```
 
+```js:simple-form
 /*
-  When rendering with ts_form_for
   — NOTE: To set default value for initial page load, ensure a value is set
   in the controller's #new action:
   e.g. if using `ts_form_for @cap_table_event`,

--- a/docs/pages/components/range.md
+++ b/docs/pages/components/range.md
@@ -90,7 +90,7 @@ Use the `disabled` attribute to disable a slider.
 ```
 
 ```pug:slim
-sl-range disabled="true"
+sl-range disabled=true
 ```
 
 ```jsx:react

--- a/docs/pages/components/rating.md
+++ b/docs/pages/components/rating.md
@@ -108,7 +108,7 @@ Use the `readonly` attribute to display a rating that users can't change.
 ```
 
 ```pug:slim
-sl-rating label="Rating" readonly="true" value="3"
+sl-rating label="Rating" readonly=true value="3"
 ```
 
 ```jsx:react
@@ -126,7 +126,7 @@ Use the `disable` attribute to disable the rating.
 ```
 
 ```pug:slim
-sl-rating label="Rating" disabled="true" value="3"
+sl-rating label="Rating" disabled=true value="3"
 ```
 
 ```jsx:react

--- a/docs/pages/components/relative-time.md
+++ b/docs/pages/components/relative-time.md
@@ -52,7 +52,7 @@ Use the `sync` attribute to update the displayed value automatically as time pas
 
 ```pug:slim
 div.relative-time-sync
-  sl-relative-time sync="true"
+  sl-relative-time sync=true
 
 javascript:
   const container = document.querySelector(.relative-time-sync);

--- a/docs/pages/components/select.md
+++ b/docs/pages/components/select.md
@@ -7,27 +7,78 @@ unusedProperties: |
   - Size `small`
   - Booleans `filled`, `pill`
 guidelines: |
-  **When to Use a Select**
+  ### When to Use a Select
   - When presenting **more than 7** options for people to choose from
   - When you **don't have enough space** to present all the options
   - Most commonly, when you want people to **choose just one** option
 
-  **When to Use a Different Component**
+  ### When to Use Something Else
   - **Use a [radio group](/components/radio-group) instead** if presenting fewer than 5 to 7 options and you want to let people choose just **one** option
   - **Use a [checkbox group](/components/checkbox-group) instead** if presenting fewer than 5 to 7 options and you want to let people choose **multiple** options
 
-  **Placeholder Text and Default Selections**
+  ### Placeholder Text and Default Selections
   - **Don't use placeholder text** in a select, even to create a default non-selectable option that serves as a hint (e.g. "Select an option")
   - If you need to allow people to **clear their selection**, include an empty (no value) option to serve as the default "empty" option
   - Whenever possible, set a **default selection** that makes sense for the use case and context
 
-  **Using the Multi-select Option**
+  ### Using the Multi-select Option
   - **Use the multi-select option sparingly.** Selects that allow people to choose multiple options are not as common, and people often don't realize that they can choose more than one option.
   - Consider whether a checkbox group would create a more straightforward experience
   - If you are opting to use the multi-select option, be sure to include a clear button using the `clearable` attribute, so that people can easily clear their selections
 
-  **Labels, Help Text, Placeholder, Etc.**
+  ### Labels, Help Text, Placeholder, Etc.
   - For additional guidelines on select **labels**, **help text**, **label tooltip**, **context note**, and **placeholder text**, refer to the [Input component usage guidelines](/components/input/#usage-guidelines)
+testing: |
+  ### With Cypress
+
+  **Adding `data-test-id` to a component**
+
+   To test `<sl-select>`, add the `data-test-id` attribute directly to the component:
+
+  ```
+    sl-select[
+      label="Select an option"
+      data-test-id="select-test"
+    ]
+      sl-option value="option-1" Option 1
+      sl-option value="option-2" Option 2
+      sl-option value="option-3" Option 3
+  ```
+
+  To test `<sl-select>` implemented with `ts_form_for`, add `data-test-id` to `input_html`:
+
+  ```
+    = ts_form_for ... do |f|
+      = f.input :select_name, 
+        collection: [
+          ["Option 1", :option-1],
+          ["Option 2", :option-2],
+          ["Option 3", :option-3],
+        ],      
+        input_html: { 
+          label: "Select an option",
+          data: { 
+            "test_id": "select-test"
+          } 
+        }
+  ```
+
+  **Cypress commands for `<sl-select>`**
+
+  To **select** an option:
+  ```
+    cy.slSelectByOptionText(`[data-test-id="select-test"]`, "Option 1");
+  ```
+
+  To verify an option **is selected**:
+  ```
+    cy.slSelectValue(`[data-test-id="select-text"]`).should("equal", "option-1");
+  ```
+
+  To verify an option **is NOT selected**:
+  ```
+    cy.slSelectValue(`[data-test-id="select-text"]`).should("not.equal", "option-2");
+  ```
 ---
 
 ## Examples

--- a/docs/pages/components/select.md
+++ b/docs/pages/components/select.md
@@ -33,7 +33,7 @@ testing: |
 
   **Adding `data-test-id` to a component**
 
-   To test `<sl-select>`, add the `data-test-id` attribute directly to the component:
+   To test `sl-select`, add the `data-test-id` attribute directly to the component:
 
   ```pug:slim
     sl-select[
@@ -45,7 +45,7 @@ testing: |
       sl-option value="option-3" Option 3
   ```
 
-  To test `<sl-select>` implemented with `ts_form_for`, add `data-test-id` to `input_html`:
+  To test `sl-select` implemented with `ts_form_for`, add `data-test-id` to `input_html`:
 
   ```js
     = ts_form_for ... do |f|
@@ -58,12 +58,12 @@ testing: |
         input_html: { 
           label: "Select an option",
           data: { 
-            "test_id": "select-test"
+            test_id: "select-test"
           } 
         }
   ```
 
-  **Cypress commands for `<sl-select>`**
+  **Cypress commands for `sl-select`**
 
   To **select** an option:
   ```js

--- a/docs/pages/components/select.md
+++ b/docs/pages/components/select.md
@@ -395,8 +395,8 @@ Use the `clearable` attribute to make the control clearable. The clear button on
 ```pug:slim
 sl-select[
   label="Clearable multi-choice select"
-  clearable="true"
-  multiple="true"
+  clearable=true
+  multiple=true
   value="option-1 option-2"
   help-text="For multi-choice selects only, display an icon button to let people clear their selections"
 ]
@@ -480,7 +480,7 @@ Add the `filled` attribute to draw a filled select.
 ```
 
 ```pug:slim
-sl-select filled="true"
+sl-select filled=true
   sl-option value="option-1" Option 1
   sl-option value="option-2" Option 2
   sl-option value="option-3" Option 3
@@ -530,7 +530,7 @@ Use the `pill` attribute to give selects rounded edges.
 ```pug:slim
 sl-select[
   label="Medium pill"
-  pill="true"
+  pill=true
 ]
   sl-option value="option-1" Option 1
   sl-option value="option-2" Option 2
@@ -542,7 +542,7 @@ br
 sl-select[
   label="Large pill"
   size="large"
-  pill="true"
+  pill=true
 ]
   sl-option value="option-1" Option 1
   sl-option value="option-2" Option 2
@@ -624,7 +624,7 @@ Use the `disabled` attribute to disable the entire select. To disable just one o
 ```pug:slim
 sl-select[
   label="Disabled select"
-  disabled="true"
+  disabled=true
 ]
   sl-option value="option-1" Option 1
   sl-option value="option-2" Option 2
@@ -705,8 +705,8 @@ To allow multiple options to be selected, use the `multiple` attribute. When thi
 sl-select[
   label="Select one or more"
   value="option-1 option-2 option-3"
-  multiple="true"
-  clearable="true"
+  multiple=true
+  clearable=true
 ]
   sl-option value="option-1" Option 1
   sl-option value="option-2" Option 2
@@ -774,8 +774,8 @@ When using `multiple`, the `value` _attribute_ uses space-delimited values to se
 sl-select[
   label="Select one or more"
   value="option-1 option-2"
-  multiple="true"
-  clearable="true"
+  multiple=true
+  clearable=true
 ]
   sl-option value="option-1" Option 1
   sl-option value="option-2" Option 2

--- a/docs/pages/components/select.md
+++ b/docs/pages/components/select.md
@@ -35,7 +35,7 @@ testing: |
 
    To test `<sl-select>`, add the `data-test-id` attribute directly to the component:
 
-  ```
+  ```pug:slim
     sl-select[
       label="Select an option"
       data-test-id="select-test"
@@ -47,7 +47,7 @@ testing: |
 
   To test `<sl-select>` implemented with `ts_form_for`, add `data-test-id` to `input_html`:
 
-  ```
+  ```js
     = ts_form_for ... do |f|
       = f.input :select_name, 
         collection: [
@@ -66,17 +66,17 @@ testing: |
   **Cypress commands for `<sl-select>`**
 
   To **select** an option:
-  ```
+  ```js
     cy.slSelectByOptionText(`[data-test-id="select-test"]`, "Option 1");
   ```
 
   To verify an option **is selected**:
-  ```
+  ```js
     cy.slSelectValue(`[data-test-id="select-text"]`).should("equal", "option-1");
   ```
 
   To verify an option **is NOT selected**:
-  ```
+  ```js
     cy.slSelectValue(`[data-test-id="select-text"]`).should("not.equal", "option-2");
   ```
 ---
@@ -106,11 +106,9 @@ sl-select label="Select one option"
   sl-option value="option-4" Option 4
   sl-option value="option-5" Option 5
   sl-option value="option-6" Option 6
+```
 
-/*
-  When rendering with ts_form_for
-*/
-
+```js:simple-form
 = ts_form_for ... do |f|
   = f.input :select_one,
     collection: [
@@ -188,12 +186,9 @@ sl-select[
     | Select one option that best describes your
     strong current
     | skill level
+```
 
-/*
-  When rendering with ts_form_for
-  — NOTE: Slots are not supported with ts_form_for —
-*/
-
+```js:simple-form
 = ts_form_for ... do |f|
   = f.input :skill_level,
     collection: [
@@ -247,11 +242,9 @@ sl-select[
   sl-option value="2" Intermediate
   sl-option value="3" Advanced
   sl-option value="4" Expert
+```
 
-/*
-  When rendering with ts_form_for
-*/
-
+```js:simple-form
 = ts_form_for ... do |f|
   = f.input :skill_level,
     collection: [
@@ -308,13 +301,13 @@ sl-select[
   sl-option value="2" Intermediate
   sl-option value="3" Advanced
   sl-option value="4" Expert
+```
 
+```js:simple-form
 /*
-  When rendering with ts_form_for
   — NOTE: Slots are not supported with ts_form_for —
   — Example below shows usage of "context-note" as attribute —
 */
-
 = ts_form_for ... do |f|
   = f.input :skill_level,
     collection: [
@@ -425,11 +418,9 @@ sl-select[
   sl-option value="option-4" Option 4
   sl-option value="option-5" Option 5
   sl-option value="option-6" Option 6
+```
 
-/*
-  When rendering with ts_form_for
-*/
-
+```js:simple-form
 = ts_form_for ... do |f|
   = f.input :clearable_multiple,
     collection: [
@@ -559,11 +550,9 @@ sl-select[
   sl-option value="option-4" Option 4
   sl-option value="option-5" Option 5
   sl-option value="option-6" Option 6
+```
 
-/*
-  When rendering with ts_form_for
-*/
-
+```js:simple-form
 = ts_form_for ... do |f|
   = f.input :pill_medium,
     collection: [
@@ -609,7 +598,7 @@ const App = () => (
 
 ### Disabled
 
-Use the `disabled` attribute to disable a select.
+Use the `disabled` attribute to disable the entire select. To disable just one option, put `disabled` on the `sl-option`.
 
 ```html:preview
 <sl-select label="Disabled select" disabled>
@@ -620,6 +609,16 @@ Use the `disabled` attribute to disable a select.
   <sl-option value="option-5">Option 5</sl-option>
   <sl-option value="option-6">Option 6</sl-option>
 </sl-select>
+<br/>
+<sl-select label="Select with disabled option">
+  <sl-option value="option-1">Option 1</sl-option>
+  <sl-option value="option-2">Option 2</sl-option>
+  <sl-option value="option-3" disabled>Option 3</sl-option>
+  <sl-option value="option-4">Option 4</sl-option>
+  <sl-option value="option-5">Option 5</sl-option>
+  <sl-option value="option-6">Option 6</sl-option>
+</sl-select>
+
 ```
 
 ```pug:slim
@@ -633,11 +632,19 @@ sl-select[
   sl-option value="option-4" Option 4
   sl-option value="option-5" Option 5
   sl-option value="option-6" Option 6
+br
+sl-select[
+  label="Disabled select"
+]
+  sl-option value="option-1" Option 1
+  sl-option value="option-2" Option 2
+  sl-option value="option-3" disabled=true Option 3
+  sl-option value="option-4" Option 4
+  sl-option value="option-5" Option 5
+  sl-option value="option-6" Option 6
+```
 
-/*
-  When rendering with ts_form_for
-*/
-
+```js:simple-form
 = ts_form_for ... do |f|
   = f.input :disabled_select,
     collection: [
@@ -651,6 +658,18 @@ sl-select[
     input_html: {
       label: "Disabled select",
       disabled: true,
+    }
+  = f.input :disabled_option,
+    collection: [
+      ["Option 1", "option-1"],
+      ["Option 2", "option-2"],
+      ["Option 3", "option-3", disabled=true],
+      ["Option 4", "option-4"],
+      ["Option 5", "option-5"],
+      ["Option 6", "option-6"],
+    ],
+    input_html: {
+      label: "Disabled select"
     }
 ```
 
@@ -695,11 +714,9 @@ sl-select[
   sl-option value="option-4" Option 4
   sl-option value="option-5" Option 5
   sl-option value="option-6" Option 6
+```
 
-/*
-  When rendering with ts_form_for
-*/
-
+```js:simple-form
 = ts_form_for ... do |f|
   = f.input :select_multiple,
     collection: [
@@ -764,11 +781,9 @@ sl-select[
   sl-option value="option-2" Option 2
   sl-option value="option-3" Option 3
   sl-option value="option-4" Option 4
+```
 
-/*
-  When rendering with ts_form_for
-*/
-
+```js:simple-form
 = ts_form_for ... do |f|
   = f.input :select_multiple,
     collection: [
@@ -825,11 +840,6 @@ Use `<sl-divider>` to group listbox items visually. You can also use `<small>` t
 ```
 
 ```pug:slim
-/*
-  — NOTE: grouping options with labels and dividers
-  is not supported with ts_form_for
-*/
-
 sl-select label="Select an option from one of the groups"
   sl-option value=""
   small Section 1
@@ -841,6 +851,13 @@ sl-select label="Select an option from one of the groups"
   sl-option value="option-4" Option 4
   sl-option value="option-5" Option 5
   sl-option value="option-6" Option 6
+```
+
+```js:simple-form
+/*
+  — NOTE: grouping options with labels and dividers
+  is not supported with ts_form_for
+*/
 ```
 
 ```jsx:react
@@ -906,11 +923,9 @@ sl-select[
   sl-option value="option-4" Option 4
   sl-option value="option-5" Option 5
   sl-option value="option-6" Option 6
+```
 
-/*
-  When rendering with ts_form_for
-*/
-
+```js:simple-form
 = ts_form_for ... do |f|
   = f.input :size_medium,
     collection: [
@@ -997,11 +1012,9 @@ sl-select[
   sl-option value="option-4" Option 4
   sl-option value="option-5" Option 5
   sl-option value="option-6" Option 6
+```
 
-/*
-  When rendering with ts_form_for
-*/
-
+```js:simple-form
 = ts_form_for ... do |f|
   = f.input :select_placement,
     collection: [
@@ -1089,11 +1102,6 @@ Follow these general guidelines when adding prefix icons to the select:
 ```
 
 ```pug:slim
-/*
-  NOTE: `ts_form_for` doesn't support slots. Prefix icons
-  cannot be added when rendering `sl-select` with `ts_form_for`
-*/
-
 sl-select label="Prefix icon example: DO"
   sl-icon[
     name="rocket-launch"
@@ -1151,6 +1159,13 @@ sl-select[
   sl-option value="option-2" Option 2 (shifted 4px right due to icon size)
   sl-option value="option-3" Option 3 (shifted 4px right due to icon size)
   sl-option value="option-4" Option 4 (shifted 4px right due to icon size)
+```
+
+```js:simple-form
+/*
+  NOTE: `ts_form_for` doesn't support slots. Prefix icons
+  cannot be added when rendering `sl-select` with `ts_form_for`
+*/
 ```
 
 ```jsx:react

--- a/docs/pages/components/split-panel.md
+++ b/docs/pages/components/split-panel.md
@@ -188,7 +188,7 @@ Add the `vertical` attribute to render the split panel in a vertical orientation
 ```
 
 ```pug:slim
-sl-split-panel vertical="true" style="height: 400px;"
+sl-split-panel vertical=true style="height: 400px;"
   div slot="start" style="height: 100%; background: var(--sl-color-neutral-50); display: flex; align-items: center; justify-content: center;"
     | Start
   div slot="end" style="height: 100%; background: var(--sl-color-neutral-50); display: flex; align-items: center; justify-content: center;"
@@ -411,7 +411,7 @@ Add the `disabled` attribute to prevent the divider from being repositioned.
 ```
 
 ```pug:slim
-sl-split-panel disabled="true"
+sl-split-panel disabled=true
   div slot="start" style="height: 200px; background: var(--sl-color-neutral-50); display: flex; align-items: center; justify-content: center;"
     | Start
   div slot="end" style="height: 200px; background: var(--sl-color-neutral-50); display: flex; align-items: center; justify-content: center;"
@@ -675,7 +675,7 @@ sl-split-panel
   div slot="start" style="height: 400px; background: var(--sl-color-neutral-50); display: flex; align-items: center; justify-content: center;"
     | Start
   div slot="end"
-    sl-split-panel vertical="true" style="height: 400px;"
+    sl-split-panel vertical=true style="height: 400px;"
       div slot="start" style="height: 100%; background: var(--sl-color-neutral-50); display: flex; align-items: center; justify-content: center;"
         | Top
       div slot="end" style="height: 100%; background: var(--sl-color-neutral-50); display: flex; align-items: center; justify-content: center;"

--- a/docs/pages/components/switch.md
+++ b/docs/pages/components/switch.md
@@ -139,7 +139,7 @@ Use the `checked` attribute to activate the switch.
 ```
 
 ```pug:slim
-sl-switch checked="true" Checked
+sl-switch checked=true Checked
 ```
 
 ```jsx:react
@@ -157,7 +157,7 @@ Use the `disabled` attribute to disable the switch.
 ```
 
 ```pug:slim
-sl-switch disabled="true" Disabled
+sl-switch disabled=true Disabled
 ```
 
 ```jsx:react

--- a/docs/pages/components/switch.md
+++ b/docs/pages/components/switch.md
@@ -48,7 +48,7 @@ testing: |
 
   **Adding `data-test-id` to a component**
 
-   To test `<sl-switch>`, add the `data-test-id` attribute directly to the component:
+   To test `sl-switch`, add the `data-test-id` attribute directly to the component:
 
   ```
     sl-switch[
@@ -57,9 +57,9 @@ testing: |
       | Switch test
   ```
 
-  **Cypress commands for `<sl-switch>`**
+  **Cypress commands for `sl-switch`**
 
-  Because `<sl-switch>` uses `<input type="checkbox">`, we can test the switch the same way we would test the [checkbox](/components/checkbox/#testing).
+  Because `sl-switch` uses `<input type="checkbox">`, we can test the switch the same way we would test the [checkbox](/components/checkbox/#testing).
 
   To toggle the switch **ON**:
   ```

--- a/docs/pages/components/switch.md
+++ b/docs/pages/components/switch.md
@@ -6,19 +6,22 @@ layout: component
 unusedProperties: |
   - Size `large`
 guidelines: |
-  **Switch or Checkbox?**
+  ### Switch or Checkbox?
   - Use a switch to let people toggle a setting that takes effect **immediately**, like a light switch
   - Use a [checkbox](/components/checkbox) to let people toggle a selection that must be **saved before taking effect**
 
-  **Switch Labels**
+  ### Switch Labels
 
-  - **Always** have a label for the switch
-  - Use **sentence case** for labels
-  - **Don’t** end labels with punctuation
+  **Label Dos**
+  - Always have a label for the switch
+  - Use **sentence case**
   - Keep labels **short and easy to scan**
-  - Only use a leading verb if it **clarifies** the switch's purpose
-  - **Avoid** phrases that describe the switch's "on" state (e.g. "Turn on" or "Enable")
-  - **Don't** update the switch's label dynamically based on its `checked` state
+  - Use a leading verb only when it **clarifies** the switch's purpose
+
+  **Label Don'ts**
+  - **Don’t** end labels with punctuation
+  - **Avoid** labels that describe the switch's "on" state (e.g. "Turn on" or "Enable")
+  - **Don't** update the label dynamically based on a switch's `checked` state
 
   :::tip
   **Do**
@@ -40,6 +43,43 @@ guidelines: |
   - Don’t use negative labels (like "hide" and "disable") that conflict with the “on” state of the switch
   - Don't repeat the switch's "on" state in the label
   :::
+testing: |
+  ### With Cypress
+
+  **Adding `data-test-id` to a component**
+
+   To test `<sl-switch>`, add the `data-test-id` attribute directly to the component:
+
+  ```
+    sl-switch[
+      data-test-id="switch-test"
+    ] 
+      | Switch test
+  ```
+
+  **Cypress commands for `<sl-switch>`**
+
+  Because `<sl-switch>` uses `<input type="checkbox">`, we can test the switch the same way we would test the [checkbox](/components/checkbox/#testing).
+
+  To toggle the switch **ON**:
+  ```
+    cy.slCheckboxCheck(`[data-test-id="switch-test"]`);
+  ```
+
+  To toggle the switch **OFF**::
+  ```
+    cy.slCheckboxUncheck(`[data-test-id="switch-test"]`);
+  ```
+
+  To verify the switch **is ON**:
+  ```
+    cy.get(`[data-test-id="switch-test"]`).should("have.prop", "checked", true);
+  ```
+
+  To verify the switch **is OFF**:
+  ```
+    cy.get(`[data-test-id="switch-test"]`).should("have.prop", "checked", false);
+  ```
 ---
 
 ## Examples

--- a/docs/pages/components/tab-group.md
+++ b/docs/pages/components/tab-group.md
@@ -32,7 +32,7 @@ sl-tab-group
   sl-tab slot="nav" panel="general" General
   sl-tab slot="nav" panel="custom" Custom
   sl-tab slot="nav" panel="advanced" Advanced
-  sl-tab slot="nav" panel="disabled" disabled="true" Disabled
+  sl-tab slot="nav" panel="disabled" disabled=true Disabled
   sl-tab-panel name="general" This is the general tab panel.
   sl-tab-panel name="custom" This is the custom tab panel.
   sl-tab-panel name="advanced" This is the advanced tab panel.
@@ -90,7 +90,7 @@ sl-tab-group placement="bottom"
   sl-tab slot="nav" panel="general" General
   sl-tab slot="nav" panel="custom" Custom
   sl-tab slot="nav" panel="advanced" Advanced
-  sl-tab slot="nav" panel="disabled" disabled="true" Disabled
+  sl-tab slot="nav" panel="disabled" disabled=true Disabled
   sl-tab-panel name="general" This is the general tab panel.
   sl-tab-panel name="custom" This is the custom tab panel.
   sl-tab-panel name="advanced" This is the advanced tab panel.
@@ -148,7 +148,7 @@ sl-tab-group placement="start"
   sl-tab slot="nav" panel="general" General
   sl-tab slot="nav" panel="custom" Custom
   sl-tab slot="nav" panel="advanced" Advanced
-  sl-tab slot="nav" panel="disabled" disabled="true" Disabled
+  sl-tab slot="nav" panel="disabled" disabled=true Disabled
   sl-tab-panel name="general" This is the general tab panel.
   sl-tab-panel name="custom" This is the custom tab panel.
   sl-tab-panel name="advanced" This is the advanced tab panel.
@@ -206,7 +206,7 @@ sl-tab-group placement="end"
   sl-tab slot="nav" panel="general" General
   sl-tab slot="nav" panel="custom" Custom
   sl-tab slot="nav" panel="advanced" Advanced
-  sl-tab slot="nav" panel="disabled" disabled="true" Disabled
+  sl-tab slot="nav" panel="disabled" disabled=true Disabled
   sl-tab-panel name="general" This is the general tab panel.
   sl-tab-panel name="custom" This is the custom tab panel.
   sl-tab-panel name="advanced" This is the advanced tab panel.
@@ -312,9 +312,9 @@ Add the `closable` attribute to a tab to show a close button. This example shows
 ```pug:slim
 sl-tab-group.tabs-closable
   sl-tab slot="nav" panel="general" General
-  sl-tab slot="nav" panel="closable-1" closable="true" Closable 1
-  sl-tab slot="nav" panel="closable-2" closable="true" Closable 2
-  sl-tab slot="nav" panel="closable-3" closable="true" Closable 3
+  sl-tab slot="nav" panel="closable-1" closable=true Closable 1
+  sl-tab slot="nav" panel="closable-2" closable=true Closable 2
+  sl-tab slot="nav" panel="closable-3" closable=true Closable 3
   sl-tab-panel name="general" This is the general tab panel.
   sl-tab-panel name="closable-1" This is the first closable tab panel.
   sl-tab-panel name="closable-2" This is the second closable tab panel.
@@ -591,7 +591,7 @@ sl-tab-group activation="manual"
   sl-tab slot="nav" panel="general" General
   sl-tab slot="nav" panel="custom" Custom
   sl-tab slot="nav" panel="advanced" Advanced
-  sl-tab slot="nav" panel="disabled" disabled="true" Disabled
+  sl-tab slot="nav" panel="disabled" disabled=true Disabled
   sl-tab-panel name="general" This is the general tab panel.
   sl-tab-panel name="custom" This is the custom tab panel.
   sl-tab-panel name="advanced" This is the advanced tab panel.

--- a/docs/pages/components/tab-panel.md
+++ b/docs/pages/components/tab-panel.md
@@ -28,7 +28,7 @@ sl-tab-group
   sl-tab slot="nav" panel="general" General
   sl-tab slot="nav" panel="custom" Custom
   sl-tab slot="nav" panel="advanced" Advanced
-  sl-tab slot="nav" panel="disabled" disabled="true" Disabled
+  sl-tab slot="nav" panel="disabled" disabled=true Disabled
   sl-tab-panel name="general" This is the general tab panel.
   sl-tab-panel name="custom" This is the custom tab panel.
   sl-tab-panel name="advanced" This is the advanced tab panel.

--- a/docs/pages/components/tab.md
+++ b/docs/pages/components/tab.md
@@ -20,9 +20,9 @@ unusedProperties: |
 
 ```pug:slim
 sl-tab Tab
-sl-tab active="true" Active
-sl-tab closable="true" Closable
-sl-tab disabled="true" Disabled
+sl-tab active=true Active
+sl-tab closable=true Closable
+sl-tab disabled=true Disabled
 ```
 
 ```jsx:react

--- a/docs/pages/components/tag.md
+++ b/docs/pages/components/tag.md
@@ -139,9 +139,9 @@ Use the `pill` attribute to give tags rounded edges. This variant is very simila
 ```
 
 ```pug:slim
-sl-tag size="small" pill="true" Small
-sl-tag size="medium" pill="true" Medium
-sl-tag size="large" pill="true" Large
+sl-tag size="small" pill=true Small
+sl-tag size="medium" pill=true Medium
+sl-tag size="large" pill=true Large
 ```
 
 ```jsx:react
@@ -192,9 +192,9 @@ Use the `removable` attribute to add a remove button to the tag.
 
 ```pug:slim
 div.tags-removable
-  sl-tag size="small" removable="true" Small
-  sl-tag size="medium" removable="true" Medium
-  sl-tag size="large" removable="true" Large
+  sl-tag size="small" removable=true Small
+  sl-tag size="medium" removable=true Medium
+  sl-tag size="large" removable=true Large
 
 javascript:
   const div = document.querySelector(.tags-removable);

--- a/docs/pages/components/tag.md
+++ b/docs/pages/components/tag.md
@@ -4,15 +4,15 @@ meta:
   description: Tags are used as labels to organize things or to indicate a selection.
 layout: component
 guidelines: |
-  **Tag Basics**
+  ### Tag Basics
   - Tags can be removed (for example, when they are being used to indicate a filter selection), but they aren't otherwise interactive
   - Don't use tags as buttons
 
-  **When to Use a Tag**
+  ### When to Use a Tag
   - Use a tag to label or organize items
   - Use a tag to show that a certain category of items has been selected (e.g. a search filter)
 
-  **When to Use a Different Component**
+  ### When to Use Something Else
   - Use a [badge](/components/badge) instead if you need to show counts
   - Use a [button](/components/button) instead if you need a clickable element that initiates an action
 unusedProperties: |

--- a/docs/pages/components/textarea.md
+++ b/docs/pages/components/textarea.md
@@ -15,7 +15,7 @@ testing: |
 
    To test `<sl-textarea>`, add the `data-test-id` attribute directly to the component:
 
-  ```
+  ```pug:slim
     sl-textarea[
       label="Bio"
       data-test-id="textarea-test"
@@ -24,7 +24,7 @@ testing: |
 
   To test `<sl-textarea>` implemented with `ts_form_for`, add `data-test-id` to `input_html`:
 
-  ```
+  ```js
     = ts_form_for ... do |f|
       = f.input :textarea_name, 
         as: :text,
@@ -39,22 +39,22 @@ testing: |
   **Cypress commands for `<sl-textarea>`**
 
   To **type** in the textarea:
-  ```
+  ```js
     cy.slTextAreaType(`[data-test-id="textarea-test"]`, "This is long text to type into the textarea for testing.");
   ```
 
   To **get the textarea's value** (note the matcher `"have.value"`):
-  ```
+  ```js
     cy.get(`[data-test-id="textarea-test"]`).should("have.value", "This is the long text value we want the textarea to have.");
   ```
 
   To **focus** on the textarea:
-  ```
+  ```js
     cy.slFocus(`[data-test-id="textarea-test"]`);
   ```
 
   To **clear** the textarea:
-  ```
+  ```js
     cy.slTextAreaClear(`[data-test-id="textarea-test"]`);
   ```
 ---
@@ -71,11 +71,9 @@ Use the `label` attribute to give the textarea an accessible label.
 
 ```pug:slim
 sl-textarea label="Month in review"
+```
 
-/*
- When rendering with ts_form_for
-*/
-
+```js:simple-form
 = ts_form_for ... do |f|
   = f.input :month_in_review,
     as: :text,
@@ -117,12 +115,9 @@ sl-textarea label="Month in review"
     | Tell us the highlights. Be sure to include details about any financial performance
     strong anomalies
     | .
+```
 
-/*
-  When rendering with ts_form_for
-  — NOTE: Slots are not supported with ts_form_for —
-*/
-
+```js:simple-form
 = ts_form_for ... do |f|
   = f.input :month_in_review,
     as: :text,
@@ -156,11 +151,9 @@ sl-textarea[
   help-text="Tell us the highlights. Be sure to include details about any financial performance anomalies."
   label-tooltip="There is no required format for this commentary. However, we suggest covering the following topics: 1) Revenue, 2) COGS, 3) Gross profit, and 4) Operating expenses."
 ]
+```
 
-/*
-  When rendering with ts_form_for
-*/
-
+```js:simple-form
 = ts_form_for ... do |f|
   = f.input :month_in_review,
     as: :text,
@@ -195,12 +188,12 @@ sl-textarea[
   help-text="Tell us the highlights. Be sure to include details about any financial performance anomalies."
   context-note="Data synced 1 hr ago"
 ]
+```
 
+```js:simple-form
 /*
-  When rendering with ts_form_for
   — NOTE: Slots are not supported with ts_form_for —
 */
-
 = ts_form_for ... do |f|
   = f.input :month_in_review,
     as: :text,
@@ -244,11 +237,9 @@ sl-textarea[
   label="Textarea with 6 rows"
   rows="6"
 ]
+```
 
-/*
-  When rendering with ts_form_for
-*/
-
+```js:simple-form
 = ts_form_for ... do |f|
   = f.input :rows_2,
     as: :text,
@@ -325,11 +316,9 @@ sl-textarea[
   label="Disabled textarea"
   disabled="true"
 ]
+```
 
-/*
-  When rendering with ts_form_for
-*/
-
+```js:simple-form
 = ts_form_for ... do |f|
   = f.input :disabled_textarea,
     as: :text,
@@ -392,13 +381,13 @@ sl-textarea[
   label="Textarea with no resizing"
   resize="none"
 ]
+```
 
+```js:simple-form
 /*
-  When rendering with ts_form_for
   — NOTE: In ts_form_for resize="auto" is the default —
   — Use resize="vertical" to match the Shoelace default —
 */
-
 = ts_form_for ... do |f|
   = f.input :no_resizing,
     as: :text,
@@ -433,13 +422,13 @@ sl-textarea[
   value="Someone’s sitting in the shade today because someone planted a tree a long time ago. ... Keep typing to see the textarea expand..."
   rows="2"
 ]
+```
 
+```js:simple-form
 /*
-  When rendering with ts_form_for
   — NOTE: In ts_form_for resize="auto" is the default —
   — Use resize="vertical" to match the Shoelace default —
 */
-
 = ts_form_for ... do |f|
   = f.input :expanding,
     as: :text,

--- a/docs/pages/components/textarea.md
+++ b/docs/pages/components/textarea.md
@@ -8,6 +8,55 @@ unusedProperties: |
   - Boolean `filled`
 guidelines: |
   - For additional guidelines on textarea **labels**, **help text**, **label tooltip**, **context note**, and **placeholder text**, refer to the [Input component usage guidelines](/components/input/#usage-guidelines)
+testing: |
+  ### With Cypress
+
+  **Adding `data-test-id` to a component**
+
+   To test `<sl-textarea>`, add the `data-test-id` attribute directly to the component:
+
+  ```
+    sl-textarea[
+      label="Bio"
+      data-test-id="textarea-test"
+    ]
+  ```
+
+  To test `<sl-textarea>` implemented with `ts_form_for`, add `data-test-id` to `input_html`:
+
+  ```
+    = ts_form_for ... do |f|
+      = f.input :textarea_name, 
+        as: :text,
+        input_html: { 
+          label: "Bio",
+          data: { 
+            "test_id": "textarea-test"
+          } 
+        }
+  ```
+
+  **Cypress commands for `<sl-textarea>`**
+
+  To **type** in the textarea:
+  ```
+    cy.slTextAreaType(`[data-test-id="textarea-test"]`, "This is long text to type into the textarea for testing.");
+  ```
+
+  To **get the textarea's value** (note the matcher `"have.value"`):
+  ```
+    cy.get(`[data-test-id="textarea-test"]`).should("have.value", "This is the long text value we want the textarea to have.");
+  ```
+
+  To **focus** on the textarea:
+  ```
+    cy.slFocus(`[data-test-id="textarea-test"]`);
+  ```
+
+  To **clear** the textarea:
+  ```
+    cy.slTextAreaClear(`[data-test-id="textarea-test"]`);
+  ```
 ---
 
 ## Examples

--- a/docs/pages/components/textarea.md
+++ b/docs/pages/components/textarea.md
@@ -13,7 +13,7 @@ testing: |
 
   **Adding `data-test-id` to a component**
 
-   To test `<sl-textarea>`, add the `data-test-id` attribute directly to the component:
+   To test `sl-textarea`, add the `data-test-id` attribute directly to the component:
 
   ```pug:slim
     sl-textarea[
@@ -22,7 +22,7 @@ testing: |
     ]
   ```
 
-  To test `<sl-textarea>` implemented with `ts_form_for`, add `data-test-id` to `input_html`:
+  To test `sl-textarea` implemented with `ts_form_for`, add `data-test-id` to `input_html`:
 
   ```js
     = ts_form_for ... do |f|
@@ -31,12 +31,12 @@ testing: |
         input_html: { 
           label: "Bio",
           data: { 
-            "test_id": "textarea-test"
+            test_id: "textarea-test"
           } 
         }
   ```
 
-  **Cypress commands for `<sl-textarea>`**
+  **Cypress commands for `sl-textarea`**
 
   To **type** in the textarea:
   ```js

--- a/docs/pages/components/textarea.md
+++ b/docs/pages/components/textarea.md
@@ -43,7 +43,7 @@ testing: |
     cy.slTextAreaType(`[data-test-id="textarea-test"]`, "This is long text to type into the textarea for testing.");
   ```
 
-  To **get the textarea's value** (note the matcher `"have.value"`):
+  To **check the textarea's value** (note the matcher `"have.value"`):
   ```js
     cy.get(`[data-test-id="textarea-test"]`).should("have.value", "This is the long text value we want the textarea to have.");
   ```

--- a/docs/pages/components/textarea.md
+++ b/docs/pages/components/textarea.md
@@ -294,7 +294,7 @@ Add the `filled` attribute to draw a filled textarea.
 ```
 
 ```pug:slim
-sl-textarea placeholder="Type something" filled="true"
+sl-textarea placeholder="Type something" filled=true
 ```
 
 ```jsx:react
@@ -314,7 +314,7 @@ Use the `disabled` attribute to disable a textarea.
 ```pug:slim
 sl-textarea[
   label="Disabled textarea"
-  disabled="true"
+  disabled=true
 ]
 ```
 

--- a/docs/pages/components/tooltip.md
+++ b/docs/pages/components/tooltip.md
@@ -4,9 +4,22 @@ meta:
   description: Tooltips display additional information based on a specific action.
 layout: component
 guidelines: |
-  - Tooltip content should be additional or supplemental. **Don't put essential information in a tooltip.**
-  - Keep the content simple — ideally just one or two words or a short phrase. If using sentences, try to keep below 2 sentences or 3 lines of text at maximum.
-  - Tooltips should not contain interactive elements like buttons and links or include elements like imagery
+  ### Tooltip Basics
+  - Tooltips are for supplemental content
+  - Keep tooltip content simple — ideally with just one or two words or a short phrase
+
+  ### Tooltip Don'ts
+  - **Don't** put essential information in a tooltip
+  - **Don't** put interactive elements like buttons and links in a tooltip
+  - **Don't** include elements like images in a tooltip
+
+  ### When to Use a Tooltip
+  - Use to provide brief supplemental (but not essential) information on hover
+    - For example, a trash icon with the word "Delete" in a tooltip, to reinforce the purpose of the icon
+    - Or a disabled "Submit" button with the words "Complete required fields" in a tooltip, to remind people why the button is disabled
+
+  ### When to Use Something Else
+  - If the supplemental information requires the use of imagery, links, or other interactions, consider a [Popup](/components/popup) or [Drawer](/components/drawer)
 ---
 
 ## Examples

--- a/docs/pages/components/tooltip.md
+++ b/docs/pages/components/tooltip.md
@@ -555,7 +555,7 @@ Tooltips will be clipped if they're inside a container that has `overflow: auto|
 div.tooltip-hoist
   sl-tooltip content="This is a tooltip"
     sl-button No Hoist
-  sl-tooltip content="This is a tooltip" hoist="true"
+  sl-tooltip content="This is a tooltip" hoist=true
     sl-button Hoist
 
 css:

--- a/docs/pages/components/tree-item.md
+++ b/docs/pages/components/tree-item.md
@@ -132,7 +132,7 @@ Use the `selected` attribute to select a tree item initially.
 
 ```pug:slim
 sl-tree
-  sl-tree-item selected="true"
+  sl-tree-item selected=true
     | Item 1
     sl-tree-item Item A
     sl-tree-item Item B
@@ -184,9 +184,9 @@ Use the `expanded` attribute to expand a tree item initially.
 
 ```pug:slim
 sl-tree
-  sl-tree-item expanded="true"
+  sl-tree-item expanded=true
     | Item 1
-    sl-tree-item expanded="true"
+    sl-tree-item expanded=true
       | Item A
       sl-tree-item Item Z
       sl-tree-item Item Y

--- a/docs/pages/components/tree.md
+++ b/docs/pages/components/tree.md
@@ -251,10 +251,10 @@ Indent guides can be drawn by setting `--indent-guide-width`. You can also chang
 
 ```pug:slim
 sl-tree.tree-with-lines
-  sl-tree-item expanded="true"
+  sl-tree-item expanded=true
     | Deciduous
     sl-tree-item Birch
-    sl-tree-item expanded="true"
+    sl-tree-item expanded=true
       | Maple
       sl-tree-item Field maple
       sl-tree-item Red maple
@@ -351,7 +351,7 @@ If you want to disable this behavior after the first load, simply remove the `la
 
 ```pug:slim
 sl-tree
-  sl-tree-item lazy="true" Available Trees
+  sl-tree-item lazy=true Available Trees
 
 <script type="module">
   const lazyItem = document.querySelector('sl-tree-item[lazy]');
@@ -568,7 +568,7 @@ Decorative icons can be used before labels to provide hints for each node.
 
 ```pug:slim
 sl-tree.tree-with-icons
-  sl-tree-item expanded="true"
+  sl-tree-item expanded=true
     sl-icon name="folder"
     | Documents
     sl-tree-item

--- a/docs/pages/teamshares/changelog.md
+++ b/docs/pages/teamshares/changelog.md
@@ -5,6 +5,20 @@ meta:
 
 # Changelog
 
+## 2.3.0
+
+- Documentation and Figma Code Connect updates (no visible changes to components)
+  - Set up Figma Code Connect for some components
+  - Add Cypress testing docs to several form-related components
+  - Add separate `TS Form` code example panel for components that can be rendered with `ts_form_for`
+  - Update string syntax in Slim code examples to use boolean (e.g. `open=true` instead of `open='true'`)
+  - Add code example for `sl-drawer` opened from `sl-dropdown` with button trigger
+- Minor component styling updates
+  - Update `sl-divider` default color
+  - Update size of close icon (x) in `sl-alert`
+  - Update `sl-tag` font weight to medium
+  - Update spacing and hover state for `sl-tab-group` and `sl-tab` to match ViewComponent Tab
+
 ## 2.2.1
 
 - Bump to update `package-lock.json` file + update docs to make sure this step isn't forgotten next time

--- a/docs/pages/teamshares/contributing.md
+++ b/docs/pages/teamshares/contributing.md
@@ -141,8 +141,10 @@ Updates to the library follow our standard PR process (make a branch, make a PR,
 ### 3. Bump `design-system` to pull in the new Shoelace release
 
 1. Cut a new branch from latest `main` on `design-system`
-1. Update `package.json` file to pull in new `@teamshares/shoelace` version
-1. Add a `CHANGELOG.MD entry`
+1. Update `package.json` file:
+   1. To pull in new `@teamshares/shoelace` version
+   1. Also bump the `design-system` version
+1. Add a `CHANGELOG.MD entry` for the new version
 1. Run `yarn install`
    1. Make sure `yarn.lock` updates
 1. Open PR

--- a/docs/pages/teamshares/contributing.md
+++ b/docs/pages/teamshares/contributing.md
@@ -33,7 +33,9 @@ Because the system is shared across all our apps, we need to make sure that any 
 
    Once you've made your changes and they're ready for feedback, make a PR and one of the core library maintainers will review the code to make sure it adheres to the [best practices](/resources/contributing?id=best-practices).
 
-   !> **Caution:** Don't accidentally open a PR against the upstream repository (Shoelace itself). Many Git tools, such as Github Desktop, will default to this behavior. Doing so will expose our codebase to anyone looking at the main Shoelace repository. While `@teamshares/shoelace` is technically public, it's best to keep things in-house.
+   :::warning
+   **Caution: Don't accidentally open a PR against the upstream repository (Shoelace itself).** Many Git tools, such as Github Desktop, will default to this behavior. Doing so will expose our codebase to anyone looking at the main Shoelace repository. While `@teamshares/shoelace` is technically public, it's best to keep things in-house.
+   :::
 
 ## Installation
 

--- a/docs/pages/teamshares/link.md
+++ b/docs/pages/teamshares/link.md
@@ -81,7 +81,7 @@ sl-button variant="text" size="medium" href="https://example.com/" target="_blan
 
 ## Usage
 
-**When to Use the Default Link Style vs the Text Button**
+### When to Use the Default Link Style vs the Text Button
 
 - Use the **default link style** for inline links that appear within a sentence or paragraph. The visible underline helps to differentiate the link text from the plain text.
 

--- a/docs/pages/teamshares/recipes/cypress.md
+++ b/docs/pages/teamshares/recipes/cypress.md
@@ -7,9 +7,13 @@ meta:
 
 > Tips for testing Shoelace components with Cypress
 
-## TL;DR:
+## TL;DR
 
-For the most part, you can use Shoelace components the same way you'd use their HTML equivalents, since they emit many of the same events (`click`, `focus`, etc). But like all web components, Shoelace components encapsulate their internal parts within the [shadow dom](https://css-tricks.com/styling-in-the-shadow-dom-with-css-shadow-parts/). This means that the internals of Shoelace components aren't available directly on the DOM (via `document.querySelector`, etc.), but have to be queried via the [`Element.shadowRoot` property](https://developer.mozilla.org/en-US/docs/Web/API/Element/shadowRoot).
+For the most part, you can use Shoelace components the same way you'd use their HTML equivalents, since they emit many of the same events (`click`, `focus`, etc).
+
+But like all web components, Shoelace components encapsulate their internal parts within the [shadow dom](https://css-tricks.com/styling-in-the-shadow-dom-with-css-shadow-parts/).
+
+This means that the internals of Shoelace components aren't available directly on the DOM (via `document.querySelector`, etc.), but have to be queried via the [`Element.shadowRoot` property](https://developer.mozilla.org/en-US/docs/Web/API/Element/shadowRoot).
 
 Cypress provides a convenience method for accessing the shadow dom via the [`.shadow()` method.](https://docs.cypress.io/api/commands/shadow).
 
@@ -18,4 +22,196 @@ cy.get('sl-button[href]').shadow().find('a'); // Will find the anchor tag within
 cy.get('[data-test-id="some_sl_button"]').click(); // Should work fine on a button where id is set at the top level
 ```
 
-More tips coming soon! (And remember, _you too_ are free to contribute to this guide!)
+### Cypress Commands Cheat Sheet
+
+<div class="cy-table-desc">This is a quick reference guide to common test actions for form components.</div>
+
+| Component             | Test action                        | Cypress Command                                                        |
+| --------------------- | ---------------------------------- | ---------------------------------------------------------------------- |
+| **Checkbox**          | <span>check</span>                 | [`cy.slCheckboxCheck()`](#cy_slcheckboxcheck)                          |
+|                       | <span>uncheck</span>               | [`cy.slCheckboxUncheck()`](#cy_slcheckboxuncheck)                      |
+|                       | <span>is checked?</span>           | [`cy.get().should("have.prop", "checked", true)`](#shouldhave_prop)    |
+|                       | <span>is not checked?</span>       | [`cy.get().should("have.prop", "checked", false)`](#shouldhave_prop)   |
+| **Checkbox Group**    | <span>check</span>                 | [`cy.slCheckboxCheck()`](#cy_slcheckboxcheck)                          |
+|                       | <span>uncheck</span>               | [`cy.slCheckboxUncheck()`](#cy_slcheckboxuncheck)                      |
+|                       | <span>items checked?</span>        | [`cy.slCheckboxGroupValue()`](#cy_slcheckboxgroupvalue)                |
+|                       | <span>items not checked?</span>    | [`cy.get().should("not.have.value", "value")`](#shouldhave_value)      |
+| **Input**             | <span>focus</span>                 | [`cy.slFocus()`](#cy_slfocus)                                          |
+|                       | <span>type</span>                  | [`cy.slInputType()`](#cy_slinputtype)                                  |
+|                       | <span>clear</span>                 | [`cy.slClear()`](#cy_slclear)                                          |
+|                       | <span>value?</span>                | [`cy.get().should("have.value", "value")`](#shouldhave_value)          |
+| **Radio/Radio Group** | <span>select radio in group</span> | [`cy.get().click()`](#click)                                           |
+|                       | <span>radio selected?</span>       | [`cy.get().should("have.value", "value")`](#shouldhave_value)          |
+|                       | <span>radio not selected?</span>   | [`cy.get().should("not.have.value", "value")`](#shouldhave_value)      |
+| **Select**            | <span>select option</span>         | [`cy.slSelectByOptionText()`](#cy_slselectbyoptiontext)                |
+|                       | <span>option selected?</span>      | [`cy.slSelectValue().should("equal", "value")`](#cy_slselectvalue)     |
+|                       | <span>option not selected?</span>  | [`cy.slSelectValue().should("not.equal", "value")`](#cy_slselectvalue) |
+| **Textarea**          | <span>focus</span>                 | [`cy.slFocus()`](#cy_slfocus)                                          |
+|                       | <span>type</span>                  | [`cy.slTextAreaType()`](#cy_sltextareatype)                            |
+|                       | <span>clear</span>                 | [`cy.slTextAreaClear()`](#cy_sltextareaclear)                          |
+|                       | <span>value?</span>                | [`cy.get().should("have.value", "value")`](#shouldhave_value)          |
+
+## Generic Commands
+
+The following are generic Cypress commands that can be used for testing Shoelace design system components:
+
+### `click()`
+
+Use to **click** an element like [sl-button](/components/button) or radio item in [sl-radio-group](/components/radio-group/#with-cypress):
+
+```js
+cy.get(`[data-test-id="item-test-1"]`).click();
+```
+
+:::tip
+What other elements does this work for?
+:::
+
+### `should('have.prop')`
+
+Use on boolean elements like [sl-checkbox](/components/checkbox/#with-cypress) and [sl-switch](/components/switch/#with-cypress) to verify whether the input is checked:
+
+```js
+cy.get(`[data-test-id="checkbox-checked"]`).should('have.prop', 'checked', true);
+cy.get(`[data-test-id="checkbox-not-checked"]`).should('have.prop', 'checked', false);
+```
+
+### `should('have.value')`
+
+Use to check an input's value. Can be used for text inputs like [sl-input](/components/input/#with-cypress), [sl-textarea](/components/textarea/#with-cypress):
+
+```js
+cy.get(`[data-test-id="input-test"]`).should('have.value', 'Your text here');
+```
+
+Also for checking the value of [sl-radio-group](/components/radio-group/#with-cypress):
+
+```js
+cy.get(`[data-test-id="checkbox-group-test"]`).should('have.value', 'option-3');
+```
+
+Can also use to verify that an input does **NOT** have a certain value:
+
+```js
+cy.get(`[data-test-id="checkbox-group-test"]`).should('not.have.value', 'option-1');
+```
+
+:::tip
+Does this also work for Checkbox Group? Select?
+:::
+
+## Custom Commands
+
+The following are custom Cypress commands created for testing Shoelace design system components:
+
+### `cy.slCheckboxCheck()`
+
+Use to **check** boolean elements like [sl-checkbox](/components/checkbox/#with-cypress), [sl-switch](/components/switch/#with-cypress):
+
+```js
+cy.slCheckboxCheck(`[data-test-id="checkbox-test"]`);
+```
+
+### `cy.slCheckboxUncheck()`
+
+Use to **uncheck** boolean elements like [sl-checkbox](/components/checkbox/#with-cypress), [sl-switch](/components/switch/#with-cypress):
+
+```js
+cy.slCheckboxUncheck(`[data-test-id="checkbox-test"]`);
+```
+
+### `cy.slCheckboxGroupValue()`
+
+Use to check the **value** of [sl-checkbox-group](/components/checkbox-group/#with-cypress):
+
+```js
+cy.slCheckboxGroupValue(`[data-test-id="checkbox-group-test"]`, ['option-1', 'option-2']);
+```
+
+### `cy.slInputType()`
+
+Use to **type** in [sl-input](/components/input/#with-cypress):
+
+```js
+cy.slInputType('[data-test-id="input-test"]', 'Your text here');
+```
+
+### `cy.slTextAreaType()`
+
+Use to **type** in [sl-textarea](/components/textarea/#with-cypress):
+
+```js
+cy.slTextAreaType(`[data-test-id="textarea-test"]`, 'This is long text to type into the textarea for testing.');
+```
+
+### `cy.slFocus()`
+
+Use to **focus** on elements like [sl-input](/components/input/#with-cypress) and [sl-textarea](/components/textarea/#with-cypress):
+
+```js
+cy.slFocus(`[data-test-id="input-test"]`);
+```
+
+:::tip
+What other elements does this work for?
+:::
+
+### `cy.slClear()`
+
+Use to **clear** [sl-input](/components/input/#with-cypress):
+
+```js
+cy.slClear(`[data-test-id="input-test"]`);
+```
+
+:::tip
+What other elements does this work for?
+:::
+
+### `cy.slTextAreaClear()`
+
+Use to **clear** [sl-textarea](/components/textarea/#with-cypress):
+
+```js
+cy.slTextAreaClear(`[data-test-id="textarea-test"]`);
+```
+
+### `cy.slSelectByOptionText()`
+
+Use to **select** an option in [sl-select](/components/select/#with-cypress):
+
+```js
+cy.slSelectByOptionText(`[data-test-id="select-test"]`, 'Option 1');
+```
+
+### `cy.slSelectValue()`
+
+Use in [sl-select](/components/select/#with-cypress), to verify that an option **is selected**:
+
+```js
+cy.slSelectValue(`[data-test-id="select-text"]`).should('equal', 'option-1');
+```
+
+To verify that an option is **NOT selected**:
+
+```js
+cy.slSelectValue(`[data-test-id="select-text"]`).should('not.equal', 'option-2');
+```
+
+## Links to Component Documentation
+
+You can find additional documentation for testing specific components with Cypress, including where to add `data-test-id` on a component, on the following component documentation pages:
+
+- [sl-checkbox](/components/checkbox/#with-cypress)
+- [sl-checkbox-group](/components/checkbox-group/#with-cypress)
+- [sl-input](/components/input/#with-cypress)
+- [sl-radio-group](/components/radio-group/#with-cypress)
+- [sl-select](/components/select/#with-cypress)
+- [sl-switch](/components/switch/#with-cypress)
+- [sl-textarea](/components/textarea/#with-cypress)
+
+## Contributions and Questions
+
+Questions? Contributions?
+
+- Link to helpers

--- a/docs/pages/teamshares/recipes/cypress.md
+++ b/docs/pages/teamshares/recipes/cypress.md
@@ -200,7 +200,7 @@ cy.slSelectValue(`[data-test-id="select-text"]`).should('not.equal', 'option-2')
 
 ## Links to Component Documentation
 
-You can find additional documentation for testing specific components with Cypress, including where to add `data-test-id` on a component, on the following component documentation pages:
+You can find additional documentation for testing specific components with Cypress, including where to add `data-test-id` on `sl-` and `ts_form_for` components, on the following component documentation pages:
 
 - [sl-checkbox](/components/checkbox/#with-cypress)
 - [sl-checkbox-group](/components/checkbox-group/#with-cypress)
@@ -210,8 +210,8 @@ You can find additional documentation for testing specific components with Cypre
 - [sl-switch](/components/switch/#with-cypress)
 - [sl-textarea](/components/textarea/#with-cypress)
 
-## Contributions and Questions
+## Questions and Feedback
 
-Questions? Contributions?
+Are any commands not working as expected? Need a specific command for testing but not seeing it here?
 
-- Link to helpers
+Ping the `#design-system` Slack channel to let the team know!

--- a/docs/pages/teamshares/recipes/cypress.md
+++ b/docs/pages/teamshares/recipes/cypress.md
@@ -5,45 +5,18 @@ meta:
 
 # Shoelace & Cypress
 
-> Tips for testing Shoelace components with Cypress
+> Testing Shoelace components with Cypress
 
-## TL;DR
+## Cypress Commands Cheat Sheet
 
-For the most part, you can use Shoelace components the same way you'd use their HTML equivalents, since they emit many of the same events (`click`, `focus`, etc). But like all web components, Shoelace components encapsulate their internal parts within the [shadow dom](https://css-tricks.com/styling-in-the-shadow-dom-with-css-shadow-parts/).
-
-This means that the internals of Shoelace components aren't available directly on the DOM (via `document.querySelector`, etc.), but have to be queried via the [`Element.shadowRoot` property](https://developer.mozilla.org/en-US/docs/Web/API/Element/shadowRoot).
-
-Cypress provides a convenience method for accessing the shadow DOM via the [`.shadow()` method.](https://docs.cypress.io/api/commands/shadow).
-
-For example, to find the anchor tag within a link button:
-
-```js
-cy.get('sl-button[href]').shadow().find('a');
-```
-
-To click on a specific button:
-
-```js
-cy.get('[data-test-id="some_sl_button"]').click();
-```
-
-Also see below for more on testing Shoelace design system components with Cypress:
-
-- [Cypress Commands Cheat Sheet](#cypress-commands-cheat-sheet)
-- [Generic Cypress Commands](#generic-commands)
-- [Custom Cypress Commands](#custom-commands)
-- [Form Components with Cypress Documentation](#form-components-with-cypress-documentation)
-
-### Cypress Commands Cheat Sheet
-
-<div class="cy-table-desc">This is a quick reference guide to common test actions for form components.</div>
+<div class="cy-table-desc">A quick reference guide to common test actions for form components.</div>
 
 | Component             | Test action                       | Cypress command                                                        |
 | --------------------- | --------------------------------- | ---------------------------------------------------------------------- |
 | **Checkbox**          | <span>check</span>                | [`cy.slCheckboxCheck()`](#cy_slcheckboxcheck)                          |
 |                       | <span>uncheck</span>              | [`cy.slCheckboxUncheck()`](#cy_slcheckboxuncheck)                      |
-|                       | <span>is checked?</span>          | [`cy.get().should("have.prop", "checked", true)`](#shouldhave_prop)    |
-|                       | <span>is not checked?</span>      | [`cy.get().should("have.prop", "checked", false)`](#shouldhave_prop)   |
+|                       | <span>checked?</span>             | [`cy.get().should("have.prop", "checked", true)`](#shouldhave_prop)    |
+|                       | <span>not checked?</span>         | [`cy.get().should("have.prop", "checked", false)`](#shouldhave_prop)   |
 | **Checkbox Group**    | <span>value?</span>               | [`cy.slCheckboxGroupValue()`](#cy_slcheckboxgroupvalue)                |
 |                       | <span>not value?</span>           | [`cy.get().should("not.have.value", "value")`](#shouldhave_value)      |
 | **Input**             | <span>focus</span>                | [`cy.slFocus()`](#cy_slfocus)                                          |
@@ -63,7 +36,7 @@ Also see below for more on testing Shoelace design system components with Cypres
 
 ## Generic Commands
 
-The following are generic Cypress commands that can be used for testing Shoelace design system components:
+Generic Cypress commands that can be used for testing Shoelace design system components:
 
 ### `click()`
 
@@ -72,10 +45,6 @@ Use to **click** an element like [sl-button](/components/button) or radio item i
 ```js
 cy.get(`[data-test-id="item-test-1"]`).click();
 ```
-
-:::tip
-What other elements does this work for?
-:::
 
 ### `should('have.prop')`
 
@@ -106,13 +75,9 @@ Can also use to verify that an input does **NOT** have a certain value:
 cy.get(`[data-test-id="checkbox-group-test"]`).should('not.have.value', 'option-1');
 ```
 
-:::tip
-Does this also work for Checkbox Group? Select?
-:::
-
 ## Custom Commands
 
-The following are custom Cypress commands created for testing Shoelace design system components:
+Custom Cypress commands created for testing Shoelace design system components:
 
 ### `cy.slCheckboxCheck()`
 
@@ -162,10 +127,6 @@ Use to **focus** on elements like [sl-input](/components/input/#with-cypress) an
 cy.slFocus(`[data-test-id="input-test"]`);
 ```
 
-:::tip
-What other elements does this work for?
-:::
-
 ### `cy.slClear()`
 
 Use to **clear** [sl-input](/components/input/#with-cypress):
@@ -173,10 +134,6 @@ Use to **clear** [sl-input](/components/input/#with-cypress):
 ```js
 cy.slClear(`[data-test-id="input-test"]`);
 ```
-
-:::tip
-What other elements does this work for?
-:::
 
 ### `cy.slTextAreaClear()`
 
@@ -219,6 +176,28 @@ You can find additional documentation for testing specific components with Cypre
 - [sl-select](/components/select/#testing)
 - [sl-switch](/components/switch/#testing)
 - [sl-textarea](/components/textarea/#testing)
+
+## Writing Custom Cypress Commands
+
+For the most part, you can use Shoelace components the same way you'd use their HTML equivalents, since they emit many of the same events (`click`, `focus`, etc).
+
+But like all web components, Shoelace components encapsulate their internal parts within the [shadow dom](https://css-tricks.com/styling-in-the-shadow-dom-with-css-shadow-parts/).
+
+This means that the internals of Shoelace components aren't available directly on the DOM (via `document.querySelector`, etc.), but have to be queried via the [`Element.shadowRoot` property](https://developer.mozilla.org/en-US/docs/Web/API/Element/shadowRoot).
+
+Cypress provides a convenience method for accessing the shadow DOM via the [`.shadow()` method.](https://docs.cypress.io/api/commands/shadow).
+
+For example, to find the anchor tag within a link button:
+
+```js
+cy.get('sl-button[href]').shadow().find('a');
+```
+
+To click on a specific button:
+
+```js
+cy.get('[data-test-id="some_sl_button"]').click();
+```
 
 ## Questions and Feedback
 

--- a/docs/pages/teamshares/recipes/cypress.md
+++ b/docs/pages/teamshares/recipes/cypress.md
@@ -9,24 +9,33 @@ meta:
 
 ## TL;DR
 
-For the most part, you can use Shoelace components the same way you'd use their HTML equivalents, since they emit many of the same events (`click`, `focus`, etc).
-
-But like all web components, Shoelace components encapsulate their internal parts within the [shadow dom](https://css-tricks.com/styling-in-the-shadow-dom-with-css-shadow-parts/).
+For the most part, you can use Shoelace components the same way you'd use their HTML equivalents, since they emit many of the same events (`click`, `focus`, etc). But like all web components, Shoelace components encapsulate their internal parts within the [shadow dom](https://css-tricks.com/styling-in-the-shadow-dom-with-css-shadow-parts/).
 
 This means that the internals of Shoelace components aren't available directly on the DOM (via `document.querySelector`, etc.), but have to be queried via the [`Element.shadowRoot` property](https://developer.mozilla.org/en-US/docs/Web/API/Element/shadowRoot).
 
-Cypress provides a convenience method for accessing the shadow dom via the [`.shadow()` method.](https://docs.cypress.io/api/commands/shadow).
+Cypress provides a convenience method for accessing the shadow DOM via the [`.shadow()` method.](https://docs.cypress.io/api/commands/shadow).
+
+For example, to find the anchor tag within a link button:
 
 ```js
-cy.get('sl-button[href]').shadow().find('a'); // Will find the anchor tag within a link button
-cy.get('[data-test-id="some_sl_button"]').click(); // Should work fine on a button where id is set at the top level
+cy.get('sl-button[href]').shadow().find('a');
 ```
+
+To click on a specific button:
+
+```js
+cy.get('[data-test-id="some_sl_button"]').click();
+```
+
+Read on for more details on using Cypress for testing Shoelace design system components, including a quick [Cypress Commands Cheat Sheet](#cypress-commands-cheat-sheet), as well as more detailed examples for [Generic Commands](#generic-commands) and [Custom Commands](#custom-commands).
+
+You can also find component-specific testing documentation for some [form-related components](#links-to-component-documentation) on that component's documentation page.
 
 ### Cypress Commands Cheat Sheet
 
 <div class="cy-table-desc">This is a quick reference guide to common test actions for form components.</div>
 
-| Component             | Test action                        | Cypress Command                                                        |
+| Component             | Test action                        | Cypress command                                                        |
 | --------------------- | ---------------------------------- | ---------------------------------------------------------------------- |
 | **Checkbox**          | <span>check</span>                 | [`cy.slCheckboxCheck()`](#cy_slcheckboxcheck)                          |
 |                       | <span>uncheck</span>               | [`cy.slCheckboxUncheck()`](#cy_slcheckboxuncheck)                      |
@@ -63,9 +72,9 @@ Use to **click** an element like [sl-button](/components/button) or radio item i
 cy.get(`[data-test-id="item-test-1"]`).click();
 ```
 
-:::tip
+<!-- :::tip
 What other elements does this work for?
-:::
+::: -->
 
 ### `should('have.prop')`
 
@@ -96,9 +105,9 @@ Can also use to verify that an input does **NOT** have a certain value:
 cy.get(`[data-test-id="checkbox-group-test"]`).should('not.have.value', 'option-1');
 ```
 
-:::tip
+<!-- :::tip
 Does this also work for Checkbox Group? Select?
-:::
+::: -->
 
 ## Custom Commands
 
@@ -152,9 +161,9 @@ Use to **focus** on elements like [sl-input](/components/input/#with-cypress) an
 cy.slFocus(`[data-test-id="input-test"]`);
 ```
 
-:::tip
+<!-- :::tip
 What other elements does this work for?
-:::
+::: -->
 
 ### `cy.slClear()`
 
@@ -164,9 +173,9 @@ Use to **clear** [sl-input](/components/input/#with-cypress):
 cy.slClear(`[data-test-id="input-test"]`);
 ```
 
-:::tip
+<!-- :::tip
 What other elements does this work for?
-:::
+::: -->
 
 ### `cy.slTextAreaClear()`
 
@@ -202,16 +211,16 @@ cy.slSelectValue(`[data-test-id="select-text"]`).should('not.equal', 'option-2')
 
 You can find additional documentation for testing specific components with Cypress, including where to add `data-test-id` on `sl-` and `ts_form_for` components, on the following component documentation pages:
 
-- [sl-checkbox](/components/checkbox/#with-cypress)
-- [sl-checkbox-group](/components/checkbox-group/#with-cypress)
-- [sl-input](/components/input/#with-cypress)
-- [sl-radio-group](/components/radio-group/#with-cypress)
-- [sl-select](/components/select/#with-cypress)
-- [sl-switch](/components/switch/#with-cypress)
-- [sl-textarea](/components/textarea/#with-cypress)
+- [sl-checkbox](/components/checkbox/#testing)
+- [sl-checkbox-group](/components/checkbox-group/#testing)
+- [sl-input](/components/input/#testing)
+- [sl-radio-group](/components/radio-group/#testing)
+- [sl-select](/components/select/#testing)
+- [sl-switch](/components/switch/#testing)
+- [sl-textarea](/components/textarea/#testing)
 
 ## Questions and Feedback
 
-Are any commands not working as expected? Need a specific command for testing but not seeing it here?
+Commands not working as expected? Need a specific command for testing but not seeing it here?
 
 Ping the `#design-system` Slack channel to let the team know!

--- a/docs/pages/teamshares/recipes/cypress.md
+++ b/docs/pages/teamshares/recipes/cypress.md
@@ -38,30 +38,28 @@ Also see below for more on testing Shoelace design system components with Cypres
 
 <div class="cy-table-desc">This is a quick reference guide to common test actions for form components.</div>
 
-| Component             | Test action                        | Cypress command                                                        |
-| --------------------- | ---------------------------------- | ---------------------------------------------------------------------- |
-| **Checkbox**          | <span>check</span>                 | [`cy.slCheckboxCheck()`](#cy_slcheckboxcheck)                          |
-|                       | <span>uncheck</span>               | [`cy.slCheckboxUncheck()`](#cy_slcheckboxuncheck)                      |
-|                       | <span>is checked?</span>           | [`cy.get().should("have.prop", "checked", true)`](#shouldhave_prop)    |
-|                       | <span>is not checked?</span>       | [`cy.get().should("have.prop", "checked", false)`](#shouldhave_prop)   |
-| **Checkbox Group**    | <span>check</span>                 | [`cy.slCheckboxCheck()`](#cy_slcheckboxcheck)                          |
-|                       | <span>uncheck</span>               | [`cy.slCheckboxUncheck()`](#cy_slcheckboxuncheck)                      |
-|                       | <span>items checked?</span>        | [`cy.slCheckboxGroupValue()`](#cy_slcheckboxgroupvalue)                |
-|                       | <span>items not checked?</span>    | [`cy.get().should("not.have.value", "value")`](#shouldhave_value)      |
-| **Input**             | <span>focus</span>                 | [`cy.slFocus()`](#cy_slfocus)                                          |
-|                       | <span>type</span>                  | [`cy.slInputType()`](#cy_slinputtype)                                  |
-|                       | <span>clear</span>                 | [`cy.slClear()`](#cy_slclear)                                          |
-|                       | <span>value?</span>                | [`cy.get().should("have.value", "value")`](#shouldhave_value)          |
-| **Radio/Radio Group** | <span>select radio in group</span> | [`cy.get().click()`](#click)                                           |
-|                       | <span>radio selected?</span>       | [`cy.get().should("have.value", "value")`](#shouldhave_value)          |
-|                       | <span>radio not selected?</span>   | [`cy.get().should("not.have.value", "value")`](#shouldhave_value)      |
-| **Select**            | <span>select option</span>         | [`cy.slSelectByOptionText()`](#cy_slselectbyoptiontext)                |
-|                       | <span>option selected?</span>      | [`cy.slSelectValue().should("equal", "value")`](#cy_slselectvalue)     |
-|                       | <span>option not selected?</span>  | [`cy.slSelectValue().should("not.equal", "value")`](#cy_slselectvalue) |
-| **Textarea**          | <span>focus</span>                 | [`cy.slFocus()`](#cy_slfocus)                                          |
-|                       | <span>type</span>                  | [`cy.slTextAreaType()`](#cy_sltextareatype)                            |
-|                       | <span>clear</span>                 | [`cy.slTextAreaClear()`](#cy_sltextareaclear)                          |
-|                       | <span>value?</span>                | [`cy.get().should("have.value", "value")`](#shouldhave_value)          |
+| Component             | Test action                       | Cypress command                                                        |
+| --------------------- | --------------------------------- | ---------------------------------------------------------------------- |
+| **Checkbox**          | <span>check</span>                | [`cy.slCheckboxCheck()`](#cy_slcheckboxcheck)                          |
+|                       | <span>uncheck</span>              | [`cy.slCheckboxUncheck()`](#cy_slcheckboxuncheck)                      |
+|                       | <span>is checked?</span>          | [`cy.get().should("have.prop", "checked", true)`](#shouldhave_prop)    |
+|                       | <span>is not checked?</span>      | [`cy.get().should("have.prop", "checked", false)`](#shouldhave_prop)   |
+| **Checkbox Group**    | <span>value?</span>               | [`cy.slCheckboxGroupValue()`](#cy_slcheckboxgroupvalue)                |
+|                       | <span>not value?</span>           | [`cy.get().should("not.have.value", "value")`](#shouldhave_value)      |
+| **Input**             | <span>focus</span>                | [`cy.slFocus()`](#cy_slfocus)                                          |
+|                       | <span>type</span>                 | [`cy.slInputType()`](#cy_slinputtype)                                  |
+|                       | <span>clear</span>                | [`cy.slClear()`](#cy_slclear)                                          |
+|                       | <span>value?</span>               | [`cy.get().should("have.value", "value")`](#shouldhave_value)          |
+| **Radio/Radio Group** | <span>select radio</span>         | [`cy.get().click()`](#click)                                           |
+|                       | <span>value?</span>               | [`cy.get().should("have.value", "value")`](#shouldhave_value)          |
+|                       | <span>not value?</span>           | [`cy.get().should("not.have.value", "value")`](#shouldhave_value)      |
+| **Select**            | <span>select option</span>        | [`cy.slSelectByOptionText()`](#cy_slselectbyoptiontext)                |
+|                       | <span>option selected?</span>     | [`cy.slSelectValue().should("equal", "value")`](#cy_slselectvalue)     |
+|                       | <span>option not selected?</span> | [`cy.slSelectValue().should("not.equal", "value")`](#cy_slselectvalue) |
+| **Textarea**          | <span>focus</span>                | [`cy.slFocus()`](#cy_slfocus)                                          |
+|                       | <span>type</span>                 | [`cy.slTextAreaType()`](#cy_sltextareatype)                            |
+|                       | <span>clear</span>                | [`cy.slTextAreaClear()`](#cy_sltextareaclear)                          |
+|                       | <span>value?</span>               | [`cy.get().should("have.value", "value")`](#shouldhave_value)          |
 
 ## Generic Commands
 
@@ -75,9 +73,9 @@ Use to **click** an element like [sl-button](/components/button) or radio item i
 cy.get(`[data-test-id="item-test-1"]`).click();
 ```
 
-<!-- :::tip
+:::tip
 What other elements does this work for?
-::: -->
+:::
 
 ### `should('have.prop')`
 
@@ -108,9 +106,9 @@ Can also use to verify that an input does **NOT** have a certain value:
 cy.get(`[data-test-id="checkbox-group-test"]`).should('not.have.value', 'option-1');
 ```
 
-<!-- :::tip
+:::tip
 Does this also work for Checkbox Group? Select?
-::: -->
+:::
 
 ## Custom Commands
 
@@ -164,9 +162,9 @@ Use to **focus** on elements like [sl-input](/components/input/#with-cypress) an
 cy.slFocus(`[data-test-id="input-test"]`);
 ```
 
-<!-- :::tip
+:::tip
 What other elements does this work for?
-::: -->
+:::
 
 ### `cy.slClear()`
 
@@ -176,9 +174,9 @@ Use to **clear** [sl-input](/components/input/#with-cypress):
 cy.slClear(`[data-test-id="input-test"]`);
 ```
 
-<!-- :::tip
+:::tip
 What other elements does this work for?
-::: -->
+:::
 
 ### `cy.slTextAreaClear()`
 

--- a/docs/pages/teamshares/recipes/cypress.md
+++ b/docs/pages/teamshares/recipes/cypress.md
@@ -27,9 +27,12 @@ To click on a specific button:
 cy.get('[data-test-id="some_sl_button"]').click();
 ```
 
-Read on for more details on using Cypress for testing Shoelace design system components, including a quick [Cypress Commands Cheat Sheet](#cypress-commands-cheat-sheet), as well as more detailed examples for [Generic Commands](#generic-commands) and [Custom Commands](#custom-commands).
+Also see below for more on testing Shoelace design system components with Cypress:
 
-You can also find component-specific testing documentation for some [form-related components](#links-to-component-documentation) on that component's documentation page.
+- [Cypress Commands Cheat Sheet](#cypress-commands-cheat-sheet)
+- [Generic Cypress Commands](#generic-commands)
+- [Custom Cypress Commands](#custom-commands)
+- [Form Components with Cypress Documentation](#form-components-with-cypress-documentation)
 
 ### Cypress Commands Cheat Sheet
 
@@ -207,7 +210,7 @@ To verify that an option is **NOT selected**:
 cy.slSelectValue(`[data-test-id="select-text"]`).should('not.equal', 'option-2');
 ```
 
-## Links to Component Documentation
+## Form Components with Cypress Documentation
 
 You can find additional documentation for testing specific components with Cypress, including where to add `data-test-id` on `sl-` and `ts_form_for` components, on the following component documentation pages:
 

--- a/docs/pages/tokens/ts-border-radius.md
+++ b/docs/pages/tokens/ts-border-radius.md
@@ -9,10 +9,10 @@ toc: false
 
 > Border radius tokens and classes are used to give sharp edges a more subtle, rounded effect.
 
-<sl-card class="token-style" id="border-radius-grid" style="margin-top: var(--ts-spacing-2x-large);">
+<sl-card class="token-style" id="three-col-grid" style="margin-top: var(--ts-spacing-2x-large);">
   <div slot="header" class="token-style--header">
     <div>Example, value &amp; usage</div>
-    <div>Tailwind class / Figma local variable</div>
+    <div>Tailwind class / Figma variable</div>
     <div>Shoelace token</div>
   </div>
   <div class="token-style">

--- a/docs/pages/tokens/ts-border-radius.md
+++ b/docs/pages/tokens/ts-border-radius.md
@@ -9,11 +9,10 @@ toc: false
 
 > Border radius tokens and classes are used to give sharp edges a more subtle, rounded effect.
 
-<sl-card class="token-style" style="margin-top: var(--ts-spacing-2x-large);">
+<sl-card class="token-style" id="border-radius-grid" style="margin-top: var(--ts-spacing-2x-large);">
   <div slot="header" class="token-style--header">
     <div>Example, value &amp; usage</div>
-    <div>Tailwind class</div>
-    <div>Figma variable</div>
+    <div>Tailwind class / Figma local variable</div>
     <div>Shoelace token</div>
   </div>
   <div class="token-style">
@@ -22,7 +21,6 @@ toc: false
     <div>Used for small elements like checkbox, tag, tooltip</div>
   </div>
     <div><code>rounded</code></div>
-    <div><code>x-small</code></div>
     <div><code>--ts-border-radius-x-small</code></div>
   </div>
   <div class="token-style">
@@ -31,7 +29,6 @@ toc: false
     <div>Used for small inputs only</div>
   </div>
     <div><code>rounded-md</code></div>
-    <div><code>small</code></div>
     <div><code>--ts-border-radius-small</code></div>
   </div>
   <div class="token-style">
@@ -40,7 +37,6 @@ toc: false
     <div>Used for larger elements like cards, inputs, selects</div>
   </div>
     <div><code>rounded-lg</code></div>
-    <div><code>large</code></div>
     <div><code>--sl-border-radius-large</code></div>
   </div>
   <div class="token-style">
@@ -49,7 +45,6 @@ toc: false
     <div>Used for dialog (modal) only</div>
   </div>
     <div><code>rounded-2xl</code></div>
-    <div><code>x-large</code></div>
     <div><code>--sl-border-radius-x-large</code></div>
   </div>
   <div class="token-style">
@@ -58,7 +53,6 @@ toc: false
     <div>Used for pill shaped elements like the button</div>
   </div>
     <div><code>rounded-full</code></div>
-    <div><code>pill</code></div>
     <div><code>--sl-border-radius-pill</code></div>
   </div>
 </sl-card>

--- a/docs/pages/tokens/ts-spacing.md
+++ b/docs/pages/tokens/ts-spacing.md
@@ -9,10 +9,10 @@ toc: false
 
 > Spacing tokens and classes are used to create consistent spacing between components and content. We use a base-4 progressive scale.
 
-<sl-card class="token-style" id="spacing-grid" style="margin-top: var(--ts-spacing-2x-large);">
+<sl-card class="token-style" id="three-col-grid" style="margin-top: var(--ts-spacing-2x-large);">
   <div slot="header" class="token-style--header">
     <div>Example &amp; value</div>
-    <div>Tailwind class / Figma local variable </div>
+    <div>Tailwind class / Figma variable</div>
     <div>Shoelace token</div>
   </div>
   <div class="token-style">

--- a/docs/pages/tokens/ts-spacing.md
+++ b/docs/pages/tokens/ts-spacing.md
@@ -9,88 +9,76 @@ toc: false
 
 > Spacing tokens and classes are used to create consistent spacing between components and content. We use a base-4 progressive scale.
 
-<sl-card class="token-style" style="margin-top: var(--ts-spacing-2x-large);">
+<sl-card class="token-style" id="spacing-grid" style="margin-top: var(--ts-spacing-2x-large);">
   <div slot="header" class="token-style--header">
     <div>Example &amp; value</div>
-    <div>Tailwind classes</div>
-    <div>Figma variable</div>
+    <div>Tailwind class / Figma local variable </div>
     <div>Shoelace token</div>
   </div>
   <div class="token-style">
     <div><div class="spacing-demo" style="width: var(--sl-spacing-3x-small); height: var(--sl-spacing-3x-small); margin-bottom: var(--sl-spacing-x-small);"></div>
     <span style="font-weight: var(--ts-font-semibold);">0.125rem (2px)</span></div>
     <div><code>p-0.5</code>, <code>m-0.5</code>...</div>
-    <div><code>3x-small</code></div>
     <div><code>--sl-spacing-3x-small</code></div>
   </div>
   <div class="token-style">
     <div><div class="spacing-demo" style="width: var(--sl-spacing-2x-small); height: var(--sl-spacing-2x-small); margin-bottom: var(--sl-spacing-x-small);"></div>
     <span style="font-weight: var(--ts-font-semibold);">0.25rem (4px)</span></div>
     <div><code>p-1</code>, <code>m-1</code>...</div>
-    <div><code>2x-small</code></div>
     <div><code>--sl-spacing-2x-small</code></div>
   </div>
   <div class="token-style">
     <div><div class="spacing-demo" style="width: var(--sl-spacing-x-small); height: var(--sl-spacing-x-small); margin-bottom: var(--sl-spacing-x-small);"></div>
     <span style="font-weight: var(--ts-font-semibold);">0.5rem (8px)</span></div>
     <div><code>p-2</code>, <code>m-2</code>...</div>
-    <div><code>x-small</code></div>
     <div><code>--sl-spacing-x-small</code></div>
   </div>
   <div class="token-style">
     <div><div class="spacing-demo" style="width: var(--sl-spacing-small); height: var(--sl-spacing-small); margin-bottom: var(--sl-spacing-x-small);"></div>
     <span style="font-weight: var(--ts-font-semibold);">0.75rem (12px)</span></div>
     <div><code>p-3</code>, <code>m-3</code>...</div>
-    <div><code>small</code></div>
     <div><code>--sl-spacing-small</code></div>
   </div>
   <div class="token-style">
     <div><div class="spacing-demo" style="width: var(--sl-spacing-medium); height: var(--sl-spacing-medium); margin-bottom: var(--sl-spacing-x-small);"></div>
     <span style="font-weight: var(--ts-font-semibold);">1rem (16px)</span></div>
     <div><code>p-4</code>, <code>m-4</code>...</div>
-    <div><code>medium</code></div>
     <div><code>--sl-spacing-medium</code></div>
   </div>
   <div class="token-style">
     <div><div class="spacing-demo" style="width: var(--sl-spacing-large); height: var(--sl-spacing-large); margin-bottom: var(--sl-spacing-x-small);"></div>
     <span style="font-weight: var(--ts-font-semibold);">1.25rem (20px)</span></div>
     <div><code>p-5</code>, <code>m-5</code>...</div>
-    <div><code>large</code></div>
     <div><code>--sl-spacing-large</code></div>
   </div>
   <div class="token-style">
     <div><div class="spacing-demo" style="width: var(--ts-spacing-large); height: var(--ts-spacing-large); margin-bottom: var(--sl-spacing-x-small);"></div>
     <span style="font-weight: var(--ts-font-semibold);">1.5rem (24px)</span></div>
     <div><code>p-6</code>, <code>m-6</code>...</div>
-    <div><code>ts-large</code></div>
     <div><code>--ts-spacing-large</code> (Shoelace <code>x-large</code> token is 28px and not in our scale)</div>
   </div>
   <div class="token-style">
     <div><div class="spacing-demo" style="width: var(--ts-spacing-2x-large); height: var(--ts-spacing-2x-large); margin-bottom: var(--sl-spacing-x-small);"></div>
     <span style="font-weight: var(--ts-font-semibold);">2rem (32px)</span></div>
     <div><code>p-8</code>, <code>m-8</code>...</div>
-    <div><code>2x-large</code></div>
     <div><code>--ts-spacing-2x-large</code> (Shoelace <code>2x-large</code> token is 36px and not in our scale)</div>
   </div>
   <div class="token-style">
     <div><div class="spacing-demo" style="width: var(--sl-spacing-3x-large); height: var(--sl-spacing-3x-large); margin-bottom: var(--sl-spacing-x-small);"></div>
     <span style="font-weight: var(--ts-font-semibold);">3rem (48px)</span></div>
     <div><code>p-12</code>, <code>m-12</code>...</div>
-    <div><code>3x-large</code></div>
     <div><code>--sl-spacing-3x-large</code></div>
   </div>
   <div class="token-style">
     <div><div class="spacing-demo" style="width: var(--ts-spacing-4x-large); height: var(--ts-spacing-4x-large); margin-bottom: var(--sl-spacing-x-small);"></div>
     <span style="font-weight: var(--ts-font-semibold);">4rem (64px)</span></div>
     <div><code>p-16</code>, <code>m-16</code>...</div>
-    <div><code>4x-large</code></div>
     <div><code>--ts-spacing-4x-large</code> (Shoelace <code>4x-large</code> token is 72px and not in our scale)</div>
   </div>
   <div class="token-style">
     <div><div class="spacing-demo" style="width: var(--ts-spacing-5x-large); height: var(--ts-spacing-5x-large); margin-bottom: var(--sl-spacing-x-small);"></div>
     <span style="font-weight: var(--ts-font-semibold);">5rem (80px)</span></div>
     <div><code>p-20</code>, <code>m-20</code>...</div>
-    <div><code>5x-large</code></div>
     <div><code>--ts-spacing-5x-large</code></div>
   </div>
 </sl-card>

--- a/figma.config.json
+++ b/figma.config.json
@@ -1,0 +1,5 @@
+{
+  "codeConnect": {
+    "parser": "react"
+  }
+}

--- a/figma.config.json
+++ b/figma.config.json
@@ -1,5 +1,7 @@
 {
   "codeConnect": {
-    "parser": "react"
+    "include": ["figma_connect/**"],
+    "parser": "react",
+    "label": "Shoelace"
   }
 }

--- a/figma_connect/README.md
+++ b/figma_connect/README.md
@@ -6,7 +6,7 @@ For more about Figma Code Connect, see: [https://github.com/figma/code-connect/b
 
 ## Token access (product@) for Figma Code Connect
 
-To run figma connect commands, you'll need to pass a secure token tied to a Figma account. A token associated with the shared `product@` account has been added to doppler.
+To run figma connect commands, you'll need to have a secure token tied to a Figma account. A token associated with the shared `product@` account has been added to doppler.
 
 To set up doppler for this project, first run:
 
@@ -40,12 +40,12 @@ You can also use the Command + L shortcut key. Either method will copy the compo
 
 3. The command will create a new `.tsx` file in your main directory.
 
-4. Drag the new file into the `figma_connect` folder, and rename the file to match the pattern you see in the rest of the files in this folder.
+4. Drag the new file into the `figma_connect` folder, and rename the file with just the component name + `figma`.
 
 5. The boilerplate example in the new file can mostly be replaced with the following structure:
 
 ```
-// @ts-nocheck
+// @ts-nocheck <-- This is to stop typescript from complaining about the Code Connect code.
 
 import React from 'react';
 import figma from '@figma/code-connect';
@@ -55,8 +55,8 @@ figma.connect(
   {
     props: {
       // Code connect will try to auto-generate code here based on the
-      // structure of the Figma component, but most of this will need
-      // to be re-written
+      // structure of the Figma component. Because of the differences in structure
+      // between Figma and code components, a lot of this will need to be rewritten.
     },
     example: ({ props }) => {
       return (
@@ -67,7 +67,7 @@ figma.connect(
 );
 ```
 
-6. Follow the examples in the existing files, as well as the [Code Connect Docs](https://github.com/figma/code-connect/blob/main/docs/react.md), to set up the dynamic code snippets using Figma's [Code Connect Helpers](https://github.com/figma/code-connect/blob/main/docs/react.md).
+6. Follow the examples in the existing files, as well as the [Code Connect Docs](https://github.com/figma/code-connect/blob/main/docs/react.md), to set up the dynamic code snippets using Figma's [Code Connect Helpers](https://github.com/figma/code-connect/blob/main/docs/react.md#strings).
 
 ### To publish code connect files
 
@@ -77,4 +77,4 @@ figma.connect(
 > doppler run npx figma connect publish
 ```
 
-2. Once Code Connect files a published, they work immediately with components in the Teamshares UI library.
+2. Once Code Connect files are published, they work immediately with components in the Teamshares UI library.

--- a/figma_connect/README.md
+++ b/figma_connect/README.md
@@ -1,0 +1,80 @@
+# Figma Code Connect
+
+The `figma_connect` folder contains `tsx` files used to set up Figma Code Connect for components in the Teamshares UI Figma library.
+
+For more about Figma Code Connect, see: [https://github.com/figma/code-connect/blob/main/docs/react.md](https://github.com/figma/code-connect/blob/main/docs/react.md)
+
+## Token access (product@) for Figma Code Connect
+
+To run figma connect commands, you'll need to pass a secure token tied to a Figma account. A token associated with the shared `product@` account has been added to doppler.
+
+To set up doppler for this project, first run:
+
+```
+> doppler setup
+```
+
+Then select `shoelace` from the list of projects, then `dev` for the config.
+
+Now prefix `doppler run` before any `npx figma` commands to use the token.
+
+For example:
+
+```
+> doppler run npx figma connect publish
+```
+
+## Figma Code Connect Basics
+
+### To auto-create a new Figma Connect file
+
+1. In the Teamshares UI Figma library, right-click on the component you want to connect and choose "Copy link to selection".
+
+You can also use the Command + L shortcut key. Either method will copy the component's link to your clipboard.
+
+2. Now run the following command in your terminal, replacing "https://..." with the link you just copied:
+
+```
+> doppler run npx figma connect create "https://..."
+```
+
+3. The command will create a new `.tsx` file in your main directory.
+
+4. Drag the new file into the `figma_connect` folder, and rename the file to match the pattern you see in the rest of the files in this folder.
+
+5. The boilerplate example in the new file can mostly be replaced with the following structure:
+
+```
+// @ts-nocheck
+
+import React from 'react';
+import figma from '@figma/code-connect';
+
+figma.connect(
+  '{This should be prefilled with the link you pasted into your 'create' command}',
+  {
+    props: {
+      // Code connect will try to auto-generate code here based on the
+      // structure of the Figma component, but most of this will need
+      // to be re-written
+    },
+    example: ({ props }) => {
+      return (
+        { Example code }
+      );
+    }
+  }
+);
+```
+
+6. Follow the examples in the existing files, as well as the [Code Connect Docs](https://github.com/figma/code-connect/blob/main/docs/react.md), to set up the dynamic code snippets using Figma's [Code Connect Helpers](https://github.com/figma/code-connect/blob/main/docs/react.md).
+
+### To publish code connect files
+
+1. When you are ready to publish the files, use this command:
+
+```
+> doppler run npx figma connect publish
+```
+
+2. Once Code Connect files a published, they work immediately with components in the Teamshares UI library.

--- a/figma_connect/alert.figma.tsx
+++ b/figma_connect/alert.figma.tsx
@@ -1,0 +1,168 @@
+// @ts-nocheck
+
+import React from 'react';
+import figma from '@figma/code-connect';
+
+/* 'primary' alert */
+figma.connect(
+  'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=5387-10977&t=CpW6E8vghe64ypz8-4',
+  {
+    variant: { variant: 'primary' },
+    props: {
+      header: figma.boolean('header?', {
+        true: figma.children('alert-header'),
+        false: undefined
+      }),
+      message: figma.string('✏️ message'),
+      link: figma.boolean('link?', {
+        true: figma.children('alert-link'),
+        false: undefined
+      }),
+      closable: figma.boolean('toast?', {
+        true: figma.boolean('closable? (toast)'),
+        false: figma.boolean('closable? (inline)')
+      })
+    },
+    example: ({ header, message, link, closable }) => {
+      return (
+        <sl-alert open variant="primary" closable={closable}>
+          <sl-icon slot="icon" library="fa" name="fas-circle-info"></sl-icon>
+          {header}
+          {message}
+          {link}
+        </sl-alert>
+      );
+    }
+  }
+);
+
+/*  'success' alert */
+figma.connect(
+  'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=5387-10977&t=CpW6E8vghe64ypz8-4',
+  {
+    variant: { variant: 'success' },
+    props: {
+      header: figma.boolean('header?', {
+        true: figma.children('alert-header'),
+        false: undefined
+      }),
+      message: figma.string('✏️ message'),
+      link: figma.boolean('link?', {
+        true: figma.children('alert-link'),
+        false: undefined
+      }),
+      closable: figma.boolean('toast?', {
+        true: figma.boolean('closable? (toast)'),
+        false: figma.boolean('closable? (inline)')
+      })
+    },
+    example: ({ header, message, link, closable }) => {
+      return (
+        <sl-alert open variant="success" closable={closable}>
+          <sl-icon slot="icon" library="fa" name="fas-circle-check"></sl-icon>
+          {header}
+          {message}
+          {link}
+        </sl-alert>
+      );
+    }
+  }
+);
+
+/*  'warning' alert */
+figma.connect(
+  'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=5387-10977&t=CpW6E8vghe64ypz8-4',
+  {
+    variant: { variant: 'warning' },
+    props: {
+      header: figma.boolean('header?', {
+        true: figma.children('alert-header'),
+        false: undefined
+      }),
+      message: figma.string('✏️ message'),
+      link: figma.boolean('link?', {
+        true: figma.children('alert-link'),
+        false: undefined
+      }),
+      closable: figma.boolean('toast?', {
+        true: figma.boolean('closable? (toast)'),
+        false: figma.boolean('closable? (inline)')
+      })
+    },
+    example: ({ header, message, link, closable }) => {
+      return (
+        <sl-alert open variant="warning" closable={closable}>
+          <sl-icon slot="icon" library="fa" name="fas-triangle-exclamation"></sl-icon>
+          {header}
+          {message}
+          {link}
+        </sl-alert>
+      );
+    }
+  }
+);
+
+/*  'danger' alert */
+figma.connect(
+  'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=5387-10977&t=CpW6E8vghe64ypz8-4',
+  {
+    variant: { variant: 'danger' },
+    props: {
+      header: figma.boolean('header?', {
+        true: figma.children('alert-header'),
+        false: undefined
+      }),
+      message: figma.string('✏️ message'),
+      link: figma.boolean('link?', {
+        true: figma.children('alert-link'),
+        false: undefined
+      }),
+      closable: figma.boolean('toast?', {
+        true: figma.boolean('closable? (toast)'),
+        false: figma.boolean('closable? (inline)')
+      })
+    },
+    example: ({ header, message, link, closable }) => {
+      return (
+        <sl-alert open variant="danger" closable={closable}>
+          <sl-icon slot="icon" library="fa" name="fas-circle-exclamation"></sl-icon>
+          {header}
+          {message}
+          {link}
+        </sl-alert>
+      );
+    }
+  }
+);
+
+/*  alert-header */
+figma.connect(
+  'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=13727-4243&t=1t9I5weUxQQWez0d-4',
+  {
+    props: {
+      header: figma.string('✏️ header')
+    },
+    example: ({ header }) => {
+      return <div slot="header">{header}</div>;
+    }
+  }
+);
+
+/*  alert-link */
+figma.connect(
+  'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=13727-4245&t=86poNs8TNe4UWDAp-4',
+  {
+    props: {
+      link: figma.string('✏️ link')
+    },
+    example: ({ link }) => {
+      return (
+        <div>
+          <a href="#" class="ts-text-link">
+            {link}
+          </a>
+        </div>
+      );
+    }
+  }
+);

--- a/figma_connect/badge.figma.tsx
+++ b/figma_connect/badge.figma.tsx
@@ -1,0 +1,17 @@
+// @ts-nocheck
+
+import React from 'react';
+import figma from '@figma/code-connect';
+
+figma.connect('https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=8564-8&t=4UIXwDXcsJSneX8X-4', {
+  props: {
+    number: figma.string('✏️ number'),
+    variant: figma.enum('variant', {
+      red: 'red',
+      gray: 'gray'
+    })
+  },
+  example: ({ number, variant }) => {
+    return <sl-badge number={number} variant={variant}></sl-badge>;
+  }
+});

--- a/figma_connect/badge.figma.tsx
+++ b/figma_connect/badge.figma.tsx
@@ -5,13 +5,13 @@ import figma from '@figma/code-connect';
 
 figma.connect('https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=8564-8&t=4UIXwDXcsJSneX8X-4', {
   props: {
-    number: figma.string('✏️ number'),
     variant: figma.enum('variant', {
       red: 'red',
       gray: 'gray'
-    })
+    }),
+    number: figma.string('✏️ number')
   },
-  example: ({ number, variant }) => {
-    return <sl-badge number={number} variant={variant}></sl-badge>;
+  example: ({ variant, number }) => {
+    return <sl-badge variant={variant} number={number}></sl-badge>;
   }
 });

--- a/figma_connect/breadcrumb.figma.tsx
+++ b/figma_connect/breadcrumb.figma.tsx
@@ -1,0 +1,55 @@
+// @ts-nocheck
+
+import React from 'react';
+import figma from '@figma/code-connect';
+
+/* breadcrumb */
+figma.connect(
+  'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=7400-7322&t=86poNs8TNe4UWDAp-4',
+  {
+    props: {
+      breadcrumbItemFirst: figma.boolean('prefix', {
+        true: figma.children('*prefix'),
+        false: figma.children('*1')
+      }),
+      breadcrumbItemsRest: figma.children(['Breadcrumb 2', 'Breadcrumb 3', 'Breadcrumb 4'])
+    },
+    example: ({ breadcrumbItemFirst, breadcrumbItemsRest }) => {
+      <sl-breadcrumb>
+        {breadcrumbItemFirst}
+        {breadcrumbItemsRest}
+      </sl-breadcrumb>;
+    }
+  }
+);
+
+/* breadcrumb-item */
+figma.connect(
+  'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=7400-7168&t=86poNs8TNe4UWDAp-4',
+  {
+    props: {
+      label: figma.string('✏️ label')
+    },
+    example: ({ label }) => {
+      return <sl-breadcrumb-item>{label}</sl-breadcrumb-item>;
+    }
+  }
+);
+
+/* breadcrumb-item, with prefix */
+figma.connect(
+  'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=7400-7175&t=86poNs8TNe4UWDAp-4',
+  {
+    props: {
+      label: figma.string('✏️ label')
+    },
+    example: ({ label }) => {
+      return (
+        <sl-breadcrumb-item>
+          <sl-icon slot="prefix" library="fa" name="fas-arrow-left"></sl-icon>
+          {label}
+        </sl-breadcrumb-item>
+      );
+    }
+  }
+);

--- a/figma_connect/button.figma.tsx
+++ b/figma_connect/button.figma.tsx
@@ -25,10 +25,6 @@ figma.connect(
       }),
       outline: figma.boolean('outline?'),
       circle: figma.boolean('circle?'),
-      circleIcon: figma.boolean('circle?', {
-        true: figma.children('Icon*'),
-        false: undefined
-      }),
       prefix: figma.boolean('prefix?', {
         true: figma.children('Prefix*'),
         false: undefined
@@ -37,14 +33,18 @@ figma.connect(
         true: undefined,
         false: figma.string('✏️ label')
       }),
+      circleIcon: figma.boolean('circle?', {
+        true: figma.children('Icon*'),
+        false: undefined
+      }),
       suffix: figma.boolean('suffix?', {
         true: figma.children('Suffix*'),
         false: undefined
       })
     },
-    example: ({ variant, size, outline, circle, disabled, prefix, label, circleIcon, suffix }) => {
+    example: ({ variant, size, disabled, outline, circle, prefix, label, circleIcon, suffix }) => {
       return (
-        <sl-button variant={variant} size={size} outline={outline} circle={circle} disabled={disabled}>
+        <sl-button variant={variant} size={size} disabled={disabled} outline={outline} circle={circle}>
           {prefix}
           {label}
           {circleIcon}

--- a/figma_connect/button.figma.tsx
+++ b/figma_connect/button.figma.tsx
@@ -1,6 +1,6 @@
 // @ts-nocheck
 
-import * as React from 'react';
+import React from 'react';
 import figma from '@figma/code-connect';
 
 figma.connect('https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=2597-1219&m=dev', {

--- a/figma_connect/button.figma.tsx
+++ b/figma_connect/button.figma.tsx
@@ -26,7 +26,7 @@ figma.connect(
       outline: figma.boolean('outline?'),
       circle: figma.boolean('circle?'),
       prefix: figma.boolean('prefix?', {
-        true: figma.children('Prefix*'),
+        true: figma.children('❇️ Prefix*'),
         false: undefined
       }),
       label: figma.boolean('circle?', {
@@ -34,11 +34,11 @@ figma.connect(
         false: figma.string('✏️ label')
       }),
       circleIcon: figma.boolean('circle?', {
-        true: figma.children('Icon*'),
+        true: figma.children('❇️ Icon*'),
         false: undefined
       }),
       suffix: figma.boolean('suffix?', {
-        true: figma.children('Suffix*'),
+        true: figma.children('❇️ Suffix*'),
         false: undefined
       })
     },

--- a/figma_connect/button.figma.tsx
+++ b/figma_connect/button.figma.tsx
@@ -3,48 +3,54 @@
 import React from 'react';
 import figma from '@figma/code-connect';
 
-figma.connect('https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=2597-1219&m=dev', {
-  props: {
-    variant: figma.enum('variant', {
-      default: 'default',
-      primary: 'primary',
-      warning: 'warning',
-      danger: 'danger',
-      text: 'text'
-    }),
-    size: figma.enum('size', {
-      small: 'small',
-      medium: 'medium',
-      large: 'large',
-      'x-large': 'x-large'
-    }),
-    outline: figma.boolean('outline?'),
-    circle: figma.boolean('circle?'),
-    circleIcon: figma.boolean('circle?', {
-      true: figma.children('Icon*'),
-      false: undefined
-    }),
-    prefix: figma.boolean('prefix?', {
-      true: figma.children('Prefix*'),
-      false: undefined
-    }),
-    label: figma.boolean('circle?', {
-      true: undefined,
-      false: figma.string('✏️ label')
-    }),
-    suffix: figma.boolean('suffix?', {
-      true: figma.children('Suffix*'),
-      false: undefined
-    })
-  },
-  example: ({ label, variant, size, outline, circle, circleIcon, prefix, suffix }) => {
-    return (
-      <sl-button variant={variant} size={size} outline={outline} circle={circle}>
-        {prefix}
-        {label}
-        {circleIcon}
-        {suffix}
-      </sl-button>
-    );
+figma.connect(
+  'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=2597-1219&t=NUUDTGV2YnFjzS2O-4',
+  {
+    props: {
+      variant: figma.enum('variant', {
+        default: 'default',
+        primary: 'primary',
+        warning: 'warning',
+        danger: 'danger',
+        text: 'text'
+      }),
+      size: figma.enum('size', {
+        small: 'small',
+        medium: 'medium',
+        large: 'large',
+        'x-large': 'x-large'
+      }),
+      disabled: figma.enum('state', {
+        disabled: true
+      }),
+      outline: figma.boolean('outline?'),
+      circle: figma.boolean('circle?'),
+      circleIcon: figma.boolean('circle?', {
+        true: figma.children('Icon*'),
+        false: undefined
+      }),
+      prefix: figma.boolean('prefix?', {
+        true: figma.children('Prefix*'),
+        false: undefined
+      }),
+      label: figma.boolean('circle?', {
+        true: undefined,
+        false: figma.string('✏️ label')
+      }),
+      suffix: figma.boolean('suffix?', {
+        true: figma.children('Suffix*'),
+        false: undefined
+      })
+    },
+    example: ({ variant, size, outline, circle, disabled, prefix, label, circleIcon, suffix }) => {
+      return (
+        <sl-button variant={variant} size={size} outline={outline} circle={circle} disabled={disabled}>
+          {prefix}
+          {label}
+          {circleIcon}
+          {suffix}
+        </sl-button>
+      );
+    }
   }
-});
+);

--- a/figma_connect/button.figma.tsx
+++ b/figma_connect/button.figma.tsx
@@ -1,0 +1,50 @@
+// @ts-nocheck
+
+import * as React from 'react';
+import figma from '@figma/code-connect';
+
+figma.connect('https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=2597-1219&m=dev', {
+  props: {
+    variant: figma.enum('variant', {
+      default: 'default',
+      primary: 'primary',
+      warning: 'warning',
+      danger: 'danger',
+      text: 'text'
+    }),
+    size: figma.enum('size', {
+      small: 'small',
+      medium: 'medium',
+      large: 'large',
+      'x-large': 'x-large'
+    }),
+    outline: figma.boolean('outline?'),
+    circle: figma.boolean('circle?'),
+    circleIcon: figma.boolean('circle?', {
+      true: figma.children('Icon*'),
+      false: undefined
+    }),
+    prefix: figma.boolean('prefix?', {
+      true: figma.children('Prefix*'),
+      false: undefined
+    }),
+    label: figma.boolean('circle?', {
+      true: undefined,
+      false: figma.string('✏️ label')
+    }),
+    suffix: figma.boolean('suffix?', {
+      true: figma.children('Suffix*'),
+      false: undefined
+    })
+  },
+  example: ({ label, variant, size, outline, circle, circleIcon, prefix, suffix }) => {
+    return (
+      <sl-button variant={variant} size={size} outline={outline} circle={circle}>
+        {prefix}
+        {label}
+        {circleIcon}
+        {suffix}
+      </sl-button>
+    );
+  }
+});

--- a/figma_connect/card.figma.tsx
+++ b/figma_connect/card.figma.tsx
@@ -1,0 +1,70 @@
+// @ts-nocheck
+
+import figma from '@figma/code-connect';
+
+/* sl-card */
+figma.connect(
+  'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=14175-9261&t=98jD5uyh8t6aakic-4',
+  {
+    props: {
+      noShadow: figma.boolean('no shadow?'),
+      body: figma.children('Body'),
+      header: figma.boolean('header?', {
+        true: figma.children('Header'),
+        false: undefined
+      }),
+      footer: figma.boolean('footer?', {
+        true: figma.children('Footer'),
+        false: undefined
+      })
+    },
+    example: ({ noShadow, body, header, footer }) => {
+      return (
+        <sl-card noShadow={noShadow}>
+          {header}
+          {body}
+          {footer}
+        </sl-card>
+      );
+    }
+  }
+);
+
+/* sl-card body */
+figma.connect(
+  'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=14176-9342&t=NxCe3yCE4wrrJ4Nl-4',
+  {
+    props: {
+      bodyContent: figma.children('*')
+    },
+    example: ({ bodyContent }) => {
+      return <div>{bodyContent}</div>;
+    }
+  }
+);
+
+/* sl-card header */
+figma.connect(
+  'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=14176-9349&t=NxCe3yCE4wrrJ4Nl-4',
+  {
+    props: {
+      headerContent: figma.children('*')
+    },
+    example: ({ headerContent }) => {
+      return <div slot="header">{headerContent}</div>;
+    }
+  }
+);
+
+/* sl-card footer */
+figma.connect(
+  'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=14176-9354&t=NxCe3yCE4wrrJ4Nl-4',
+  {
+    props: {
+      footerContent: figma.children('*')
+    },
+    example: ({ footerContent }) => {
+      return <div slot="footer">{footerContent}</div>;
+    }
+  }
+);

--- a/figma_connect/checkbox.figma.tsx
+++ b/figma_connect/checkbox.figma.tsx
@@ -32,8 +32,8 @@ figma.connect(
         /* .. = f.input :foo,
         /* .. as: :boolean,
         /* .. input_html: {
-        /* .... { attribute: value,
-        /* ...... attribute: value }  */
+        /* .... label: "Label text",
+        /* .... description: "Description text", ... }  */
         <sl-checkbox
           value="checkbox-value"
           disabled={disabled}
@@ -128,13 +128,13 @@ figma.connect(
         /* .. = f.input :foo,
         /* .. as: :check_boxes,
         /* .. label: "Group label",
-        /* .. collection: [ */
-        /* ["Checkbox label 1", :checkbox-id-1, description: "Checkbox description", disabled: true], */
-        /* ["Checkbox label 2", :checkbox-id-2, description: "Checkbox description", checked: true], */
+        /* .. collection: [ 
+        /* ["Checkbox label 1", :checkbox-id-1, description: "Checkbox description", disabled: true], 
+        /* ["Checkbox label 2", :checkbox-id-2, description: "Checkbox description", checked: true], 
         /* ],
         /* .. wrapper_html: {
-        /* .... { attribute: value,
-        /* ...... attribute: value }  */
+        /* .... "help-text": "Help text",
+        /* .... "label-tooltip": "Tooltip text", ... }  */
         <sl-checkbox-group
           name="group-name"
           contained={contained}
@@ -178,13 +178,14 @@ figma.connect(
         /* .. = f.input :foo,
         /* .. as: :check_boxes,
         /* .. label: "Group label",
-        /* .. collection: [ */
-        /* ["Checkbox label 1", :checkbox-id-1, description: "Checkbox description", disabled: true], */
-        /* ["Checkbox label 2", :checkbox-id-2, description: "Checkbox description"], */
+        /* .. collection: [ 
+        /* ["Checkbox label 1", :checkbox-id-1, description: "Checkbox description", disabled: true], 
+        /* ["Checkbox label 2", :checkbox-id-2, description: "Checkbox description"], 
         /* ],
         /* .. wrapper_html: {
-        /* .... { horizontal: true,
-        /* ...... attribute: value }  */
+        /* .... horizontal: true,
+        /* .... "help-text": "Help text",
+        /* .... "label-tooltip": "Tooltip text", ... }  */
         <sl-checkbox-group
           name="group-name"
           horizontal

--- a/figma_connect/checkbox.figma.tsx
+++ b/figma_connect/checkbox.figma.tsx
@@ -81,7 +81,7 @@ figma.connect(
 
 /* selected content */
 figma.connect(
-  'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=13962-14334&t=i5tSCH2YPyEjzbRg-4',
+  'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=13962-14334&t=NxCe3yCE4wrrJ4Nl-4',
   {
     props: {
       slottedContent: figma.children('*')

--- a/figma_connect/checkbox.figma.tsx
+++ b/figma_connect/checkbox.figma.tsx
@@ -1,0 +1,202 @@
+// @ts-nocheck
+
+import React from 'react';
+import figma from '@figma/code-connect';
+
+/* sl-checkbox */
+figma.connect(
+  'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=11076-9294&t=NNGawB6i0ms5UNAf-4',
+  {
+    props: {
+      disabled: figma.enum('state', {
+        disabled: true
+      }),
+      checked: figma.boolean('checked?'),
+      contained: figma.boolean('contained?'),
+      label: figma.boolean('label?', {
+        true: figma.string('✏️ label'),
+        false: undefined
+      }),
+      description: figma.boolean('description?', {
+        true: figma.string('✏️ description'),
+        false: undefined
+      }),
+      selectedContent: figma.boolean('selected content?', {
+        true: figma.children('Selected content'),
+        false: undefined
+      })
+    },
+    example: ({ disabled, checked, contained, label, description, selectedContent }) => {
+      return (
+        /* = ts_form_for ... do |f|
+        /* .. = f.input :foo,
+        /* .. as: :boolean,
+        /* .. input_html: {
+        /* .... { attribute: value,
+        /* ...... attribute: value }  */
+        <sl-checkbox
+          value="checkbox-value"
+          disabled={disabled}
+          checked={checked}
+          contained={contained}
+          description={description}
+        >
+          {label}
+          {selectedContent}
+        </sl-checkbox>
+      );
+    }
+  }
+);
+
+/* sl-checkbox, for group only */
+figma.connect(
+  'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=13983-9458&t=3YWGeE0W4lVcmVDw-4',
+  {
+    props: {
+      disabled: figma.enum('state', {
+        disabled: true
+      }),
+      checked: figma.boolean('checked?'),
+      label: figma.string('✏️ label'),
+      description: figma.boolean('description?', {
+        true: figma.string('✏️ description'),
+        false: undefined
+      }),
+      selectedContent: figma.boolean('selected content?', {
+        true: figma.children('Selected content'),
+        false: undefined
+      })
+    },
+    example: ({ disabled, checked, label, description, selectedContent }) => {
+      return (
+        <sl-checkbox value="checkbox-value" disabled={disabled} checked={checked} description={description}>
+          {label}
+          {selectedContent}
+        </sl-checkbox>
+      );
+    }
+  }
+);
+
+/* selected content */
+figma.connect(
+  'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=13962-14334&t=i5tSCH2YPyEjzbRg-4',
+  {
+    props: {
+      slottedContent: figma.children('*')
+    },
+    example: ({ slottedContent }) => {
+      return <div slot="selected-content">{slottedContent}</div>;
+    }
+  }
+);
+
+/* sl-checkbox-group, default */
+figma.connect(
+  'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=13977-8487&t=3YWGeE0W4lVcmVDw-4',
+  {
+    variant: { 'horizontal?': 'false' },
+    props: {
+      contained: figma.boolean('contained?'),
+      label: figma.boolean('label?', {
+        true: figma.string('✏️ label'),
+        false: undefined
+      }),
+      required: figma.boolean('required?'),
+      tooltip: figma.boolean('tooltip?', {
+        true: '{Include tooltip text here}',
+        false: undefined
+      }),
+      helpText: figma.boolean('help text?', {
+        true: figma.string('✏️ help text'),
+        false: undefined
+      }),
+      checkboxList: figma.children([
+        'Checkbox 1',
+        'Checkbox 2',
+        'Checkbox 3',
+        'Checkbox 4',
+        'Checkbox 5',
+        'Checkbox 6',
+        'Checkbox 7'
+      ])
+    },
+    example: ({ contained, label, required, tooltip, helpText, checkboxList }) => {
+      return (
+        /* = ts_form_for ... do |f|
+        /* .. = f.input :foo,
+        /* .. as: :check_boxes,
+        /* .. label: "Group label",
+        /* .. collection: [ */
+        /* ["Checkbox label 1", :checkbox-id-1, description: "Checkbox description", disabled: true], */
+        /* ["Checkbox label 2", :checkbox-id-2, description: "Checkbox description", checked: true], */
+        /* ],
+        /* .. wrapper_html: {
+        /* .... { attribute: value,
+        /* ...... attribute: value }  */
+        <sl-checkbox-group
+          name="group-name"
+          contained={contained}
+          label={label}
+          required={required}
+          label-tooltip={tooltip}
+          help-text={helpText}
+        >
+          {checkboxList}
+        </sl-checkbox-group>
+      );
+    }
+  }
+);
+
+/* sl-checkbox-group, horizontal */
+figma.connect(
+  'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=13977-8487&t=3YWGeE0W4lVcmVDw-4',
+  {
+    variant: { 'horizontal?': 'true' },
+    props: {
+      contained: figma.boolean('contained?'),
+      label: figma.boolean('label?', {
+        true: figma.string('✏️ label'),
+        false: undefined
+      }),
+      required: figma.boolean('required?'),
+      tooltip: figma.boolean('tooltip?', {
+        true: '{Include tooltip text here}',
+        false: undefined
+      }),
+      helpText: figma.boolean('help text?', {
+        true: figma.string('✏️ help text'),
+        false: undefined
+      }),
+      checkboxItems: figma.children(['Checkbox 1', 'Checkbox 2', 'Checkbox 3', 'Checkbox 4'])
+    },
+    example: ({ contained, label, required, tooltip, helpText, checkboxItems }) => {
+      return (
+        /* = ts_form_for ... do |f|
+        /* .. = f.input :foo,
+        /* .. as: :check_boxes,
+        /* .. label: "Group label",
+        /* .. collection: [ */
+        /* ["Checkbox label 1", :checkbox-id-1, description: "Checkbox description", disabled: true], */
+        /* ["Checkbox label 2", :checkbox-id-2, description: "Checkbox description"], */
+        /* ],
+        /* .. wrapper_html: {
+        /* .... { horizontal: true,
+        /* ...... attribute: value }  */
+        <sl-checkbox-group
+          name="group-name"
+          horizontal
+          contained={contained}
+          label={label}
+          required={required}
+          label-tooltip={tooltip}
+          help-text={helpText}
+        >
+          {checkboxItems}
+        </sl-checkbox-group>
+      );
+    }
+  }
+);

--- a/figma_connect/divider.figma.tsx
+++ b/figma_connect/divider.figma.tsx
@@ -1,0 +1,16 @@
+// @ts-nocheck
+
+import React from 'react';
+import figma from '@figma/code-connect';
+
+figma.connect(
+  'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=13662-6967&t=nKUmVuBTwC6GFu1I-4',
+  {
+    props: {
+      vertical: figma.boolean('vertical?')
+    },
+    example: ({ vertical }) => {
+      return <sl-divider vertical={vertical}></sl-divider>;
+    }
+  }
+);

--- a/figma_connect/icon-button.figma.tsx
+++ b/figma_connect/icon-button.figma.tsx
@@ -7,19 +7,19 @@ figma.connect(
   'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=2621-1914&t=NUUDTGV2YnFjzS2O-4',
   {
     props: {
-      name: figma.nestedProps('Icon for Button  ❇️', {
-        iconName: figma.string('icon-name')
-      }),
       size: figma.enum('size', {
         'small (16px)': 'text-base',
         'large (24px)': 'text-2xl'
       }),
       disabled: figma.enum('state', {
         disabled: true
+      }),
+      name: figma.nestedProps('❇️ Icon for Button', {
+        iconName: figma.string('icon-name')
       })
     },
-    example: ({ size, name, disabled }) => {
-      return <sl-icon-button library="fa" class={size} name={name.iconName} disabled={disabled}></sl-icon-button>;
+    example: ({ size, disabled, name }) => {
+      return <sl-icon-button library="fa" class={size} disabled={disabled} name={name.iconName}></sl-icon-button>;
     }
   }
 );

--- a/figma_connect/icon-button.figma.tsx
+++ b/figma_connect/icon-button.figma.tsx
@@ -4,20 +4,22 @@ import React from 'react';
 import figma from '@figma/code-connect';
 
 figma.connect(
-  'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=2621-1914&t=7Ax1j0oSE1rKXXRL-4',
+  'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=2621-1914&t=NUUDTGV2YnFjzS2O-4',
   {
     props: {
-      name: figma.nestedProps('Icon for Button', {
+      name: figma.nestedProps('Icon for Button  ❇️', {
         iconName: figma.string('icon-name')
       }),
       size: figma.enum('size', {
         'small (16px)': 'text-base',
-        'medium (20px)': 'text-xl',
         'large (24px)': 'text-2xl'
+      }),
+      disabled: figma.enum('state', {
+        disabled: true
       })
     },
-    example: ({ size, name }) => {
-      return <sl-icon-button library="fa" class={size} name={name.iconName}></sl-icon-button>;
+    example: ({ size, name, disabled }) => {
+      return <sl-icon-button library="fa" class={size} name={name.iconName} disabled={disabled}></sl-icon-button>;
     }
   }
 );

--- a/figma_connect/icon-button.figma.tsx
+++ b/figma_connect/icon-button.figma.tsx
@@ -1,0 +1,23 @@
+// @ts-nocheck
+
+import React from 'react';
+import figma from '@figma/code-connect';
+
+figma.connect(
+  'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=2621-1914&t=7Ax1j0oSE1rKXXRL-4',
+  {
+    props: {
+      name: figma.nestedProps('Icon for Button', {
+        iconName: figma.string('icon-name')
+      }),
+      size: figma.enum('size', {
+        'small (16px)': 'text-base',
+        'medium (20px)': 'text-xl',
+        'large (24px)': 'text-2xl'
+      })
+    },
+    example: ({ size, name }) => {
+      return <sl-icon-button library="fa" class={size} name={name.iconName}></sl-icon-button>;
+    }
+  }
+);

--- a/figma_connect/icon-duotone.figma.tsx
+++ b/figma_connect/icon-duotone.figma.tsx
@@ -26,8 +26,7 @@ figma.connect(
     },
     example: ({ iconName, scale }) => {
       return (
-        /* Prepend 'fad-' to the name value */
-        /* Strip the '#' from the name value */
+        /* Strip the '#' from and prepend 'fad-' to the name value */
         <sl-icon library="fa" name={iconName}></sl-icon>
       );
     }

--- a/figma_connect/icon-duotone.figma.tsx
+++ b/figma_connect/icon-duotone.figma.tsx
@@ -1,0 +1,34 @@
+// @ts-nocheck
+import React from 'react';
+import figma from '@figma/code-connect';
+
+figma.connect(
+  'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=6593-17066&t=gIidLo6BlYmxFnTS-4',
+  {
+    props: {
+      iconName: figma.string('icon-name#'),
+      scale: figma.enum('scale', {
+        '1x': 'text-base',
+        '1.25x': 'text-xl',
+        '1.5x': 'text-2xl',
+        '2x': 'text-[32px]',
+        '2.5x': 'text-[40px]',
+        '3x': 'text-5xl',
+        '4x': 'text-[64px]',
+        '5x': 'text-[80px]',
+        '6x': 'text-8xl',
+        '7x': 'text-[112px]',
+        '8x': 'text-9xl',
+        '9x': 'text-[144px]',
+        '10x': 'text-[160px]'
+      })
+    },
+    example: ({ iconName, scale }) => {
+      return (
+        /* Prepend 'fad-' to the name value */
+        /* Strip the '#' from the name value */
+        <sl-icon library="fa" name={iconName}></sl-icon>
+      );
+    }
+  }
+);

--- a/figma_connect/icon-duotone.figma.tsx
+++ b/figma_connect/icon-duotone.figma.tsx
@@ -1,4 +1,5 @@
 // @ts-nocheck
+
 import React from 'react';
 import figma from '@figma/code-connect';
 

--- a/figma_connect/icon.figma.tsx
+++ b/figma_connect/icon.figma.tsx
@@ -1,0 +1,149 @@
+// @ts-nocheck
+
+import * as React from 'react';
+import figma from '@figma/code-connect';
+
+/* <sl-icon> */
+figma.connect(
+  'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=6593-16323&t=DaTJhUJKLkDLJ0Zl-4',
+  {
+    props: {
+      iconName: figma.string('icon-name'),
+      style: figma.enum('style', {
+        solid: 'fas-',
+        regular: undefined,
+        light: 'fal-',
+        thin: 'fat-'
+      }),
+      scale: figma.enum('scale', {
+        '.75x': 'text-xs',
+        '.875x': 'text-sm',
+        '1x': 'text-base',
+        '1.25x': 'text-xl',
+        '1.5x': 'text-2xl',
+        '2x': 'text-[32px]',
+        '2.5x': 'text-[40px]',
+        '3x': 'text-5xl',
+        '4x': 'text-[64px]',
+        '5x': 'text-[80px]',
+        '6x': 'text-8xl',
+        '7x': 'text-[112px]',
+        '8x': 'text-9xl',
+        '9x': 'text-[144px]',
+        '10x': 'text-[160px]'
+      })
+    },
+    example: ({ style, iconName, scale }) => {
+      return <sl-icon library="fa" style={style} name={iconName} class={scale}></sl-icon>;
+    }
+  }
+);
+
+/* <sl-icon slot="prefix"> */
+figma.connect(
+  'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=12989-18337&t=XQ5ktD0B254PC5m2-4',
+  {
+    props: {
+      iconName: figma.string('icon-name'),
+      style: figma.enum('style', {
+        solid: 'fas-',
+        regular: undefined,
+        light: 'fal-',
+        thin: 'fat-'
+      }),
+      scale: figma.enum('scale', {
+        '.75x': 'text-xs',
+        '.875x': 'text-sm',
+        '1x': 'text-base',
+        '1.25x': 'text-xl',
+        '1.5x': 'text-2xl',
+        '2x': 'text-[32px]',
+        '2.5x': 'text-[40px]',
+        '3x': 'text-5xl',
+        '4x': 'text-[64px]',
+        '5x': 'text-[80px]',
+        '6x': 'text-8xl',
+        '7x': 'text-[112px]',
+        '8x': 'text-9xl',
+        '9x': 'text-[144px]',
+        '10x': 'text-[160px]'
+      })
+    },
+    example: ({ style, iconName }) => {
+      return <sl-icon slot="prefix" library="fa" style={style} name={iconName}></sl-icon>;
+    }
+  }
+);
+
+/* <sl-icon slot="suffix"> */
+figma.connect(
+  'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=12991-2572&t=1cV1fw0FXz0L8Pr3-4',
+  {
+    props: {
+      iconName: figma.string('icon-name'),
+      style: figma.enum('style', {
+        solid: 'fas-',
+        regular: undefined,
+        light: 'fal-',
+        thin: 'fat-'
+      }),
+      scale: figma.enum('scale', {
+        '.75x': 'text-xs',
+        '.875x': 'text-sm',
+        '1x': 'text-base',
+        '1.25x': 'text-xl',
+        '1.5x': 'text-2xl',
+        '2x': 'text-[32px]',
+        '2.5x': 'text-[40px]',
+        '3x': 'text-5xl',
+        '4x': 'text-[64px]',
+        '5x': 'text-[80px]',
+        '6x': 'text-8xl',
+        '7x': 'text-[112px]',
+        '8x': 'text-9xl',
+        '9x': 'text-[144px]',
+        '10x': 'text-[160px]'
+      })
+    },
+    example: ({ style, iconName }) => {
+      return <sl-icon slot="suffix" library="fa" style={style} name={iconName}></sl-icon>;
+    }
+  }
+);
+
+/* <sl-icon> for Icon Button and Circle Button */
+
+figma.connect(
+  'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=13295-17509&t=6MS2mSbs4kwWAQ5V-4',
+  {
+    props: {
+      iconName: figma.string('icon-name'),
+      style: figma.enum('style', {
+        solid: 'fas-',
+        regular: undefined,
+        light: 'fal-',
+        thin: 'fat-'
+      }),
+      scale: figma.enum('scale', {
+        '.75x': 'text-xs',
+        '.875x': 'text-sm',
+        '1x': 'text-base',
+        '1.25x': 'text-xl',
+        '1.5x': 'text-2xl',
+        '2x': 'text-[32px]',
+        '2.5x': 'text-[40px]',
+        '3x': 'text-5xl',
+        '4x': 'text-[64px]',
+        '5x': 'text-[80px]',
+        '6x': 'text-8xl',
+        '7x': 'text-[112px]',
+        '8x': 'text-9xl',
+        '9x': 'text-[144px]',
+        '10x': 'text-[160px]'
+      })
+    },
+    example: ({ style, iconName }) => {
+      return <sl-icon library="fa" style={style} name={iconName}></sl-icon>;
+    }
+  }
+);

--- a/figma_connect/icon.figma.tsx
+++ b/figma_connect/icon.figma.tsx
@@ -1,6 +1,6 @@
 // @ts-nocheck
 
-import * as React from 'react';
+import React from 'react';
 import figma from '@figma/code-connect';
 
 /* <sl-icon> */

--- a/figma_connect/icon.figma.tsx
+++ b/figma_connect/icon.figma.tsx
@@ -34,7 +34,10 @@ figma.connect(
       iconName: figma.string('icon-name')
     },
     example: ({ style, scale, iconName }) => {
-      return <sl-icon library="fa" style={style} class={scale} name={iconName}></sl-icon>;
+      return (
+        /* Prepend style value to name, e.g. name='fal-user' */
+        <sl-icon library="fa" style={style} class={scale} name={iconName}></sl-icon>
+      );
     }
   }
 );
@@ -53,7 +56,10 @@ figma.connect(
       iconName: figma.string('icon-name')
     },
     example: ({ style, iconName }) => {
-      return <sl-icon slot="prefix" library="fa" style={style} name={iconName}></sl-icon>;
+      return (
+        /* Prepend style value to name, e.g. name='fal-user' */
+        <sl-icon slot="prefix" library="fa" style={style} name={iconName}></sl-icon>
+      );
     }
   }
 );
@@ -72,7 +78,10 @@ figma.connect(
       iconName: figma.string('icon-name')
     },
     example: ({ style, iconName }) => {
-      return <sl-icon slot="suffix" library="fa" style={style} name={iconName}></sl-icon>;
+      return (
+        /* Prepend style value to name, e.g. name='fal-user' */
+        <sl-icon slot="suffix" library="fa" style={style} name={iconName}></sl-icon>
+      );
     }
   }
 );
@@ -92,7 +101,10 @@ figma.connect(
       iconName: figma.string('icon-name')
     },
     example: ({ style, iconName }) => {
-      return <sl-icon library="fa" style={style} name={iconName}></sl-icon>;
+      return (
+        /* Prepend style value to name, e.g. name='fal-user' */
+        <sl-icon library="fa" style={style} name={iconName}></sl-icon>
+      );
     }
   }
 );

--- a/figma_connect/icon.figma.tsx
+++ b/figma_connect/icon.figma.tsx
@@ -8,7 +8,6 @@ figma.connect(
   'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=6593-16323&t=DaTJhUJKLkDLJ0Zl-4',
   {
     props: {
-      iconName: figma.string('icon-name'),
       style: figma.enum('style', {
         solid: 'fas-',
         regular: undefined,
@@ -31,10 +30,11 @@ figma.connect(
         '8x': 'text-9xl',
         '9x': 'text-[144px]',
         '10x': 'text-[160px]'
-      })
+      }),
+      iconName: figma.string('icon-name')
     },
-    example: ({ style, iconName, scale }) => {
-      return <sl-icon library="fa" style={style} name={iconName} class={scale}></sl-icon>;
+    example: ({ style, scale, iconName }) => {
+      return <sl-icon library="fa" style={style} class={scale} name={iconName}></sl-icon>;
     }
   }
 );
@@ -44,30 +44,13 @@ figma.connect(
   'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=12989-18337&t=XQ5ktD0B254PC5m2-4',
   {
     props: {
-      iconName: figma.string('icon-name'),
       style: figma.enum('style', {
         solid: 'fas-',
         regular: undefined,
         light: 'fal-',
         thin: 'fat-'
       }),
-      scale: figma.enum('scale', {
-        '.75x': 'text-xs',
-        '.875x': 'text-sm',
-        '1x': 'text-base',
-        '1.25x': 'text-xl',
-        '1.5x': 'text-2xl',
-        '2x': 'text-[32px]',
-        '2.5x': 'text-[40px]',
-        '3x': 'text-5xl',
-        '4x': 'text-[64px]',
-        '5x': 'text-[80px]',
-        '6x': 'text-8xl',
-        '7x': 'text-[112px]',
-        '8x': 'text-9xl',
-        '9x': 'text-[144px]',
-        '10x': 'text-[160px]'
-      })
+      iconName: figma.string('icon-name')
     },
     example: ({ style, iconName }) => {
       return <sl-icon slot="prefix" library="fa" style={style} name={iconName}></sl-icon>;
@@ -80,30 +63,13 @@ figma.connect(
   'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=12991-2572&t=1cV1fw0FXz0L8Pr3-4',
   {
     props: {
-      iconName: figma.string('icon-name'),
       style: figma.enum('style', {
         solid: 'fas-',
         regular: undefined,
         light: 'fal-',
         thin: 'fat-'
       }),
-      scale: figma.enum('scale', {
-        '.75x': 'text-xs',
-        '.875x': 'text-sm',
-        '1x': 'text-base',
-        '1.25x': 'text-xl',
-        '1.5x': 'text-2xl',
-        '2x': 'text-[32px]',
-        '2.5x': 'text-[40px]',
-        '3x': 'text-5xl',
-        '4x': 'text-[64px]',
-        '5x': 'text-[80px]',
-        '6x': 'text-8xl',
-        '7x': 'text-[112px]',
-        '8x': 'text-9xl',
-        '9x': 'text-[144px]',
-        '10x': 'text-[160px]'
-      })
+      iconName: figma.string('icon-name')
     },
     example: ({ style, iconName }) => {
       return <sl-icon slot="suffix" library="fa" style={style} name={iconName}></sl-icon>;
@@ -117,30 +83,13 @@ figma.connect(
   'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=13295-17509&t=6MS2mSbs4kwWAQ5V-4',
   {
     props: {
-      iconName: figma.string('icon-name'),
       style: figma.enum('style', {
         solid: 'fas-',
         regular: undefined,
         light: 'fal-',
         thin: 'fat-'
       }),
-      scale: figma.enum('scale', {
-        '.75x': 'text-xs',
-        '.875x': 'text-sm',
-        '1x': 'text-base',
-        '1.25x': 'text-xl',
-        '1.5x': 'text-2xl',
-        '2x': 'text-[32px]',
-        '2.5x': 'text-[40px]',
-        '3x': 'text-5xl',
-        '4x': 'text-[64px]',
-        '5x': 'text-[80px]',
-        '6x': 'text-8xl',
-        '7x': 'text-[112px]',
-        '8x': 'text-9xl',
-        '9x': 'text-[144px]',
-        '10x': 'text-[160px]'
-      })
+      iconName: figma.string('icon-name')
     },
     example: ({ style, iconName }) => {
       return <sl-icon library="fa" style={style} name={iconName}></sl-icon>;

--- a/figma_connect/input.figma.tsx
+++ b/figma_connect/input.figma.tsx
@@ -47,8 +47,9 @@ figma.connect(
         /* = ts_form_for ... do |f|
         /* .. = f.input :foo,
         /* .. input_html: {
-        /* .... { type: 'text',
-        /* ...... attribute: value ... }  */
+        /* .... type: "text",
+        /* .... label: "Label text",
+        /* .... "help-text": "Help text" ... }  */
         <sl-input
           type="text"
           size={size}
@@ -103,8 +104,9 @@ figma.connect(
         /* = ts_form_for ... do |f|
         /* .. = f.input :foo,
         /* .. input_html: {
-        /* .... { type: 'currency',
-        /* ...... attribute: value ... }  */
+        /* .... type: "currency",
+        /* .... label: "Label text",
+        /* .... "help-text": "Help text" ... }  */
         <sl-input
           type="currency"
           size={size}
@@ -157,8 +159,9 @@ figma.connect(
         /* = ts_form_for ... do |f|
         /* .. = f.input :foo,
         /* .. input_html: {
-        /* .... { type: 'search',
-        /* ...... attribute: value ... }  */
+        /* .... type: "search",
+        /* .... label: "Label text",
+        /* .... "help-text": "Help text" ... }  */
         <sl-input
           type="search"
           size={size}
@@ -211,8 +214,9 @@ figma.connect(
         /* = ts_form_for ... do |f|
         /* .. = f.input :foo,
         /* .. input_html: {
-        /* .... { type: 'date',
-        /* ...... attribute: value ... }  */
+        /* .... type: "date",
+        /* .... label: "Label text",
+        /* .... "help-text": "Help text" ... }  */
         <sl-input
           type="date"
           size={size}
@@ -265,8 +269,9 @@ figma.connect(
         /* = ts_form_for ... do |f|
         /* .. = f.input :foo,
         /* .. input_html: {
-        /* .... { type: 'email',
-        /* ...... attribute: value ... }  */
+        /* .... type: "email",
+        /* .... label: "Label text",
+        /* .... "help-text": "Help text" ... }  */
         <sl-input
           type="email"
           size={size}
@@ -319,8 +324,9 @@ figma.connect(
         /* = ts_form_for ... do |f|
         /* .. = f.input :foo,
         /* .. input_html: {
-        /* .... { type: 'password',
-        /* ...... attribute: value ... }  */
+        /* .... type: "password",
+        /* .... label: "Label text",
+        /* .... "help-text": "Help text" ... }  */
         <sl-input
           type="password"
           size={size}
@@ -374,8 +380,9 @@ figma.connect(
         /* = ts_form_for ... do |f|
         /* .. = f.input :foo,
         /* .. input_html: {
-        /* .... { type: 'tel',
-        /* ...... attribute: value }  */
+        /* .... type: "tel",
+        /* .... label: "Label text",
+        /* .... "help-text": "Help text" ... }  */
         <sl-input
           type="tel"
           size={size}

--- a/figma_connect/input.figma.tsx
+++ b/figma_connect/input.figma.tsx
@@ -1,0 +1,453 @@
+// @ts-nocheck
+
+import React from 'react';
+import figma from '@figma/code-connect';
+
+/*  input type 'text' */
+figma.connect(
+  'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=2725-1451&t=xczOrvme3QjS06mn-4',
+  {
+    variant: { type: 'text' },
+    props: {
+      size: figma.enum('size', {
+        medium: 'medium',
+        large: 'large'
+      }),
+      disabled: figma.enum('state', {
+        disabled: true
+      }),
+      label: figma.boolean('label?', {
+        true: figma.string('✏️ label'),
+        false: undefined
+      }),
+      required: figma.boolean('required?'),
+      tooltip: figma.boolean('tooltip?', {
+        true: '{Include tooltip text here}',
+        false: undefined
+      }),
+      contextNote: figma.boolean('context note?', {
+        true: figma.string('✏️ note text'),
+        false: undefined
+      }),
+      helpText: figma.boolean('help text?', {
+        true: figma.string('✏️ help text'),
+        false: undefined
+      }),
+      prefix: figma.boolean('prefix?', {
+        true: figma.children('Prefix'),
+        false: undefined
+      }),
+      suffix: figma.boolean('suffix?', {
+        true: figma.children('Suffix'),
+        false: undefined
+      })
+    },
+    example: ({ size, disabled, label, required, tooltip, contextNote, helpText, prefix, suffix }) => {
+      return (
+        /* = ts_form_for ... do |f|
+        /* .. = f.input :foo,
+        /* .. input_html: {
+        /* .... { type: 'text',
+        /* ...... attribute: value ... }  */
+        <sl-input
+          type="text"
+          size={size}
+          disabled={disabled}
+          label={label}
+          required={required}
+          label-tooltip={tooltip}
+          context-note={contextNote}
+          help-text={helpText}
+        >
+          {prefix}
+          {suffix}
+        </sl-input>
+      );
+    }
+  }
+);
+
+/*  input type 'currency' */
+figma.connect(
+  'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=2725-1451&t=xczOrvme3QjS06mn-4',
+  {
+    variant: { type: 'currency' },
+    props: {
+      size: figma.enum('size', {
+        medium: 'medium',
+        large: 'large'
+      }),
+      disabled: figma.enum('state', {
+        disabled: true
+      }),
+      label: figma.boolean('label?', {
+        true: figma.string('✏️ label'),
+        false: undefined
+      }),
+      required: figma.boolean('required?'),
+      tooltip: figma.boolean('tooltip?', {
+        true: '{Include tooltip text here}',
+        false: undefined
+      }),
+      contextNote: figma.boolean('context note?', {
+        true: figma.string('✏️ note text'),
+        false: undefined
+      }),
+      helpText: figma.boolean('help text?', {
+        true: figma.string('✏️ help text'),
+        false: undefined
+      })
+    },
+    example: ({ size, disabled, label, required, tooltip, contextNote, helpText }) => {
+      return (
+        /* = ts_form_for ... do |f|
+        /* .. = f.input :foo,
+        /* .. input_html: {
+        /* .... { type: 'currency',
+        /* ...... attribute: value ... }  */
+        <sl-input
+          type="currency"
+          size={size}
+          disabled={disabled}
+          label={label}
+          required={required}
+          label-tooltip={tooltip}
+          context-note={contextNote}
+          help-text={helpText}
+        ></sl-input>
+      );
+    }
+  }
+);
+
+/*  input type 'search' */
+figma.connect(
+  'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=2725-1451&t=xczOrvme3QjS06mn-4',
+  {
+    variant: { type: 'search' },
+    props: {
+      size: figma.enum('size', {
+        medium: 'medium',
+        large: 'large'
+      }),
+      disabled: figma.enum('state', {
+        disabled: true
+      }),
+      label: figma.boolean('label?', {
+        true: figma.string('✏️ label'),
+        false: undefined
+      }),
+      required: figma.boolean('required?'),
+      tooltip: figma.boolean('tooltip?', {
+        true: '{Include tooltip text here}',
+        false: undefined
+      }),
+      contextNote: figma.boolean('context note?', {
+        true: figma.string('✏️ note text'),
+        false: undefined
+      }),
+      helpText: figma.boolean('help text?', {
+        true: figma.string('✏️ help text'),
+        false: undefined
+      }),
+      clearable: figma.boolean('clearable?')
+    },
+    example: ({ size, disabled, label, required, tooltip, contextNote, helpText, clearable }) => {
+      return (
+        /* = ts_form_for ... do |f|
+        /* .. = f.input :foo,
+        /* .. input_html: {
+        /* .... { type: 'search',
+        /* ...... attribute: value ... }  */
+        <sl-input
+          type="search"
+          size={size}
+          disabled={disabled}
+          label={label}
+          required={required}
+          label-tooltip={tooltip}
+          context-note={contextNote}
+          help-text={helpText}
+          clearable={clearable}
+        ></sl-input>
+      );
+    }
+  }
+);
+
+/*  input type 'date' */
+figma.connect(
+  'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=2725-1451&t=xczOrvme3QjS06mn-4',
+  {
+    variant: { type: 'date' },
+    props: {
+      size: figma.enum('size', {
+        medium: 'medium',
+        large: 'large'
+      }),
+      disabled: figma.enum('state', {
+        disabled: true
+      }),
+      label: figma.boolean('label?', {
+        true: figma.string('✏️ label'),
+        false: undefined
+      }),
+      required: figma.boolean('required?'),
+      tooltip: figma.boolean('tooltip?', {
+        true: '{Include tooltip text here}',
+        false: undefined
+      }),
+      contextNote: figma.boolean('context note?', {
+        true: figma.string('✏️ note text'),
+        false: undefined
+      }),
+      helpText: figma.boolean('help text?', {
+        true: figma.string('✏️ help text'),
+        false: undefined
+      })
+    },
+    example: ({ size, disabled, label, required, tooltip, contextNote, helpText }) => {
+      return (
+        /* = ts_form_for ... do |f|
+        /* .. = f.input :foo,
+        /* .. input_html: {
+        /* .... { type: 'date',
+        /* ...... attribute: value ... }  */
+        <sl-input
+          type="date"
+          size={size}
+          disabled={disabled}
+          label={label}
+          required={required}
+          label-tooltip={tooltip}
+          context-note={contextNote}
+          help-text={helpText}
+        ></sl-input>
+      );
+    }
+  }
+);
+
+/*  input type 'email' */
+figma.connect(
+  'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=2725-1451&t=xczOrvme3QjS06mn-4',
+  {
+    variant: { type: 'email' },
+    props: {
+      size: figma.enum('size', {
+        medium: 'medium',
+        large: 'large'
+      }),
+      disabled: figma.enum('state', {
+        disabled: true
+      }),
+      label: figma.boolean('label?', {
+        true: figma.string('✏️ label'),
+        false: undefined
+      }),
+      required: figma.boolean('required?'),
+      tooltip: figma.boolean('tooltip?', {
+        true: '{Include tooltip text here}',
+        false: undefined
+      }),
+      contextNote: figma.boolean('context note?', {
+        true: figma.string('✏️ note text'),
+        false: undefined
+      }),
+      helpText: figma.boolean('help text?', {
+        true: figma.string('✏️ help text'),
+        false: undefined
+      }),
+      optionalIcon: figma.boolean('optional icon?')
+    },
+    example: ({ size, disabled, label, required, tooltip, contextNote, helpText, optionalIcon }) => {
+      return (
+        /* = ts_form_for ... do |f|
+        /* .. = f.input :foo,
+        /* .. input_html: {
+        /* .... { type: 'email',
+        /* ...... attribute: value ... }  */
+        <sl-input
+          type="email"
+          size={size}
+          disabled={disabled}
+          label={label}
+          required={required}
+          label-tooltip={tooltip}
+          context-note={contextNote}
+          help-text={helpText}
+          optional-icon={optionalIcon}
+        ></sl-input>
+      );
+    }
+  }
+);
+
+/*  input type 'password' */
+figma.connect(
+  'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=2725-1451&t=xczOrvme3QjS06mn-4',
+  {
+    variant: { type: 'password' },
+    props: {
+      size: figma.enum('size', {
+        medium: 'medium',
+        large: 'large'
+      }),
+      disabled: figma.enum('state', {
+        disabled: true
+      }),
+      label: figma.boolean('label?', {
+        true: figma.string('✏️ label'),
+        false: undefined
+      }),
+      required: figma.boolean('required?'),
+      tooltip: figma.boolean('tooltip?', {
+        true: '{Include tooltip text here}',
+        false: undefined
+      }),
+      contextNote: figma.boolean('context note?', {
+        true: figma.string('✏️ note text'),
+        false: undefined
+      }),
+      helpText: figma.boolean('help text?', {
+        true: figma.string('✏️ help text'),
+        false: undefined
+      })
+    },
+    example: ({ size, disabled, label, required, tooltip, contextNote, helpText }) => {
+      return (
+        /* = ts_form_for ... do |f|
+        /* .. = f.input :foo,
+        /* .. input_html: {
+        /* .... { type: 'password',
+        /* ...... attribute: value ... }  */
+        <sl-input
+          type="password"
+          size={size}
+          disabled={disabled}
+          label={label}
+          required={required}
+          label-tooltip={tooltip}
+          context-note={contextNote}
+          help-text={helpText}
+          password-toggle
+        ></sl-input>
+      );
+    }
+  }
+);
+
+/*  input type 'tel' */
+figma.connect(
+  'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=2725-1451&t=xczOrvme3QjS06mn-4',
+  {
+    variant: { type: 'tel' },
+    props: {
+      size: figma.enum('size', {
+        medium: 'medium',
+        large: 'large'
+      }),
+      disabled: figma.enum('state', {
+        disabled: true
+      }),
+      label: figma.boolean('label?', {
+        true: figma.string('✏️ label'),
+        false: undefined
+      }),
+      required: figma.boolean('required?'),
+      tooltip: figma.boolean('tooltip?', {
+        true: '{Include tooltip text here}',
+        false: undefined
+      }),
+      contextNote: figma.boolean('context note?', {
+        true: figma.string('✏️ note text'),
+        false: undefined
+      }),
+      helpText: figma.boolean('help text?', {
+        true: figma.string('✏️ help text'),
+        false: undefined
+      }),
+      optionalIcon: figma.boolean('optional icon?')
+    },
+    example: ({ size, disabled, label, required, tooltip, contextNote, helpText, optionalIcon }) => {
+      return (
+        /* = ts_form_for ... do |f|
+        /* .. = f.input :foo,
+        /* .. input_html: {
+        /* .... { type: 'tel',
+        /* ...... attribute: value }  */
+        <sl-input
+          type="tel"
+          size={size}
+          disabled={disabled}
+          label={label}
+          required={required}
+          label-tooltip={tooltip}
+          context-note={contextNote}
+          help-text={helpText}
+          optional-icon={optionalIcon}
+        ></sl-input>
+      );
+    }
+  }
+);
+
+/* text prefix */
+figma.connect(
+  'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=4860-10242&t=xczOrvme3QjS06mn-4',
+  {
+    variant: { type: 'text' },
+    props: {
+      prefixText: figma.string('✏️ prefix-text')
+    },
+    example: ({ prefixText }) => {
+      return <span slot="prefix">{prefixText}</span>;
+    }
+  }
+);
+
+/* icon prefix */
+figma.connect(
+  'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=4860-10242&t=xczOrvme3QjS06mn-4',
+  {
+    variant: { type: 'icon' },
+    props: {
+      name: figma.nestedProps('❇️ Prefix Icon', {
+        iconName: figma.string('icon-name')
+      })
+    },
+    example: ({ name }) => {
+      return <sl-icon slot="prefix" library="fa" name={name.iconName}></sl-icon>;
+    }
+  }
+);
+
+/* text suffix */
+figma.connect(
+  'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=4860-10250&t=xczOrvme3QjS06mn-4',
+  {
+    variant: { type: 'text' },
+    props: {
+      suffixText: figma.string('✏️ suffix-text')
+    },
+    example: ({ suffixText }) => {
+      return <span slot="suffix">{suffixText}</span>;
+    }
+  }
+);
+
+/* icon suffix */
+figma.connect(
+  'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=4860-10250&t=xczOrvme3QjS06mn-4',
+  {
+    variant: { type: 'icon' },
+    props: {
+      name: figma.nestedProps('❇️ Suffix Icon', {
+        iconName: figma.string('icon-name')
+      })
+    },
+    example: ({ name }) => {
+      return <sl-icon slot="suffix" library="fa" name={name.iconName}></sl-icon>;
+    }
+  }
+);

--- a/figma_connect/radio-group.figma.tsx
+++ b/figma_connect/radio-group.figma.tsx
@@ -74,17 +74,18 @@ figma.connect(
     },
     example: ({ contained, label, required, tooltip, helpText, value, radioList }) => {
       return (
+        /* When rendering with ts_form_for 
         /* = ts_form_for ... do |f|
         /* .. = f.input :foo,
         /* .. as: :radio_buttons,
         /* .. label: "Group label",
-        /* .. collection: [ */
-        /* ["Radio label 1", :id-1, description: "Item description"], */
-        /* ["Radio label 2", :id-2, description: "Item description", disabled: true], */
+        /* .. collection: [ 
+        /* ["Radio label 1", :id-1, description: "Item description"], 
+        /* ["Radio label 2", :id-2, description: "Item description", disabled: true], 
         /* ],
-        /* .. wrapper_html: {
-        /* .... { "help-text": {value},
-        /* ...... "label-tooltip": {value}, }  */
+        /* .. wrapper_html: { 
+        /* .... "help-text": "Help text", 
+        /* .... "label-tooltip": "Tooltip text", ... }  */
         <sl-radio-group
           name="group-name"
           contained={contained}
@@ -130,13 +131,14 @@ figma.connect(
         /* .. = f.input :foo,
         /* .. as: :radio_buttons,
         /* .. label: "Group label",
-        /* .. collection: [ */
-        /* ["Radio label 1", :id-1, description: "Item description"], */
-        /* ["Radio label 2", :id-2, description: "Item description", disabled: true], */
+        /* .. collection: [ 
+        /* ["Radio label 1", :id-1, description: "Item description"], 
+        /* ["Radio label 2", :id-2, description: "Item description", disabled: true], 
         /* ],
         /* .. wrapper_html: {
-        /* .... { "help-text": {value},
-        /* ...... "label-tooltip": {value}, }  */
+        /* .... horizontal: true,
+        /* .... "help-text": "Help text",
+        /* .... "label-tooltip": "Tooltip text", ... }  */
         <sl-radio-group
           name="group-name"
           horizontal

--- a/figma_connect/radio-group.figma.tsx
+++ b/figma_connect/radio-group.figma.tsx
@@ -1,0 +1,155 @@
+// @ts-nocheck
+
+import React from 'react';
+import figma from '@figma/code-connect';
+
+/* sl-radio */
+figma.connect(
+  'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=11255-4575&t=MZDnlRrHkRW0flgq-4',
+  {
+    props: {
+      disabled: figma.enum('state', {
+        disabled: true
+      }),
+      value: figma.boolean('checked?', {
+        true: 'checked-value',
+        false: 'value'
+      }),
+      contained: figma.boolean('contained?'),
+      label: figma.string('✏️ label'),
+      description: figma.boolean('description?', {
+        true: figma.string('✏️ description'),
+        false: undefined
+      }),
+      selectedContent: figma.boolean('selected content?', {
+        true: figma.children('Selected content'),
+        false: undefined
+      })
+    },
+    example: ({ disabled, value, contained, label, description, selectedContent }) => {
+      return (
+        <sl-radio value={value} disabled={disabled} description={description}>
+          {label}
+          {selectedContent}
+        </sl-radio>
+      );
+    }
+  }
+);
+
+/* selected content */
+figma.connect(
+  'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=14001-4880&t=OPQ2iRvIeCZDwVR5-4',
+  {
+    props: {
+      slottedContent: figma.children('*')
+    },
+    example: ({ slottedContent }) => {
+      return <div slot="selected-content">{slottedContent}</div>;
+    }
+  }
+);
+
+/* sl-radio-group, default */
+figma.connect(
+  'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=13995-16708&t=MZDnlRrHkRW0flgq-4',
+  {
+    variant: { 'horizontal?': 'false' },
+    props: {
+      contained: figma.boolean('contained?'),
+      label: figma.boolean('label?', {
+        true: figma.string('✏️ label'),
+        false: undefined
+      }),
+      required: figma.boolean('required?'),
+      tooltip: figma.boolean('tooltip?', {
+        true: '{Include tooltip text here}',
+        false: undefined
+      }),
+      helpText: figma.boolean('help text?', {
+        true: figma.string('✏️ help text'),
+        false: undefined
+      }),
+      radioList: figma.children(['Radio 1', 'Radio 2', 'Radio 3', 'Radio 4', 'Radio 5', 'Radio 6', 'Radio 7'])
+    },
+    example: ({ contained, label, required, tooltip, helpText, value, radioList }) => {
+      return (
+        /* = ts_form_for ... do |f|
+        /* .. = f.input :foo,
+        /* .. as: :radio_buttons,
+        /* .. label: "Group label",
+        /* .. collection: [ */
+        /* ["Radio label 1", :id-1, description: "Item description"], */
+        /* ["Radio label 2", :id-2, description: "Item description", disabled: true], */
+        /* ],
+        /* .. wrapper_html: {
+        /* .... { "help-text": {value},
+        /* ...... "label-tooltip": {value}, }  */
+        <sl-radio-group
+          name="group-name"
+          contained={contained}
+          label={label}
+          required={required}
+          label-tooltip={tooltip}
+          help-text={helpText}
+          value="checked-value"
+        >
+          {radioList}
+        </sl-radio-group>
+      );
+    }
+  }
+);
+
+/* sl-radio-group, horizontal */
+figma.connect(
+  'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=13995-16708&t=MZDnlRrHkRW0flgq-4',
+  {
+    variant: { 'horizontal?': 'true' },
+    props: {
+      contained: figma.boolean('contained?'),
+      label: figma.boolean('label?', {
+        true: figma.string('✏️ label'),
+        false: undefined
+      }),
+      required: figma.boolean('required?'),
+      tooltip: figma.boolean('tooltip?', {
+        true: '{Include tooltip text here}',
+        false: undefined
+      }),
+      helpText: figma.boolean('help text?', {
+        true: figma.string('✏️ help text'),
+        false: undefined
+      }),
+      radioList: figma.children(['Radio 1', 'Radio 2', 'Radio 3', 'Radio 4'])
+    },
+    example: ({ contained, label, required, tooltip, helpText, value, radioList }) => {
+      return (
+        /* When rendering with ts_form_for */
+        /* = ts_form_for ... do |f|
+        /* .. = f.input :foo,
+        /* .. as: :radio_buttons,
+        /* .. label: "Group label",
+        /* .. collection: [ */
+        /* ["Radio label 1", :id-1, description: "Item description"], */
+        /* ["Radio label 2", :id-2, description: "Item description", disabled: true], */
+        /* ],
+        /* .. wrapper_html: {
+        /* .... { "help-text": {value},
+        /* ...... "label-tooltip": {value}, }  */
+        <sl-radio-group
+          name="group-name"
+          horizontal
+          contained={contained}
+          label={label}
+          required={required}
+          label-tooltip={tooltip}
+          help-text={helpText}
+          value="checked-value"
+        >
+          {radioList}
+        </sl-radio-group>
+      );
+    }
+  }
+);

--- a/figma_connect/select.figma.tsx
+++ b/figma_connect/select.figma.tsx
@@ -1,0 +1,157 @@
+// @ts-nocheck
+
+import React from 'react';
+import figma from '@figma/code-connect';
+
+/* select, default */
+figma.connect(
+  'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=10720-8726&t=AiumK76u2Tv4EXMB-4',
+  {
+    variant: { 'multiple?': 'false' },
+    props: {
+      size: figma.enum('size', {
+        medium: 'medium',
+        large: 'large'
+      }),
+      disabled: figma.enum('state', {
+        disabled: true
+      }),
+      label: figma.boolean('label?', {
+        true: figma.string('✏️ label'),
+        false: undefined
+      }),
+      required: figma.boolean('required?'),
+      tooltip: figma.boolean('tooltip?', {
+        true: '{Include tooltip text here}',
+        false: undefined
+      }),
+      contextNote: figma.boolean('context note?', {
+        true: figma.string('✏️ note text'),
+        false: undefined
+      }),
+      prefix: figma.boolean('prefix?', {
+        true: figma.children('Prefix*'),
+        false: undefined
+      }),
+      value: figma.string('✏️ value text'),
+      valueID: figma.boolean('value?', {
+        true: 'option-a',
+        false: undefined
+      }),
+      helpText: figma.boolean('help text?', {
+        true: figma.string('✏️ help text'),
+        false: undefined
+      })
+    },
+    example: ({ size, disabled, label, required, tooltip, contextNote, prefix, value, valueID, helpText }) => {
+      return (
+        /* = ts_form_for ... do |f|
+        /* .. = f.input :foo,
+        /* .. collection: [ 
+        /* ["Option A", :option-a], 
+        /* ["Option B", :option-b], 
+        /* ["Option C", :option-c], 
+        /* ],
+        /* .. input_html: {
+        /* .... label: "Label text",
+        /* .... "help-text": "Help text",
+        /* .... "label-tooltip": "Tooltip text",
+        /* .... value: "option-a", ... }  */
+        <sl-select
+          size={size}
+          disabled={disabled}
+          label={label}
+          required={required}
+          label-tooltip={tooltip}
+          context-note={contextNote}
+          value={valueID}
+          help-text={helpText}
+        >
+          {prefix}
+          <sl-option value="option-a">{value}</sl-option>
+          <sl-option value="option-b">Option B</sl-option>
+          <sl-option value="option-c">Option C</sl-option>
+        </sl-select>
+      );
+    }
+  }
+);
+
+/* select, multiple */
+figma.connect(
+  'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=10720-8726&t=AiumK76u2Tv4EXMB-4',
+  {
+    variant: { 'multiple?': 'true' },
+    props: {
+      size: figma.enum('size', {
+        medium: 'medium',
+        large: 'large'
+      }),
+      disabled: figma.enum('state', {
+        disabled: true
+      }),
+      label: figma.boolean('label?', {
+        true: figma.string('✏️ label'),
+        false: undefined
+      }),
+      required: figma.boolean('required?'),
+      tooltip: figma.boolean('tooltip?', {
+        true: '{Include tooltip text here}',
+        false: undefined
+      }),
+      contextNote: figma.boolean('context note?', {
+        true: figma.string('✏️ note text'),
+        false: undefined
+      }),
+      prefix: figma.boolean('prefix?', {
+        true: figma.children('Prefix*'),
+        false: undefined
+      }),
+      valueID: figma.boolean('value (multiple)?', {
+        true: 'option-1 option-2',
+        false: undefined
+      }),
+      helpText: figma.boolean('help text?', {
+        true: figma.string('✏️ help text'),
+        false: undefined
+      })
+    },
+    example: ({ size, disabled, label, required, tooltip, contextNote, prefix, valueID, helpText }) => {
+      return (
+        /* = ts_form_for ... do |f|
+        /* .. = f.input :foo,
+        /* .. collection: [ 
+        /* ["Option 1", :option-1], 
+        /* ["Option 2", :option-2], 
+        /* ["Option 3", :option-3], 
+        /* ],
+        /* .. input_html: {
+        /* .... label: "Label text",
+        /* .... "help-text": "Help text",
+        /* .... "label-tooltip": "Tooltip text",
+        /* .... multiple: true,
+        /* .... clearable: true,
+        /* .... value: "option-1 option-2 ...", ... }  */
+        <sl-select
+          size={size}
+          disabled={disabled}
+          multiple
+          clearable
+          label={label}
+          required={required}
+          label-tooltip={tooltip}
+          context-note={contextNote}
+          value={valueID}
+          help-text={helpText}
+        >
+          {prefix}
+          <sl-option value="option-1">Option 1</sl-option>
+          <sl-option value="option-2">Option 2</sl-option>
+          <sl-option value="option-3">Option 3</sl-option>
+          <sl-option value="option-4">Option 4</sl-option>
+          <sl-option>...</sl-option>
+        </sl-select>
+      );
+    }
+  }
+);

--- a/figma_connect/spinner.figma.tsx
+++ b/figma_connect/spinner.figma.tsx
@@ -1,0 +1,21 @@
+// @ts-nocheck
+
+import React from 'react';
+import figma from '@figma/code-connect';
+
+figma.connect(
+  'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=8436-1402&t=j7gCllmM5d054D0f-4',
+  {
+    props: {
+      size: figma.enum('size', {
+        small: 'small',
+        medium: 'medium',
+        large: 'large',
+        'x-large': 'x-large'
+      })
+    },
+    example: ({ size }) => {
+      return <sl-spinner size={size}></sl-spinner>;
+    }
+  }
+);

--- a/figma_connect/switch.figma.tsx
+++ b/figma_connect/switch.figma.tsx
@@ -1,0 +1,67 @@
+// @ts-nocheck
+
+import React from 'react';
+import figma from '@figma/code-connect';
+
+figma.connect(
+  'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=4844-10248&t=up6Nxobejwhsftnh-4',
+  {
+    props: {
+      labelPosition: figma.enum('label position', {
+        right: 'right',
+        left: 'left',
+        'left justified': 'left-justified'
+      }),
+      size: figma.enum('size', {
+        medium: 'medium',
+        small: 'small'
+      }),
+      checked: figma.boolean('checked?'),
+      disabled: figma.enum('state', {
+        disabled: true
+      }),
+      label: figma.string('✏️ label'),
+      helpText: figma.boolean('help text?', {
+        true: figma.string('✏️ help text'),
+        false: undefined
+      })
+    },
+    example: ({ labelPosition, helpText, size, checked, disabled, label }) => {
+      return (
+        <sl-switch
+          label-position={labelPosition}
+          help-text={helpText}
+          size={size}
+          checked={checked}
+          disabled={disabled}
+        >
+          {label}
+        </sl-switch>
+      );
+    }
+  }
+);
+
+figma.connect(
+  'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=4844-10248&t=up6Nxobejwhsftnh-4',
+  {
+    variant: { 'label position': 'no label' },
+    props: {
+      size: figma.enum('size', {
+        medium: 'medium',
+        small: 'small'
+      }),
+      checked: figma.boolean('checked?'),
+      disabled: figma.enum('state', {
+        disabled: true
+      }),
+      helpText: figma.boolean('help text?', {
+        true: figma.string('✏️ help text'),
+        false: undefined
+      })
+    },
+    example: ({ helpText, size, checked, disabled }) => {
+      return <sl-switch help-text={helpText} size={size} checked={checked} disabled={disabled}></sl-switch>;
+    }
+  }
+);

--- a/figma_connect/switch.figma.tsx
+++ b/figma_connect/switch.figma.tsx
@@ -16,24 +16,24 @@ figma.connect(
         medium: 'medium',
         small: 'small'
       }),
-      checked: figma.boolean('checked?'),
       disabled: figma.enum('state', {
         disabled: true
       }),
+      checked: figma.boolean('checked?'),
       label: figma.string('✏️ label'),
       helpText: figma.boolean('help text?', {
         true: figma.string('✏️ help text'),
         false: undefined
       })
     },
-    example: ({ labelPosition, helpText, size, checked, disabled, label }) => {
+    example: ({ labelPosition, size, disabled, checked, label, helpText }) => {
       return (
         <sl-switch
           label-position={labelPosition}
-          help-text={helpText}
           size={size}
-          checked={checked}
           disabled={disabled}
+          checked={checked}
+          help-text={helpText}
         >
           {label}
         </sl-switch>
@@ -51,17 +51,17 @@ figma.connect(
         medium: 'medium',
         small: 'small'
       }),
-      checked: figma.boolean('checked?'),
       disabled: figma.enum('state', {
         disabled: true
       }),
+      checked: figma.boolean('checked?'),
       helpText: figma.boolean('help text?', {
         true: figma.string('✏️ help text'),
         false: undefined
       })
     },
-    example: ({ helpText, size, checked, disabled }) => {
-      return <sl-switch help-text={helpText} size={size} checked={checked} disabled={disabled}></sl-switch>;
+    example: ({ size, disabled, checked, helpText }) => {
+      return <sl-switch size={size} disabled={disabled} checked={checked} help-text={helpText}></sl-switch>;
     }
   }
 );

--- a/figma_connect/tab.figma.tsx
+++ b/figma_connect/tab.figma.tsx
@@ -1,0 +1,149 @@
+// @ts-nocheck
+
+import React from 'react';
+import figma from '@figma/code-connect';
+
+/* tab group, 2 tabs */
+figma.connect(
+  'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=7542-8307&t=AiumK76u2Tv4EXMB-4',
+  {
+    variant: { '# of tabs': 'two' },
+    props: {
+      tabItems: figma.children(['Tab 1', 'Tab 2'])
+    },
+    example: ({ tabItems }) => {
+      return (
+        /* Every <sl-tab> needs a unique 'panel' value
+        /* that matches a <sl-tab-panel>'s 'name' value. */
+        <sl-tab-group>
+          {tabItems}
+          <sl-tab-panel name="panel-name">Panel content</sl-tab-panel>
+          <sl-tab-panel name="panel-name">Panel content</sl-tab-panel>
+        </sl-tab-group>
+      );
+    }
+  }
+);
+
+/* tab group, 3 tabs */
+figma.connect(
+  'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=7542-8307&t=AiumK76u2Tv4EXMB-4',
+  {
+    variant: { '# of tabs': 'three' },
+    props: {
+      tabItems: figma.children(['Tab 1', 'Tab 2', 'Tab 3'])
+    },
+    example: ({ tabItems }) => {
+      return (
+        /* Every <sl-tab> needs a unique 'panel' value
+        /* that matches a <sl-tab-panel>'s 'name' value. */
+        <sl-tab-group>
+          {tabItems}
+          <sl-tab-panel name="panel-name">Panel content</sl-tab-panel>
+          <sl-tab-panel name="panel-name">Panel content</sl-tab-panel>
+          <sl-tab-panel name="panel-name">Panel content</sl-tab-panel>
+        </sl-tab-group>
+      );
+    }
+  }
+);
+
+/* tab group, 4 tabs */
+figma.connect(
+  'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=7542-8307&t=AiumK76u2Tv4EXMB-4',
+  {
+    variant: { '# of tabs': 'four' },
+    props: {
+      tabItems: figma.children(['Tab 1', 'Tab 2', 'Tab 3', 'Tab 4'])
+    },
+    example: ({ tabItems }) => {
+      return (
+        /* Every <sl-tab> needs a unique 'panel' value
+        /* that matches a <sl-tab-panel>'s 'name' value. */
+        <sl-tab-group>
+          {tabItems}
+          <sl-tab-panel name="panel-name">Panel content</sl-tab-panel>
+          <sl-tab-panel name="panel-name">Panel content</sl-tab-panel>
+          <sl-tab-panel name="panel-name">Panel content</sl-tab-panel>
+          <sl-tab-panel name="panel-name">Panel content</sl-tab-panel>
+        </sl-tab-group>
+      );
+    }
+  }
+);
+
+/* tab group, 5 tabs */
+figma.connect(
+  'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=7542-8307&t=AiumK76u2Tv4EXMB-4',
+  {
+    variant: { '# of tabs': 'five' },
+    props: {
+      tabItems: figma.children(['Tab 1', 'Tab 2', 'Tab 3', 'Tab 4', 'Tab 5'])
+    },
+    example: ({ tabItems }) => {
+      return (
+        /* Every <sl-tab> needs a unique 'panel' value
+        /* that matches a <sl-tab-panel>'s 'name' value. */
+        <sl-tab-group>
+          {tabItems}
+          <sl-tab-panel name="panel-name">Panel content</sl-tab-panel>
+          <sl-tab-panel name="panel-name">Panel content</sl-tab-panel>
+          <sl-tab-panel name="panel-name">Panel content</sl-tab-panel>
+          <sl-tab-panel name="panel-name">Panel content</sl-tab-panel>
+          <sl-tab-panel name="panel-name">Panel content</sl-tab-panel>
+        </sl-tab-group>
+      );
+    }
+  }
+);
+
+/* tab group, 6 tabs */
+figma.connect(
+  'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=7542-8307&t=AiumK76u2Tv4EXMB-4',
+  {
+    variant: { '# of tabs': 'six' },
+    props: {
+      tabItems: figma.children(['Tab 1', 'Tab 2', 'Tab 3', 'Tab 4', 'Tab 5', 'Tab 6'])
+    },
+    example: ({ tabItems }) => {
+      return (
+        /* Every <sl-tab> needs a unique 'panel' value
+        /* that matches a <sl-tab-panel>'s 'name' value. */
+        <sl-tab-group>
+          {tabItems}
+          <sl-tab-panel name="panel-name">Panel content</sl-tab-panel>
+          <sl-tab-panel name="panel-name">Panel content</sl-tab-panel>
+          <sl-tab-panel name="panel-name">Panel content</sl-tab-panel>
+          <sl-tab-panel name="panel-name">Panel content</sl-tab-panel>
+          <sl-tab-panel name="panel-name">Panel content</sl-tab-panel>
+          <sl-tab-panel name="panel-name">Panel content</sl-tab-panel>
+        </sl-tab-group>
+      );
+    }
+  }
+);
+
+/* tab item */
+figma.connect(
+  'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=2719-1340&t=AiumK76u2Tv4EXMB-4',
+  {
+    props: {
+      disabled: figma.enum('state', {
+        disabled: true
+      }),
+      label: figma.string('✏️ label'),
+      badge: figma.boolean('badge?', {
+        true: figma.children('❇️ Badge*'),
+        false: undefined
+      })
+    },
+    example: ({ label, badge }) => {
+      return (
+        <sl-tab slot="nav" panel="panel-name">
+          {label}
+          {badge}
+        </sl-tab>
+      );
+    }
+  }
+);

--- a/figma_connect/tag.figma.tsx
+++ b/figma_connect/tag.figma.tsx
@@ -27,10 +27,10 @@ figma.connect(
         medium: 'medium',
         large: 'large'
       }),
-      removable: figma.boolean('removable?'),
-      content: figma.string('✏️ content')
+      content: figma.string('✏️ content'),
+      removable: figma.boolean('removable?')
     },
-    example: ({ removable, content, variant, size }) => {
+    example: ({ variant, size, content, removable }) => {
       return (
         <sl-tag variant={variant} size={size} removable={removable}>
           {content}

--- a/figma_connect/tag.figma.tsx
+++ b/figma_connect/tag.figma.tsx
@@ -1,0 +1,41 @@
+// @ts-nocheck
+
+import React from 'react';
+import figma from '@figma/code-connect';
+
+figma.connect(
+  'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=2662-1381&t=4UIXwDXcsJSneX8X-4',
+  {
+    props: {
+      removable: figma.boolean('removable?'),
+      content: figma.string('✏️ content'),
+      variant: figma.enum('variant', {
+        blue: 'blue',
+        green: 'green',
+        gray: 'gray',
+        yellow: 'yellow',
+        red: 'red',
+        teal: 'teal',
+        fuchsia: 'fuchsia',
+        purple: 'purple',
+        primary: 'primary',
+        success: 'success',
+        neutral: 'neutral',
+        warning: 'warning',
+        danger: 'danger'
+      }),
+      size: figma.enum('size', {
+        small: 'small',
+        medium: 'medium',
+        large: 'large'
+      })
+    },
+    example: ({ removable, content, variant, size }) => {
+      return (
+        <sl-tag variant={variant} size={size} removable={removable}>
+          {content}
+        </sl-tag>
+      );
+    }
+  }
+);

--- a/figma_connect/tag.figma.tsx
+++ b/figma_connect/tag.figma.tsx
@@ -7,8 +7,6 @@ figma.connect(
   'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=2662-1381&t=4UIXwDXcsJSneX8X-4',
   {
     props: {
-      removable: figma.boolean('removable?'),
-      content: figma.string('✏️ content'),
       variant: figma.enum('variant', {
         blue: 'blue',
         green: 'green',
@@ -28,7 +26,9 @@ figma.connect(
         small: 'small',
         medium: 'medium',
         large: 'large'
-      })
+      }),
+      removable: figma.boolean('removable?'),
+      content: figma.string('✏️ content')
     },
     example: ({ removable, content, variant, size }) => {
       return (

--- a/figma_connect/textarea.figma.tsx
+++ b/figma_connect/textarea.figma.tsx
@@ -1,0 +1,62 @@
+// @ts-nocheck
+
+import React from 'react';
+import figma from '@figma/code-connect';
+
+figma.connect(
+  'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=5622-11416&t=NUUDTGV2YnFjzS2O-4',
+  {
+    props: {
+      disabled: figma.enum('state', {
+        disabled: true
+      }),
+      rows: figma.enum('rows', {
+        '2': '2',
+        '4 (default)': undefined,
+        '6': '6'
+      }),
+      label: figma.boolean('label?', {
+        true: figma.string('✏️ label'),
+        false: undefined
+      }),
+      tooltip: figma.boolean('tooltip?', {
+        true: '{Include tooltip text here}',
+        false: undefined
+      }),
+      contextNote: figma.boolean('context note?', {
+        true: figma.string('✏️ note text'),
+        false: undefined
+      }),
+      helpText: figma.boolean('help text?', {
+        true: figma.string('✏️ help text'),
+        false: undefined
+      }),
+      required: figma.boolean('required?'),
+      resize: figma.boolean('resize?', {
+        true: undefined,
+        false: 'none'
+      })
+    },
+    example: ({ rows, label, tooltip, contextNote, helpText, required, resize, disabled }) => {
+      return (
+        /* When rendering with ts_form_for */
+        /* = ts_form_for ... do |f|
+        /* .. = f.input :field,
+        /* .. as: :text,
+        /* .. input_html: {
+        /* .... { attribute: value,
+        /* ...... attribute: value, }  */
+        <sl-textarea
+          rows={rows}
+          label={label}
+          label-tooltip={tooltip}
+          context-note={contextNote}
+          help-text={helpText}
+          required={required}
+          resize={resize}
+          disabled={disabled}
+        ></sl-textarea>
+      );
+    }
+  }
+);

--- a/figma_connect/textarea.figma.tsx
+++ b/figma_connect/textarea.figma.tsx
@@ -43,8 +43,9 @@ figma.connect(
         /* .. = f.input :foo,
         /* .. as: :text,
         /* .. input_html: {
-        /* .... { attribute: value,
-        /* ...... attribute: value }  */
+        /* .... label: "Label text",
+        /* .... "help-text": "Help text",
+        /* .... attribute: value ... }  */
         <sl-textarea
           disabled={disabled}
           rows={rows}

--- a/figma_connect/textarea.figma.tsx
+++ b/figma_connect/textarea.figma.tsx
@@ -19,6 +19,7 @@ figma.connect(
         true: figma.string('✏️ label'),
         false: undefined
       }),
+      required: figma.boolean('required?'),
       tooltip: figma.boolean('tooltip?', {
         true: '{Include tooltip text here}',
         false: undefined
@@ -31,30 +32,28 @@ figma.connect(
         true: figma.string('✏️ help text'),
         false: undefined
       }),
-      required: figma.boolean('required?'),
       resize: figma.boolean('resize?', {
         true: undefined,
         false: 'none'
       })
     },
-    example: ({ rows, label, tooltip, contextNote, helpText, required, resize, disabled }) => {
+    example: ({ disabled, rows, label, required, tooltip, contextNote, helpText, resize }) => {
       return (
-        /* When rendering with ts_form_for */
         /* = ts_form_for ... do |f|
-        /* .. = f.input :field,
+        /* .. = f.input :foo,
         /* .. as: :text,
         /* .. input_html: {
         /* .... { attribute: value,
-        /* ...... attribute: value, }  */
+        /* ...... attribute: value }  */
         <sl-textarea
+          disabled={disabled}
           rows={rows}
           label={label}
+          required={required}
           label-tooltip={tooltip}
           context-note={contextNote}
           help-text={helpText}
-          required={required}
           resize={resize}
-          disabled={disabled}
         ></sl-textarea>
       );
     }

--- a/figma_connect/tooltip.figma.tsx
+++ b/figma_connect/tooltip.figma.tsx
@@ -1,0 +1,84 @@
+// @ts-nocheck
+
+import React from 'react';
+import figma from '@figma/code-connect';
+
+figma.connect(
+  'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=8106-945&t=j7gCllmM5d054D0f-4',
+  {
+    variant: { placement: 'top' },
+    props: {
+      content: figma.string('✏️ content'),
+      placement: figma.nestedProps('top', {
+        topPlacement: figma.enum('arrow-placement', {
+          default: 'top',
+          start: 'top-start',
+          end: 'top-end'
+        })
+      })
+    },
+    example: ({ content, placement }) => {
+      return <sl-tooltip content={content} placement={placement.topPlacement}></sl-tooltip>;
+    }
+  }
+);
+
+figma.connect(
+  'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=8106-945&t=j7gCllmM5d054D0f-4',
+  {
+    variant: { placement: 'bottom' },
+    props: {
+      content: figma.string('✏️ content'),
+      placement: figma.nestedProps('bottom', {
+        bottomPlacement: figma.enum('arrow-placement', {
+          default: 'bottom',
+          start: 'bottom-start',
+          end: 'bottom-end'
+        })
+      })
+    },
+    example: ({ content, placement }) => {
+      return <sl-tooltip content={content} placement={placement.bottomPlacement}></sl-tooltip>;
+    }
+  }
+);
+
+figma.connect(
+  'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=8106-945&t=j7gCllmM5d054D0f-4',
+  {
+    variant: { placement: 'right' },
+    props: {
+      content: figma.string('✏️ content'),
+      placement: figma.nestedProps('right', {
+        rightPlacement: figma.enum('arrow-placement', {
+          default: 'right',
+          start: 'right-start',
+          end: 'right-end'
+        })
+      })
+    },
+    example: ({ content, placement }) => {
+      return <sl-tooltip content={content} placement={placement.rightPlacement}></sl-tooltip>;
+    }
+  }
+);
+
+figma.connect(
+  'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=8106-945&t=j7gCllmM5d054D0f-4',
+  {
+    variant: { placement: 'left' },
+    props: {
+      content: figma.string('✏️ content'),
+      placement: figma.nestedProps('left', {
+        leftPlacement: figma.enum('arrow-placement', {
+          default: 'left',
+          start: 'left-start',
+          end: 'left-end'
+        })
+      })
+    },
+    example: ({ content, placement }) => {
+      return <sl-tooltip content={content} placement={placement.leftPlacement}></sl-tooltip>;
+    }
+  }
+);

--- a/figma_connect/tooltip.figma.tsx
+++ b/figma_connect/tooltip.figma.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import figma from '@figma/code-connect';
 
+/* placement 'top' tooltips */
 figma.connect(
   'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=8106-945&t=j7gCllmM5d054D0f-4',
   {
@@ -23,6 +24,7 @@ figma.connect(
   }
 );
 
+/* placement 'bottom' tooltips */
 figma.connect(
   'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=8106-945&t=j7gCllmM5d054D0f-4',
   {
@@ -43,6 +45,7 @@ figma.connect(
   }
 );
 
+/* placement 'right' tooltips */
 figma.connect(
   'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=8106-945&t=j7gCllmM5d054D0f-4',
   {
@@ -63,6 +66,7 @@ figma.connect(
   }
 );
 
+/* placement 'left' tooltips */
 figma.connect(
   'https://www.figma.com/design/BrXOVNTglDWg03DL7ZZeW1/Teamshares-UI?node-id=8106-945&t=j7gCllmM5d054D0f-4',
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@ctrl/tinycolor": "^4.0.2",
+        "@figma/code-connect": "^1.0.3",
         "@floating-ui/dom": "^1.5.3",
         "@lit/react": "^1.0.0",
         "@shoelace-style/animations": "^1.1.0",
@@ -243,102 +244,257 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/@babel/code-frame": {
-      "version": "7.23.4",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.4.tgz",
-      "integrity": "sha512-r1IONyb6Ia+jYR2vvIDhdWdlTGhqbBoFqLTQidzZ4kepUFH15ejXvFHxCVbtl7BOXIudsIubf4E81xeA3h3IXA==",
-      "dev": true,
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
       "dependencies": {
-        "@babel/highlight": "^7.23.4",
-        "chalk": "^2.4.2"
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
+      "integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
+      "dependencies": {
+        "@babel/highlight": "^7.24.7",
+        "picocolors": "^1.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/code-frame/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
+    "node_modules/@babel/compat-data": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.24.7.tgz",
+      "integrity": "sha512-qJzAIcv03PyaWqxRgO4mSU3lihncDT296vnyuE2O8uA4w3UHWI4S3hgeZd1L8W1Bft40w9JxJ2b412iDUFFRhw==",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.7.tgz",
+      "integrity": "sha512-nykK+LEK86ahTkX/3TgauT0ikKoNCfKHEaZYTUVupJdTLzGNvrblu4u6fa7DhZONAltdf8e662t/abY8idrd/g==",
       "dependencies": {
-        "color-convert": "^1.9.0"
+        "@ampproject/remapping": "^2.2.0",
+        "@babel/code-frame": "^7.24.7",
+        "@babel/generator": "^7.24.7",
+        "@babel/helper-compilation-targets": "^7.24.7",
+        "@babel/helper-module-transforms": "^7.24.7",
+        "@babel/helpers": "^7.24.7",
+        "@babel/parser": "^7.24.7",
+        "@babel/template": "^7.24.7",
+        "@babel/traverse": "^7.24.7",
+        "@babel/types": "^7.24.7",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
       }
     },
-    "node_modules/@babel/code-frame/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.7.tgz",
+      "integrity": "sha512-oipXieGC3i45Y1A41t4tAqpnEZWgB/lC6Ehh6+rOviR5XWpTtMmLN+fGjz9vOiNRt0p6RtO6DtD0pdU3vpqdSA==",
       "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
+        "@babel/types": "^7.24.7",
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "jsesc": "^2.5.1"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/code-frame/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.24.7.tgz",
+      "integrity": "sha512-ctSdRHBi20qWOfy27RUb4Fhp07KSJ3sXcuSvTrXrc4aG8NSYDo1ici3Vhg9bg69y5bj0Mr1lh0aeEgTvc12rMg==",
       "dependencies": {
-        "has-flag": "^3.0.0"
+        "@babel/compat-data": "^7.24.7",
+        "@babel/helper-validator-option": "^7.24.7",
+        "browserslist": "^4.22.2",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+    },
+    "node_modules/@babel/helper-environment-visitor": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.24.7.tgz",
+      "integrity": "sha512-DoiN84+4Gnd0ncbBOM9AZENV4a5ZiL39HYMyZJGZ/AZEykHYdJw0wW3kdcsh9/Kn+BRXHLkkklZ51ecPKmI1CQ==",
+      "dependencies": {
+        "@babel/types": "^7.24.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-function-name": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.24.7.tgz",
+      "integrity": "sha512-FyoJTsj/PEUWu1/TYRiXTIHc8lbw+TDYkZuoE43opPS5TrI7MyONBE1oNvfguEXAD9yhQRrVBnXdXzSLQl9XnA==",
+      "dependencies": {
+        "@babel/template": "^7.24.7",
+        "@babel/types": "^7.24.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-hoist-variables": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.24.7.tgz",
+      "integrity": "sha512-MJJwhkoGy5c4ehfoRyrJ/owKeMl19U54h27YYftT0o2teQ3FJ3nQUf/I3LlJsX4l3qlw7WRXUmiyajvHXoTubQ==",
+      "dependencies": {
+        "@babel/types": "^7.24.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.24.7.tgz",
+      "integrity": "sha512-8AyH3C+74cgCVVXow/myrynrAGv+nTVg5vKu2nZph9x7RcRwzmh0VFallJuFTZ9mx6u4eSdXZfcOzSqTUm0HCA==",
+      "dependencies": {
+        "@babel/traverse": "^7.24.7",
+        "@babel/types": "^7.24.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.24.7.tgz",
+      "integrity": "sha512-1fuJEwIrp+97rM4RWdO+qrRsZlAeL1lQJoPqtCYWv0NL115XM93hIH4CSRln2w52SqvmY5hqdtauB6QFCDiZNQ==",
+      "dependencies": {
+        "@babel/helper-environment-visitor": "^7.24.7",
+        "@babel/helper-module-imports": "^7.24.7",
+        "@babel/helper-simple-access": "^7.24.7",
+        "@babel/helper-split-export-declaration": "^7.24.7",
+        "@babel/helper-validator-identifier": "^7.24.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-simple-access": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.24.7.tgz",
+      "integrity": "sha512-zBAIvbCMh5Ts+b86r/CjU+4XGYIs+R1j951gxI3KmmxBMhCg4oQMsv6ZXQ64XOm/cvzfU1FmoCyt6+owc5QMYg==",
+      "dependencies": {
+        "@babel/traverse": "^7.24.7",
+        "@babel/types": "^7.24.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-split-export-declaration": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.7.tgz",
+      "integrity": "sha512-oy5V7pD+UvfkEATUKvIjvIAH/xCzfsFVw7ygW2SI6NClZzquT+mwdTfgfdbUiceh6iQO0CHtCPsyze/MZ2YbAA==",
+      "dependencies": {
+        "@babel/types": "^7.24.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.23.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.23.4.tgz",
-      "integrity": "sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==",
-      "dev": true,
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.7.tgz",
+      "integrity": "sha512-7MbVt6xrwFQbunH2DNQsAP5sTGxfqQtErvBIvIMi6EQnbgUOuVYanvREcmFrOPhoXBrTtjhhP+lW+o5UfK+tDg==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
-      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
-      "dev": true,
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
+      "integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.24.7.tgz",
+      "integrity": "sha512-yy1/KvjhV/ZCL+SM7hBrvnZJ3ZuT9OuZgIJAGpPEToANvc3iM6iDvBnRjtElWibHU6n8/LPR/EjX9EtIEYO3pw==",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.24.7.tgz",
+      "integrity": "sha512-NlmJJtvcw72yRJRcnCmGvSi+3jDEg8qFu3z0AFoymmzLx5ERVWyzd9kVXr7Th9/8yIJi2Zc6av4Tqz3wFs8QWg==",
+      "dependencies": {
+        "@babel/template": "^7.24.7",
+        "@babel/types": "^7.24.7"
+      },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.23.4",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
-      "integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
-      "dev": true,
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
+      "integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.22.20",
+        "@babel/helper-validator-identifier": "^7.24.7",
         "chalk": "^2.4.2",
-        "js-tokens": "^4.0.0"
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -348,7 +504,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -360,7 +515,6 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -374,7 +528,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -383,7 +536,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -392,7 +544,6 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -401,10 +552,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.23.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.4.tgz",
-      "integrity": "sha512-vf3Xna6UEprW+7t6EtOmFpHNAuxw3xqPZghy+brsnusscJRW5BMUzzHZc5ICjULee81WeUV2jjakG09MDglJXQ==",
-      "dev": true,
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.7.tgz",
+      "integrity": "sha512-9uUYRm6OqQrCqQdG1iCBwBPZgN8ciDBro2nIOFaiRz1/BCxaI7CNvQbDHvsArAC7Tw9Hda/B3U+6ui9u4HWXPw==",
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -412,14 +562,54 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@babel/types": {
-      "version": "7.23.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.4.tgz",
-      "integrity": "sha512-7uIFwVYpoplT5jp/kVv6EF93VaJ8H+Yn5IczYiaAi98ajzjfoZfslet/e0sLh+wVBjb2qqIut1b0S26VSafsSQ==",
-      "dev": true,
+    "node_modules/@babel/template": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.7.tgz",
+      "integrity": "sha512-jYqfPrU9JTF0PmPy1tLYHW4Mp4KlgxJD9l2nP9fD6yT/ICi554DmrWBAEYpIelzjHf1msDP3PxJIRt/nFNfBig==",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.23.4",
-        "@babel/helper-validator-identifier": "^7.22.20",
+        "@babel/code-frame": "^7.24.7",
+        "@babel/parser": "^7.24.7",
+        "@babel/types": "^7.24.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.7.tgz",
+      "integrity": "sha512-yb65Ed5S/QAcewNPh0nZczy9JdYXkkAbIsEo+P7BE7yO3txAY30Y/oPa3QkQ5It3xVG2kpKMg9MsdxZaO31uKA==",
+      "dependencies": {
+        "@babel/code-frame": "^7.24.7",
+        "@babel/generator": "^7.24.7",
+        "@babel/helper-environment-visitor": "^7.24.7",
+        "@babel/helper-function-name": "^7.24.7",
+        "@babel/helper-hoist-variables": "^7.24.7",
+        "@babel/helper-split-export-declaration": "^7.24.7",
+        "@babel/parser": "^7.24.7",
+        "@babel/types": "^7.24.7",
+        "debug": "^4.3.1",
+        "globals": "^11.1.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse/node_modules/globals": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.7.tgz",
+      "integrity": "sha512-XEFXSlxiG5td2EJRe8vOmRbaXVgfcBlszKujvVmWIK/UpywWljQCfzAv3RQCGujWQ1RD4YYWEAqDXfuJiy8f5Q==",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.24.7",
+        "@babel/helper-validator-identifier": "^7.24.7",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -1390,6 +1580,329 @@
         "@types/chai": "^4.2.12"
       }
     },
+    "node_modules/@figma/code-connect": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@figma/code-connect/-/code-connect-1.0.3.tgz",
+      "integrity": "sha512-fZzvvAb3LXVUxjD/PjMW8jMh1Ur17I4AQ6DQyDQ99W9P/dCQVd3CLkWRFYPQtOut5whP3DmLNpERlTIzCcJlSg==",
+      "dependencies": {
+        "@babel/core": "^7.24.7",
+        "@babel/generator": "^7.24.7",
+        "@babel/parser": "^7.24.7",
+        "@babel/types": "^7.24.7",
+        "@storybook/csf-tools": "^7.6.7",
+        "axios": "^1.6.0",
+        "boxen": "5.1.1",
+        "chalk": "^4.1.2",
+        "commander": "^11.1.0",
+        "compare-versions": "^6.1.0",
+        "cross-spawn": "^7.0.3",
+        "dotenv": "^16.3.1",
+        "fast-fuzzy": "^1.12.0",
+        "find-up": "^5.0.0",
+        "glob": "^10.3.10",
+        "lodash": "^4.17.21",
+        "minimatch": "^9.0.3",
+        "ora": "^5.4.1",
+        "prettier": "^2.8.8",
+        "prompts": "^2.4.2",
+        "strip-ansi": "^6.0.0",
+        "typescript": "5.4.2",
+        "zod": "^3.23.6",
+        "zod-validation-error": "^3.2.0"
+      },
+      "bin": {
+        "figma": "bin/figma"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@figma/code-connect/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@figma/code-connect/node_modules/axios": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
+      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/@figma/code-connect/node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/@figma/code-connect/node_modules/boxen": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-5.1.1.tgz",
+      "integrity": "sha512-JtIQYts08AFAYGF4eSh3pUt3NQkYV/e75pRtQmAVTLNWR/1L7Bsswxlgzgk8nmLEM+gFszsIlA9BgD3XnSqp3g==",
+      "dependencies": {
+        "ansi-align": "^3.0.0",
+        "camelcase": "^6.2.0",
+        "chalk": "^4.1.0",
+        "cli-boxes": "^2.2.1",
+        "string-width": "^4.2.2",
+        "type-fest": "^0.20.2",
+        "widest-line": "^3.1.0",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@figma/code-connect/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@figma/code-connect/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/@figma/code-connect/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@figma/code-connect/node_modules/cli-boxes": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",
+      "integrity": "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@figma/code-connect/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@figma/code-connect/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/@figma/code-connect/node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@figma/code-connect/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "node_modules/@figma/code-connect/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@figma/code-connect/node_modules/is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@figma/code-connect/node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@figma/code-connect/node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@figma/code-connect/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@figma/code-connect/node_modules/ora": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "dependencies": {
+        "bl": "^4.1.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "is-unicode-supported": "^0.1.0",
+        "log-symbols": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@figma/code-connect/node_modules/prettier": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/@figma/code-connect/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@figma/code-connect/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@figma/code-connect/node_modules/widest-line": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
+      "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
+      "dependencies": {
+        "string-width": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@figma/code-connect/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/@floating-ui/core": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.5.0.tgz",
@@ -1467,7 +1980,6 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-      "dev": true,
       "dependencies": {
         "string-width": "^5.1.2",
         "string-width-cjs": "npm:string-width@^4.2.0",
@@ -1484,7 +1996,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
       "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
-      "dev": true,
       "engines": {
         "node": ">=12"
       },
@@ -1496,7 +2007,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
       "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-      "dev": true,
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -1507,11 +2017,31 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
+      "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
+      "dependencies": {
+        "@jridgewell/set-array": "^1.2.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
       "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
-      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/set-array": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
       "engines": {
         "node": ">=6.0.0"
       }
@@ -1519,14 +2049,12 @@
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.15",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
-      "dev": true
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.20",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.20.tgz",
-      "integrity": "sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==",
-      "dev": true,
+      "version": "0.3.25",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -1810,7 +2338,6 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "dev": true,
       "optional": true,
       "engines": {
         "node": ">=14"
@@ -2298,6 +2825,138 @@
       "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==",
       "dev": true
     },
+    "node_modules/@storybook/channels": {
+      "version": "7.6.20",
+      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-7.6.20.tgz",
+      "integrity": "sha512-4hkgPSH6bJclB2OvLnkZOGZW1WptJs09mhQ6j6qLjgBZzL/ZdD6priWSd7iXrmPiN5TzUobkG4P4Dp7FjkiO7A==",
+      "dependencies": {
+        "@storybook/client-logger": "7.6.20",
+        "@storybook/core-events": "7.6.20",
+        "@storybook/global": "^5.0.0",
+        "qs": "^6.10.0",
+        "telejson": "^7.2.0",
+        "tiny-invariant": "^1.3.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/client-logger": {
+      "version": "7.6.20",
+      "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-7.6.20.tgz",
+      "integrity": "sha512-NwG0VIJQCmKrSaN5GBDFyQgTAHLNishUPLW1NrzqTDNAhfZUoef64rPQlinbopa0H4OXmlB+QxbQIb3ubeXmSQ==",
+      "dependencies": {
+        "@storybook/global": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/core-events": {
+      "version": "7.6.20",
+      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-7.6.20.tgz",
+      "integrity": "sha512-tlVDuVbDiNkvPDFAu+0ou3xBBYbx9zUURQz4G9fAq0ScgBOs/bpzcRrFb4mLpemUViBAd47tfZKdH4MAX45KVQ==",
+      "dependencies": {
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/csf": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@storybook/csf/-/csf-0.1.9.tgz",
+      "integrity": "sha512-JlZ6v/iFn+iKohKGpYXnMeNeTiiAMeFoDhYnPLIC8GnyyIWqEI9wJYrOK9i9rxlJ8NZAH/ojGC/u/xVC41qSgQ==",
+      "dependencies": {
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/@storybook/csf-tools": {
+      "version": "7.6.20",
+      "resolved": "https://registry.npmjs.org/@storybook/csf-tools/-/csf-tools-7.6.20.tgz",
+      "integrity": "sha512-rwcwzCsAYh/m/WYcxBiEtLpIW5OH1ingxNdF/rK9mtGWhJxXRDV8acPkFrF8rtFWIVKoOCXu5USJYmc3f2gdYQ==",
+      "dependencies": {
+        "@babel/generator": "^7.23.0",
+        "@babel/parser": "^7.23.0",
+        "@babel/traverse": "^7.23.2",
+        "@babel/types": "^7.23.0",
+        "@storybook/csf": "^0.1.2",
+        "@storybook/types": "7.6.20",
+        "fs-extra": "^11.1.0",
+        "recast": "^0.23.1",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/csf-tools/node_modules/fs-extra": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/@storybook/csf-tools/node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@storybook/csf-tools/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@storybook/csf/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@storybook/global": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@storybook/global/-/global-5.0.0.tgz",
+      "integrity": "sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ=="
+    },
+    "node_modules/@storybook/types": {
+      "version": "7.6.20",
+      "resolved": "https://registry.npmjs.org/@storybook/types/-/types-7.6.20.tgz",
+      "integrity": "sha512-GncdY3x0LpbhmUAAJwXYtJDUQEwfF175gsjH0/fxPkxPoV7Sef9TM41jQLJW/5+6TnZoCZP/+aJZTJtq3ni23Q==",
+      "dependencies": {
+        "@storybook/channels": "7.6.20",
+        "@types/babel__core": "^7.0.0",
+        "@types/express": "^4.7.0",
+        "file-system-cache": "2.3.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
     "node_modules/@szmarczak/http-timer": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",
@@ -2386,11 +3045,47 @@
       "integrity": "sha512-Anitqkl3+KrzcW2k77lRlg/GfLZLWXBuNgbEcIOU6M92yw42vsd3xV/Z/yAHEj8m+KUjL6bWOVOFqX8PFPJ4LA==",
       "dev": true
     },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.6.8",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.8.tgz",
+      "integrity": "sha512-ASsj+tpEDsEiFr1arWrlN6V3mdfjRMZt6LtK/Vp/kreFLnr5QH5+DhvD5nINYZXzwJvXeGq+05iUXcAzVrqWtw==",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.20.6",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.6.tgz",
+      "integrity": "sha512-r1bzfrm0tomOI8g1SzvCaQHo6Lcv6zu0EA+W2kHrt8dyrHQxGzBBL4kdkzIS+jBMV+EYcMAEAqXqYaLJq5rOZg==",
+      "dependencies": {
+        "@babel/types": "^7.20.7"
+      }
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.5",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
       "integrity": "sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==",
-      "dev": true,
       "dependencies": {
         "@types/connect": "*",
         "@types/node": "*"
@@ -2431,7 +3126,6 @@
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
-      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -2491,7 +3185,6 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
       "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
-      "dev": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.33",
@@ -2503,7 +3196,6 @@
       "version": "4.17.41",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.41.tgz",
       "integrity": "sha512-OaJ7XLaelTgrvlZD8/aa0vvvxZdUmlCn6MtWeB7TkiKW70BQLc9XEPpDLPdbo52ZhXUCrznlWdCHWxJWtdyajA==",
-      "dev": true,
       "dependencies": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -2532,8 +3224,7 @@
     "node_modules/@types/http-errors": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
-      "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
-      "dev": true
+      "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA=="
     },
     "node_modules/@types/inquirer": {
       "version": "9.0.7",
@@ -2634,8 +3325,7 @@
     "node_modules/@types/mime": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
-      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
-      "dev": true
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w=="
     },
     "node_modules/@types/minimatch": {
       "version": "3.0.5",
@@ -2653,7 +3343,6 @@
       "version": "20.9.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.3.tgz",
       "integrity": "sha512-nk5wXLAXGBKfrhLB0cyHGbSqopS+nz0BUgZkUQqSHSSgdee0kssp1IAqlQOu333bW+gMNs2QREx7iynm19Abxw==",
-      "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -2672,14 +3361,12 @@
     "node_modules/@types/qs": {
       "version": "6.9.10",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.10.tgz",
-      "integrity": "sha512-3Gnx08Ns1sEoCrWssEgTSJs/rsT2vhGP+Ja9cnnk9k4ALxinORlQneLXFeFKOTJMOeZUFD1s7w+w2AphTpvzZw==",
-      "dev": true
+      "integrity": "sha512-3Gnx08Ns1sEoCrWssEgTSJs/rsT2vhGP+Ja9cnnk9k4ALxinORlQneLXFeFKOTJMOeZUFD1s7w+w2AphTpvzZw=="
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
-      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
-      "dev": true
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="
     },
     "node_modules/@types/react": {
       "version": "18.2.38",
@@ -2712,7 +3399,6 @@
       "version": "0.17.4",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
       "integrity": "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==",
-      "dev": true,
       "dependencies": {
         "@types/mime": "^1",
         "@types/node": "*"
@@ -2722,7 +3408,6 @@
       "version": "1.15.5",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.5.tgz",
       "integrity": "sha512-PDRk21MnK70hja/YF8AHfC7yIsiQHn1rcXx7ijCFBX/k+XQJhQT/gw3xekXKJvx+5SXaMMS8oqQy09Mzvz2TuQ==",
-      "dev": true,
       "dependencies": {
         "@types/http-errors": "*",
         "@types/mime": "*",
@@ -4131,7 +4816,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
       "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
-      "dev": true,
       "dependencies": {
         "string-width": "^4.1.0"
       }
@@ -4139,14 +4823,12 @@
     "node_modules/ansi-align/node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "node_modules/ansi-align/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -4155,7 +4837,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -4204,7 +4885,6 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
       "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
-      "dev": true,
       "engines": {
         "node": ">=12"
       },
@@ -4536,8 +5216,7 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/autoprefixer": {
       "version": "10.4.18",
@@ -4632,14 +5311,12 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5305,7 +5982,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.5.tgz",
       "integrity": "sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==",
-      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.2",
         "get-intrinsic": "^1.2.1",
@@ -5338,7 +6014,6 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
       "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -5671,7 +6346,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
       "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-      "dev": true,
       "dependencies": {
         "restore-cursor": "^3.1.0"
       },
@@ -5683,7 +6357,6 @@
       "version": "2.9.1",
       "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.1.tgz",
       "integrity": "sha512-jHgecW0pxkonBJdrKsqxgRX9AcG+u/5k0Q7WPDfi8AogLAdwxEkyYYNWwZ5GvVFoFx2uiY1eNcSK00fh+1+FyQ==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       },
@@ -5889,7 +6562,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "dependencies": {
         "color-name": "1.1.3"
       }
@@ -5897,8 +6569,7 @@
     "node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
     "node_modules/color-support": {
       "version": "1.1.3",
@@ -5919,7 +6590,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -6008,6 +6678,11 @@
       "engines": {
         "node": ">= 12.0.0"
       }
+    },
+    "node_modules/compare-versions": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.0.tgz",
+      "integrity": "sha512-LNZQXhqUvqUTotpZ00qLSaify3b4VFD588aRr8MKFw4CMUr98ytzCW5wDH5qx/DEY5kCDXcbcRuCqL0szEf2tg=="
     },
     "node_modules/composed-offset-position": {
       "version": "0.0.4",
@@ -6182,8 +6857,7 @@
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
-      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="
     },
     "node_modules/cookie": {
       "version": "0.4.2",
@@ -6254,7 +6928,6 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
       "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-      "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -6641,7 +7314,6 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -6908,7 +7580,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
       "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
-      "dev": true,
       "dependencies": {
         "clone": "^1.0.2"
       },
@@ -6920,7 +7591,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
       "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
-      "dev": true,
       "engines": {
         "node": ">=0.8"
       }
@@ -6938,7 +7608,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.1.tgz",
       "integrity": "sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==",
-      "dev": true,
       "dependencies": {
         "get-intrinsic": "^1.2.1",
         "gopd": "^1.0.1",
@@ -7014,7 +7683,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -7250,6 +7918,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/dotenv": {
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/download": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/download/-/download-8.0.0.tgz",
@@ -7315,8 +7994,7 @@
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "dev": true
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
     },
     "node_modules/easy-extender": {
       "version": "2.3.4",
@@ -8222,7 +8900,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true,
       "bin": {
         "esparse": "bin/esparse.js",
         "esvalidate": "bin/esvalidate.js"
@@ -8469,6 +9146,14 @@
       "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
       "dev": true
     },
+    "node_modules/fast-fuzzy": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/fast-fuzzy/-/fast-fuzzy-1.12.0.tgz",
+      "integrity": "sha512-sXxGgHS+ubYpsdLnvOvJ9w5GYYZrtL9mkosG3nfuD446ahvoWEsSKBP7ieGmWIKVLnaxRDgUJkZMdxRgA2Ni+Q==",
+      "dependencies": {
+        "graphemesplit": "^2.4.1"
+      }
+    },
     "node_modules/fast-glob": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
@@ -8557,6 +9242,47 @@
       },
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/file-system-cache": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/file-system-cache/-/file-system-cache-2.3.0.tgz",
+      "integrity": "sha512-l4DMNdsIPsVnKrgEXbJwDJsA5mB8rGwHYERMgqQx/xAUtChPJMre1bXBzDEqqVbWv9AIbFezXMxeEkZDSrXUOQ==",
+      "dependencies": {
+        "fs-extra": "11.1.1",
+        "ramda": "0.29.0"
+      }
+    },
+    "node_modules/file-system-cache/node_modules/fs-extra": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
+      "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/file-system-cache/node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/file-system-cache/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/file-type": {
@@ -8681,7 +9407,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-      "dev": true,
       "dependencies": {
         "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
@@ -8754,10 +9479,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
-      "dev": true,
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
       "funding": [
         {
           "type": "individual",
@@ -8807,7 +9531,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
       "integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
-      "dev": true,
       "dependencies": {
         "cross-spawn": "^7.0.0",
         "signal-exit": "^4.0.1"
@@ -8823,7 +9546,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
       "engines": {
         "node": ">=14"
       },
@@ -8835,7 +9557,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -8986,7 +9707,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -9075,6 +9795,14 @@
         "node": ">=14"
       }
     },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -9087,7 +9815,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.2.tgz",
       "integrity": "sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==",
-      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.2",
         "has-proto": "^1.0.1",
@@ -9192,7 +9919,6 @@
       "version": "10.3.10",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
       "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
-      "dev": true,
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^2.3.5",
@@ -9225,7 +9951,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -9234,7 +9959,6 @@
       "version": "9.0.3",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
       "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
-      "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -9363,7 +10087,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
       "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-      "dev": true,
       "dependencies": {
         "get-intrinsic": "^1.1.3"
       },
@@ -9427,6 +10150,15 @@
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
+    },
+    "node_modules/graphemesplit": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/graphemesplit/-/graphemesplit-2.4.4.tgz",
+      "integrity": "sha512-lKrpp1mk1NH26USxC/Asw4OHbhSQf5XfrWZ+CDv/dFVvd1j17kFgMotdJvOesmHkbFX9P9sBfpH8VogxOWLg8w==",
+      "dependencies": {
+        "js-base64": "^3.6.0",
+        "unicode-trie": "^2.0.0"
+      }
     },
     "node_modules/gray-matter": {
       "version": "4.0.3",
@@ -9514,7 +10246,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -9532,7 +10263,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.1.tgz",
       "integrity": "sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==",
-      "dev": true,
       "dependencies": {
         "get-intrinsic": "^1.2.2"
       },
@@ -9544,7 +10274,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
       "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -9565,7 +10294,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
       "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -9622,7 +10350,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
       "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
-      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -9881,7 +10608,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -10055,8 +10781,7 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/ini": {
       "version": "4.1.1",
@@ -11059,8 +11784,7 @@
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
     "node_modules/iso-639-1": {
       "version": "2.1.15",
@@ -11148,7 +11872,6 @@
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.6.tgz",
       "integrity": "sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==",
-      "dev": true,
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
       },
@@ -11235,6 +11958,11 @@
       "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
       "dev": true
     },
+    "node_modules/js-base64": {
+      "version": "3.7.7",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.7.tgz",
+      "integrity": "sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw=="
+    },
     "node_modules/js-levenshtein-esm": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/js-levenshtein-esm/-/js-levenshtein-esm-1.2.0.tgz",
@@ -11250,8 +11978,7 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -11356,6 +12083,17 @@
         "node": ">=14"
       }
     },
+    "node_modules/jsesc": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -11393,7 +12131,6 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true,
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -12130,7 +12867,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "dev": true,
       "dependencies": {
         "p-locate": "^5.0.0"
       },
@@ -12144,8 +12880,7 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.assignwith": {
       "version": "4.2.0",
@@ -12483,6 +13218,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/map-or-similar": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/map-or-similar/-/map-or-similar-1.5.0.tgz",
+      "integrity": "sha512-0aF7ZmVon1igznGI4VS30yugpduQW3y3GkcgGJOp7d8x8QrizhigUxjI/m2UojsXXto+jLAH3KSz+xOJTiORjg=="
+    },
     "node_modules/markdown-it": {
       "version": "13.0.2",
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-13.0.2.tgz",
@@ -12625,6 +13365,14 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/memoizerific": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/memoizerific/-/memoizerific-1.11.3.tgz",
+      "integrity": "sha512-/EuHYwAPdLtXwAwSZkh/Gutery6pD2KYd44oQLhAvQp/50mpyduZh8Q7PYHXTCJ+wuXxt7oij2LXyIJOOYFPog==",
+      "dependencies": {
+        "map-or-similar": "^1.5.0"
+      }
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -12687,7 +13435,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -12696,7 +13443,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -12750,7 +13496,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
       "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -12963,8 +13708,7 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/multimatch": {
       "version": "5.0.0",
@@ -13974,7 +14718,6 @@
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
       "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -14369,7 +15112,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "dev": true,
       "dependencies": {
         "yocto-queue": "^0.1.0"
       },
@@ -14384,7 +15126,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "dev": true,
       "dependencies": {
         "p-limit": "^3.0.2"
       },
@@ -14726,6 +15467,11 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA=="
+    },
     "node_modules/param-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
@@ -14873,7 +15619,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -14891,7 +15636,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -14927,7 +15671,6 @@
       "version": "1.10.1",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.1.tgz",
       "integrity": "sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==",
-      "dev": true,
       "dependencies": {
         "lru-cache": "^9.1.1 || ^10.0.0",
         "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
@@ -14943,7 +15686,6 @@
       "version": "10.0.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.3.tgz",
       "integrity": "sha512-B7gr+F6MkqB3uzINHXNctGieGsRTMwIBgxkp0yq/5BwcuDzD4A8wQpHQW6vDAm1uKSLQghmRdD9sKqf2vJ1cEg==",
-      "dev": true,
       "engines": {
         "node": "14 || >=16.14"
       }
@@ -15526,6 +16268,18 @@
         "node": ">=10"
       }
     },
+    "node_modules/prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/prompts-ncu": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/prompts-ncu/-/prompts-ncu-3.0.0.tgz",
@@ -15537,6 +16291,14 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/prompts/node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/proto-list": {
@@ -15628,8 +16390,7 @@
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "dev": true
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/prr": {
       "version": "1.0.1",
@@ -15856,7 +16617,6 @@
       "version": "6.11.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.2.tgz",
       "integrity": "sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==",
-      "dev": true,
       "dependencies": {
         "side-channel": "^1.0.4"
       },
@@ -15922,6 +16682,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ramda": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.29.0.tgz",
+      "integrity": "sha512-BBea6L67bYLtdbOqfp8f58fPMqEwx0doL+pAi8TZyp2YWz8R9G8z9x75CZI8W+ftqhFHCpEX2cRnUUXK130iKA==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ramda"
       }
     },
     "node_modules/range-parser": {
@@ -16122,6 +16891,40 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/recast": {
+      "version": "0.23.9",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.23.9.tgz",
+      "integrity": "sha512-Hx/BGIbwj+Des3+xy5uAtAbdCyqK9y9wbBcDFDYanLS9JnMqf7OeF87HQwUimE87OEc72mr6tkKUKMBBL+hF9Q==",
+      "dependencies": {
+        "ast-types": "^0.16.1",
+        "esprima": "~4.0.0",
+        "source-map": "~0.6.1",
+        "tiny-invariant": "^1.3.3",
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/recast/node_modules/ast-types": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.16.1.tgz",
+      "integrity": "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/recast/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/rechoir": {
@@ -16465,7 +17268,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
       "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-      "dev": true,
       "dependencies": {
         "onetime": "^5.1.0",
         "signal-exit": "^3.0.2"
@@ -16478,7 +17280,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -16487,7 +17288,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-      "dev": true,
       "dependencies": {
         "mimic-fn": "^2.1.0"
       },
@@ -17039,7 +17839,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.1.1.tgz",
       "integrity": "sha512-VoaqjbBJKiWtg4yRcKBQ7g7wnGnLV3M8oLvVWwOk2PdYY6PEFegR1vezXR0tw6fZGF9csVakIRjrJiy2veSBFQ==",
-      "dev": true,
       "dependencies": {
         "define-data-property": "^1.1.1",
         "get-intrinsic": "^1.2.1",
@@ -17074,7 +17873,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -17086,7 +17884,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -17095,7 +17892,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
       "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
-      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.0",
         "get-intrinsic": "^1.0.2",
@@ -17108,8 +17904,7 @@
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
     },
     "node_modules/sigstore": {
       "version": "1.9.0",
@@ -17151,8 +17946,7 @@
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
-      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
-      "dev": true
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="
     },
     "node_modules/slash": {
       "version": "4.0.0",
@@ -17560,7 +18354,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -17568,8 +18361,7 @@
     "node_modules/string_decoder/node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/string-argv": {
       "version": "0.3.2",
@@ -17584,7 +18376,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "dev": true,
       "dependencies": {
         "eastasianwidth": "^0.2.0",
         "emoji-regex": "^9.2.2",
@@ -17602,7 +18393,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -17615,14 +18405,12 @@
     "node_modules/string-width-cjs/node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "node_modules/string-width-cjs/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -17631,7 +18419,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
       "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
-      "dev": true,
       "engines": {
         "node": ">=12"
       },
@@ -17642,14 +18429,12 @@
     "node_modules/string-width/node_modules/emoji-regex": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
     },
     "node_modules/string-width/node_modules/strip-ansi": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
       "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-      "dev": true,
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -17721,7 +18506,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -17820,7 +18604,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -17976,6 +18759,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/telejson": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/telejson/-/telejson-7.2.0.tgz",
+      "integrity": "sha512-1QTEcJkJEhc8OnStBx/ILRu5J2p0GjvWsBx56bmZRqnrkdBMUe+nX92jxV+p3dB4CP6PZCdJMQJwCggkNBMzkQ==",
+      "dependencies": {
+        "memoizerific": "^1.11.3"
+      }
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -18001,6 +18792,16 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw=="
+    },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="
     },
     "node_modules/title-case": {
       "version": "3.0.3",
@@ -18033,7 +18834,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
       "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -18133,6 +18933,14 @@
         "typescript": ">=4.2.0"
       }
     },
+    "node_modules/ts-dedent": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
+      "integrity": "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==",
+      "engines": {
+        "node": ">=6.10"
+      }
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.14.2",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz",
@@ -18160,8 +18968,7 @@
     "node_modules/tslib": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/tsscmp": {
       "version": "1.0.6",
@@ -18211,7 +19018,6 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -18307,10 +19113,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.2.tgz",
-      "integrity": "sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ==",
-      "dev": true,
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.2.tgz",
+      "integrity": "sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -18431,8 +19236,16 @@
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      }
     },
     "node_modules/unique-filename": {
       "version": "3.0.0",
@@ -18722,8 +19535,7 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",
@@ -18825,7 +19637,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
       "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
-      "dev": true,
       "dependencies": {
         "defaults": "^1.0.3"
       }
@@ -18877,7 +19688,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -19010,7 +19820,6 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
       "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^6.1.0",
         "string-width": "^5.0.1",
@@ -19028,7 +19837,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -19045,7 +19853,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -19060,7 +19867,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -19071,20 +19877,17 @@
     "node_modules/wrap-ansi-cjs/node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "node_modules/wrap-ansi-cjs/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -19093,7 +19896,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -19107,7 +19909,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
       "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
-      "dev": true,
       "engines": {
         "node": ">=12"
       },
@@ -19119,7 +19920,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
       "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-      "dev": true,
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -19308,12 +20108,30 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-validation-error": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-3.3.0.tgz",
+      "integrity": "sha512-Syib9oumw1NTqEv4LT0e6U83Td9aVRk9iTXPUQr1otyV1PuXQKOvOwhMNqZIq5hluzHP2pMgnOmHEo7kPdI2mw==",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.18.0"
       }
     }
   },
@@ -19428,87 +20246,203 @@
       "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
       "dev": true
     },
-    "@babel/code-frame": {
-      "version": "7.23.4",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.4.tgz",
-      "integrity": "sha512-r1IONyb6Ia+jYR2vvIDhdWdlTGhqbBoFqLTQidzZ4kepUFH15ejXvFHxCVbtl7BOXIudsIubf4E81xeA3h3IXA==",
-      "dev": true,
+    "@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
       "requires": {
-        "@babel/highlight": "^7.23.4",
-        "chalk": "^2.4.2"
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "@babel/code-frame": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
+      "integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
+      "requires": {
+        "@babel/highlight": "^7.24.7",
+        "picocolors": "^1.0.0"
+      }
+    },
+    "@babel/compat-data": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.24.7.tgz",
+      "integrity": "sha512-qJzAIcv03PyaWqxRgO4mSU3lihncDT296vnyuE2O8uA4w3UHWI4S3hgeZd1L8W1Bft40w9JxJ2b412iDUFFRhw=="
+    },
+    "@babel/core": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.7.tgz",
+      "integrity": "sha512-nykK+LEK86ahTkX/3TgauT0ikKoNCfKHEaZYTUVupJdTLzGNvrblu4u6fa7DhZONAltdf8e662t/abY8idrd/g==",
+      "requires": {
+        "@ampproject/remapping": "^2.2.0",
+        "@babel/code-frame": "^7.24.7",
+        "@babel/generator": "^7.24.7",
+        "@babel/helper-compilation-targets": "^7.24.7",
+        "@babel/helper-module-transforms": "^7.24.7",
+        "@babel/helpers": "^7.24.7",
+        "@babel/parser": "^7.24.7",
+        "@babel/template": "^7.24.7",
+        "@babel/traverse": "^7.24.7",
+        "@babel/types": "^7.24.7",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
       },
       "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
+        "semver": {
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
         }
       }
     },
+    "@babel/generator": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.7.tgz",
+      "integrity": "sha512-oipXieGC3i45Y1A41t4tAqpnEZWgB/lC6Ehh6+rOviR5XWpTtMmLN+fGjz9vOiNRt0p6RtO6DtD0pdU3vpqdSA==",
+      "requires": {
+        "@babel/types": "^7.24.7",
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "jsesc": "^2.5.1"
+      }
+    },
+    "@babel/helper-compilation-targets": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.24.7.tgz",
+      "integrity": "sha512-ctSdRHBi20qWOfy27RUb4Fhp07KSJ3sXcuSvTrXrc4aG8NSYDo1ici3Vhg9bg69y5bj0Mr1lh0aeEgTvc12rMg==",
+      "requires": {
+        "@babel/compat-data": "^7.24.7",
+        "@babel/helper-validator-option": "^7.24.7",
+        "browserslist": "^4.22.2",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+          "requires": {
+            "yallist": "^3.0.2"
+          }
+        },
+        "semver": {
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
+        },
+        "yallist": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+        }
+      }
+    },
+    "@babel/helper-environment-visitor": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.24.7.tgz",
+      "integrity": "sha512-DoiN84+4Gnd0ncbBOM9AZENV4a5ZiL39HYMyZJGZ/AZEykHYdJw0wW3kdcsh9/Kn+BRXHLkkklZ51ecPKmI1CQ==",
+      "requires": {
+        "@babel/types": "^7.24.7"
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.24.7.tgz",
+      "integrity": "sha512-FyoJTsj/PEUWu1/TYRiXTIHc8lbw+TDYkZuoE43opPS5TrI7MyONBE1oNvfguEXAD9yhQRrVBnXdXzSLQl9XnA==",
+      "requires": {
+        "@babel/template": "^7.24.7",
+        "@babel/types": "^7.24.7"
+      }
+    },
+    "@babel/helper-hoist-variables": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.24.7.tgz",
+      "integrity": "sha512-MJJwhkoGy5c4ehfoRyrJ/owKeMl19U54h27YYftT0o2teQ3FJ3nQUf/I3LlJsX4l3qlw7WRXUmiyajvHXoTubQ==",
+      "requires": {
+        "@babel/types": "^7.24.7"
+      }
+    },
+    "@babel/helper-module-imports": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.24.7.tgz",
+      "integrity": "sha512-8AyH3C+74cgCVVXow/myrynrAGv+nTVg5vKu2nZph9x7RcRwzmh0VFallJuFTZ9mx6u4eSdXZfcOzSqTUm0HCA==",
+      "requires": {
+        "@babel/traverse": "^7.24.7",
+        "@babel/types": "^7.24.7"
+      }
+    },
+    "@babel/helper-module-transforms": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.24.7.tgz",
+      "integrity": "sha512-1fuJEwIrp+97rM4RWdO+qrRsZlAeL1lQJoPqtCYWv0NL115XM93hIH4CSRln2w52SqvmY5hqdtauB6QFCDiZNQ==",
+      "requires": {
+        "@babel/helper-environment-visitor": "^7.24.7",
+        "@babel/helper-module-imports": "^7.24.7",
+        "@babel/helper-simple-access": "^7.24.7",
+        "@babel/helper-split-export-declaration": "^7.24.7",
+        "@babel/helper-validator-identifier": "^7.24.7"
+      }
+    },
+    "@babel/helper-simple-access": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.24.7.tgz",
+      "integrity": "sha512-zBAIvbCMh5Ts+b86r/CjU+4XGYIs+R1j951gxI3KmmxBMhCg4oQMsv6ZXQ64XOm/cvzfU1FmoCyt6+owc5QMYg==",
+      "requires": {
+        "@babel/traverse": "^7.24.7",
+        "@babel/types": "^7.24.7"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.7.tgz",
+      "integrity": "sha512-oy5V7pD+UvfkEATUKvIjvIAH/xCzfsFVw7ygW2SI6NClZzquT+mwdTfgfdbUiceh6iQO0CHtCPsyze/MZ2YbAA==",
+      "requires": {
+        "@babel/types": "^7.24.7"
+      }
+    },
     "@babel/helper-string-parser": {
-      "version": "7.23.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.23.4.tgz",
-      "integrity": "sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==",
-      "dev": true
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.7.tgz",
+      "integrity": "sha512-7MbVt6xrwFQbunH2DNQsAP5sTGxfqQtErvBIvIMi6EQnbgUOuVYanvREcmFrOPhoXBrTtjhhP+lW+o5UfK+tDg=="
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
-      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
-      "dev": true
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
+      "integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w=="
+    },
+    "@babel/helper-validator-option": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.24.7.tgz",
+      "integrity": "sha512-yy1/KvjhV/ZCL+SM7hBrvnZJ3ZuT9OuZgIJAGpPEToANvc3iM6iDvBnRjtElWibHU6n8/LPR/EjX9EtIEYO3pw=="
+    },
+    "@babel/helpers": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.24.7.tgz",
+      "integrity": "sha512-NlmJJtvcw72yRJRcnCmGvSi+3jDEg8qFu3z0AFoymmzLx5ERVWyzd9kVXr7Th9/8yIJi2Zc6av4Tqz3wFs8QWg==",
+      "requires": {
+        "@babel/template": "^7.24.7",
+        "@babel/types": "^7.24.7"
+      }
     },
     "@babel/highlight": {
-      "version": "7.23.4",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
-      "integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
-      "dev": true,
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
+      "integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
       "requires": {
-        "@babel/helper-validator-identifier": "^7.22.20",
+        "@babel/helper-validator-identifier": "^7.24.7",
         "chalk": "^2.4.2",
-        "js-tokens": "^4.0.0"
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.0.0"
       },
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
           }
@@ -19517,7 +20451,6 @@
           "version": "2.4.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
@@ -19527,20 +20460,17 @@
         "escape-string-regexp": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-          "dev": true
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
         },
         "has-flag": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-          "dev": true
+          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="
         },
         "supports-color": {
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -19548,19 +20478,51 @@
       }
     },
     "@babel/parser": {
-      "version": "7.23.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.4.tgz",
-      "integrity": "sha512-vf3Xna6UEprW+7t6EtOmFpHNAuxw3xqPZghy+brsnusscJRW5BMUzzHZc5ICjULee81WeUV2jjakG09MDglJXQ==",
-      "dev": true
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.7.tgz",
+      "integrity": "sha512-9uUYRm6OqQrCqQdG1iCBwBPZgN8ciDBro2nIOFaiRz1/BCxaI7CNvQbDHvsArAC7Tw9Hda/B3U+6ui9u4HWXPw=="
+    },
+    "@babel/template": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.7.tgz",
+      "integrity": "sha512-jYqfPrU9JTF0PmPy1tLYHW4Mp4KlgxJD9l2nP9fD6yT/ICi554DmrWBAEYpIelzjHf1msDP3PxJIRt/nFNfBig==",
+      "requires": {
+        "@babel/code-frame": "^7.24.7",
+        "@babel/parser": "^7.24.7",
+        "@babel/types": "^7.24.7"
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.7.tgz",
+      "integrity": "sha512-yb65Ed5S/QAcewNPh0nZczy9JdYXkkAbIsEo+P7BE7yO3txAY30Y/oPa3QkQ5It3xVG2kpKMg9MsdxZaO31uKA==",
+      "requires": {
+        "@babel/code-frame": "^7.24.7",
+        "@babel/generator": "^7.24.7",
+        "@babel/helper-environment-visitor": "^7.24.7",
+        "@babel/helper-function-name": "^7.24.7",
+        "@babel/helper-hoist-variables": "^7.24.7",
+        "@babel/helper-split-export-declaration": "^7.24.7",
+        "@babel/parser": "^7.24.7",
+        "@babel/types": "^7.24.7",
+        "debug": "^4.3.1",
+        "globals": "^11.1.0"
+      },
+      "dependencies": {
+        "globals": {
+          "version": "11.12.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
+        }
+      }
     },
     "@babel/types": {
-      "version": "7.23.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.4.tgz",
-      "integrity": "sha512-7uIFwVYpoplT5jp/kVv6EF93VaJ8H+Yn5IczYiaAi98ajzjfoZfslet/e0sLh+wVBjb2qqIut1b0S26VSafsSQ==",
-      "dev": true,
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.7.tgz",
+      "integrity": "sha512-XEFXSlxiG5td2EJRe8vOmRbaXVgfcBlszKujvVmWIK/UpywWljQCfzAv3RQCGujWQ1RD4YYWEAqDXfuJiy8f5Q==",
       "requires": {
-        "@babel/helper-string-parser": "^7.23.4",
-        "@babel/helper-validator-identifier": "^7.22.20",
+        "@babel/helper-string-parser": "^7.24.7",
+        "@babel/helper-validator-identifier": "^7.24.7",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -20253,6 +21215,227 @@
         "@types/chai": "^4.2.12"
       }
     },
+    "@figma/code-connect": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@figma/code-connect/-/code-connect-1.0.3.tgz",
+      "integrity": "sha512-fZzvvAb3LXVUxjD/PjMW8jMh1Ur17I4AQ6DQyDQ99W9P/dCQVd3CLkWRFYPQtOut5whP3DmLNpERlTIzCcJlSg==",
+      "requires": {
+        "@babel/core": "^7.24.7",
+        "@babel/generator": "^7.24.7",
+        "@babel/parser": "^7.24.7",
+        "@babel/types": "^7.24.7",
+        "@storybook/csf-tools": "^7.6.7",
+        "axios": "^1.6.0",
+        "boxen": "5.1.1",
+        "chalk": "^4.1.2",
+        "commander": "^11.1.0",
+        "compare-versions": "^6.1.0",
+        "cross-spawn": "^7.0.3",
+        "dotenv": "^16.3.1",
+        "fast-fuzzy": "^1.12.0",
+        "find-up": "^5.0.0",
+        "glob": "^10.3.10",
+        "lodash": "^4.17.21",
+        "minimatch": "^9.0.3",
+        "ora": "^5.4.1",
+        "prettier": "^2.8.8",
+        "prompts": "^2.4.2",
+        "strip-ansi": "^6.0.0",
+        "typescript": "5.4.2",
+        "zod": "^3.23.6",
+        "zod-validation-error": "^3.2.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "axios": {
+          "version": "1.7.2",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
+          "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
+          "requires": {
+            "follow-redirects": "^1.15.6",
+            "form-data": "^4.0.0",
+            "proxy-from-env": "^1.1.0"
+          }
+        },
+        "bl": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+          "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+          "requires": {
+            "buffer": "^5.5.0",
+            "inherits": "^2.0.4",
+            "readable-stream": "^3.4.0"
+          }
+        },
+        "boxen": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/boxen/-/boxen-5.1.1.tgz",
+          "integrity": "sha512-JtIQYts08AFAYGF4eSh3pUt3NQkYV/e75pRtQmAVTLNWR/1L7Bsswxlgzgk8nmLEM+gFszsIlA9BgD3XnSqp3g==",
+          "requires": {
+            "ansi-align": "^3.0.0",
+            "camelcase": "^6.2.0",
+            "chalk": "^4.1.0",
+            "cli-boxes": "^2.2.1",
+            "string-width": "^4.2.2",
+            "type-fest": "^0.20.2",
+            "widest-line": "^3.1.0",
+            "wrap-ansi": "^7.0.0"
+          }
+        },
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "buffer": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "cli-boxes": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",
+          "integrity": "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw=="
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "commander": {
+          "version": "11.1.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+          "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+        },
+        "is-interactive": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+          "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w=="
+        },
+        "is-unicode-supported": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+          "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw=="
+        },
+        "log-symbols": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+          "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+          "requires": {
+            "chalk": "^4.1.0",
+            "is-unicode-supported": "^0.1.0"
+          }
+        },
+        "minimatch": {
+          "version": "9.0.5",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+          "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        },
+        "ora": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+          "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+          "requires": {
+            "bl": "^4.1.0",
+            "chalk": "^4.1.0",
+            "cli-cursor": "^3.1.0",
+            "cli-spinners": "^2.5.0",
+            "is-interactive": "^1.0.0",
+            "is-unicode-supported": "^0.1.0",
+            "log-symbols": "^4.1.0",
+            "strip-ansi": "^6.0.0",
+            "wcwidth": "^1.0.1"
+          }
+        },
+        "prettier": {
+          "version": "2.8.8",
+          "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+          "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q=="
+        },
+        "readable-stream": {
+          "version": "3.6.2",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+          "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        },
+        "widest-line": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
+          "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
+          "requires": {
+            "string-width": "^4.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        }
+      }
+    },
     "@floating-ui/core": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.5.0.tgz",
@@ -20320,7 +21503,6 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-      "dev": true,
       "requires": {
         "string-width": "^5.1.2",
         "string-width-cjs": "npm:string-width@^4.2.0",
@@ -20333,37 +21515,47 @@
         "ansi-regex": {
           "version": "6.0.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-          "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
-          "dev": true
+          "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA=="
         },
         "strip-ansi": {
           "version": "7.1.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
           "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-          "dev": true,
           "requires": {
             "ansi-regex": "^6.0.1"
           }
         }
       }
     },
+    "@jridgewell/gen-mapping": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
+      "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
+      "requires": {
+        "@jridgewell/set-array": "^1.2.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
     "@jridgewell/resolve-uri": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
-      "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
-      "dev": true
+      "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA=="
+    },
+    "@jridgewell/set-array": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A=="
     },
     "@jridgewell/sourcemap-codec": {
       "version": "1.4.15",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
-      "dev": true
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
     },
     "@jridgewell/trace-mapping": {
-      "version": "0.3.20",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.20.tgz",
-      "integrity": "sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==",
-      "dev": true,
+      "version": "0.3.25",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
       "requires": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -20593,7 +21785,6 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "dev": true,
       "optional": true
     },
     "@pnpm/config.env-replace": {
@@ -20926,6 +22117,108 @@
       "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==",
       "dev": true
     },
+    "@storybook/channels": {
+      "version": "7.6.20",
+      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-7.6.20.tgz",
+      "integrity": "sha512-4hkgPSH6bJclB2OvLnkZOGZW1WptJs09mhQ6j6qLjgBZzL/ZdD6priWSd7iXrmPiN5TzUobkG4P4Dp7FjkiO7A==",
+      "requires": {
+        "@storybook/client-logger": "7.6.20",
+        "@storybook/core-events": "7.6.20",
+        "@storybook/global": "^5.0.0",
+        "qs": "^6.10.0",
+        "telejson": "^7.2.0",
+        "tiny-invariant": "^1.3.1"
+      }
+    },
+    "@storybook/client-logger": {
+      "version": "7.6.20",
+      "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-7.6.20.tgz",
+      "integrity": "sha512-NwG0VIJQCmKrSaN5GBDFyQgTAHLNishUPLW1NrzqTDNAhfZUoef64rPQlinbopa0H4OXmlB+QxbQIb3ubeXmSQ==",
+      "requires": {
+        "@storybook/global": "^5.0.0"
+      }
+    },
+    "@storybook/core-events": {
+      "version": "7.6.20",
+      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-7.6.20.tgz",
+      "integrity": "sha512-tlVDuVbDiNkvPDFAu+0ou3xBBYbx9zUURQz4G9fAq0ScgBOs/bpzcRrFb4mLpemUViBAd47tfZKdH4MAX45KVQ==",
+      "requires": {
+        "ts-dedent": "^2.0.0"
+      }
+    },
+    "@storybook/csf": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@storybook/csf/-/csf-0.1.9.tgz",
+      "integrity": "sha512-JlZ6v/iFn+iKohKGpYXnMeNeTiiAMeFoDhYnPLIC8GnyyIWqEI9wJYrOK9i9rxlJ8NZAH/ojGC/u/xVC41qSgQ==",
+      "requires": {
+        "type-fest": "^2.19.0"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+        }
+      }
+    },
+    "@storybook/csf-tools": {
+      "version": "7.6.20",
+      "resolved": "https://registry.npmjs.org/@storybook/csf-tools/-/csf-tools-7.6.20.tgz",
+      "integrity": "sha512-rwcwzCsAYh/m/WYcxBiEtLpIW5OH1ingxNdF/rK9mtGWhJxXRDV8acPkFrF8rtFWIVKoOCXu5USJYmc3f2gdYQ==",
+      "requires": {
+        "@babel/generator": "^7.23.0",
+        "@babel/parser": "^7.23.0",
+        "@babel/traverse": "^7.23.2",
+        "@babel/types": "^7.23.0",
+        "@storybook/csf": "^0.1.2",
+        "@storybook/types": "7.6.20",
+        "fs-extra": "^11.1.0",
+        "recast": "^0.23.1",
+        "ts-dedent": "^2.0.0"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "11.2.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+          "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        },
+        "jsonfile": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^2.0.0"
+          }
+        },
+        "universalify": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+          "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="
+        }
+      }
+    },
+    "@storybook/global": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@storybook/global/-/global-5.0.0.tgz",
+      "integrity": "sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ=="
+    },
+    "@storybook/types": {
+      "version": "7.6.20",
+      "resolved": "https://registry.npmjs.org/@storybook/types/-/types-7.6.20.tgz",
+      "integrity": "sha512-GncdY3x0LpbhmUAAJwXYtJDUQEwfF175gsjH0/fxPkxPoV7Sef9TM41jQLJW/5+6TnZoCZP/+aJZTJtq3ni23Q==",
+      "requires": {
+        "@storybook/channels": "7.6.20",
+        "@types/babel__core": "^7.0.0",
+        "@types/express": "^4.7.0",
+        "file-system-cache": "2.3.0"
+      }
+    },
     "@szmarczak/http-timer": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",
@@ -20998,11 +22291,47 @@
       "integrity": "sha512-Anitqkl3+KrzcW2k77lRlg/GfLZLWXBuNgbEcIOU6M92yw42vsd3xV/Z/yAHEj8m+KUjL6bWOVOFqX8PFPJ4LA==",
       "dev": true
     },
+    "@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "requires": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "@types/babel__generator": {
+      "version": "7.6.8",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.8.tgz",
+      "integrity": "sha512-ASsj+tpEDsEiFr1arWrlN6V3mdfjRMZt6LtK/Vp/kreFLnr5QH5+DhvD5nINYZXzwJvXeGq+05iUXcAzVrqWtw==",
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "requires": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@types/babel__traverse": {
+      "version": "7.20.6",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.6.tgz",
+      "integrity": "sha512-r1bzfrm0tomOI8g1SzvCaQHo6Lcv6zu0EA+W2kHrt8dyrHQxGzBBL4kdkzIS+jBMV+EYcMAEAqXqYaLJq5rOZg==",
+      "requires": {
+        "@babel/types": "^7.20.7"
+      }
+    },
     "@types/body-parser": {
       "version": "1.19.5",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
       "integrity": "sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==",
-      "dev": true,
       "requires": {
         "@types/connect": "*",
         "@types/node": "*"
@@ -21043,7 +22372,6 @@
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
-      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -21103,7 +22431,6 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
       "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
-      "dev": true,
       "requires": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.33",
@@ -21115,7 +22442,6 @@
       "version": "4.17.41",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.41.tgz",
       "integrity": "sha512-OaJ7XLaelTgrvlZD8/aa0vvvxZdUmlCn6MtWeB7TkiKW70BQLc9XEPpDLPdbo52ZhXUCrznlWdCHWxJWtdyajA==",
-      "dev": true,
       "requires": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -21144,8 +22470,7 @@
     "@types/http-errors": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
-      "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
-      "dev": true
+      "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA=="
     },
     "@types/inquirer": {
       "version": "9.0.7",
@@ -21246,8 +22571,7 @@
     "@types/mime": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
-      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
-      "dev": true
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w=="
     },
     "@types/minimatch": {
       "version": "3.0.5",
@@ -21265,7 +22589,6 @@
       "version": "20.9.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.3.tgz",
       "integrity": "sha512-nk5wXLAXGBKfrhLB0cyHGbSqopS+nz0BUgZkUQqSHSSgdee0kssp1IAqlQOu333bW+gMNs2QREx7iynm19Abxw==",
-      "dev": true,
       "requires": {
         "undici-types": "~5.26.4"
       }
@@ -21284,14 +22607,12 @@
     "@types/qs": {
       "version": "6.9.10",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.10.tgz",
-      "integrity": "sha512-3Gnx08Ns1sEoCrWssEgTSJs/rsT2vhGP+Ja9cnnk9k4ALxinORlQneLXFeFKOTJMOeZUFD1s7w+w2AphTpvzZw==",
-      "dev": true
+      "integrity": "sha512-3Gnx08Ns1sEoCrWssEgTSJs/rsT2vhGP+Ja9cnnk9k4ALxinORlQneLXFeFKOTJMOeZUFD1s7w+w2AphTpvzZw=="
     },
     "@types/range-parser": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
-      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
-      "dev": true
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="
     },
     "@types/react": {
       "version": "18.2.38",
@@ -21324,7 +22645,6 @@
       "version": "0.17.4",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
       "integrity": "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==",
-      "dev": true,
       "requires": {
         "@types/mime": "^1",
         "@types/node": "*"
@@ -21334,7 +22654,6 @@
       "version": "1.15.5",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.5.tgz",
       "integrity": "sha512-PDRk21MnK70hja/YF8AHfC7yIsiQHn1rcXx7ijCFBX/k+XQJhQT/gw3xekXKJvx+5SXaMMS8oqQy09Mzvz2TuQ==",
-      "dev": true,
       "requires": {
         "@types/http-errors": "*",
         "@types/mime": "*",
@@ -22269,7 +23588,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
       "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
-      "dev": true,
       "requires": {
         "string-width": "^4.1.0"
       },
@@ -22277,20 +23595,17 @@
         "emoji-regex": {
           "version": "8.0.0",
           "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-          "dev": true
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
         },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-          "dev": true
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
         },
         "string-width": {
           "version": "4.2.3",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
           "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-          "dev": true,
           "requires": {
             "emoji-regex": "^8.0.0",
             "is-fullwidth-code-point": "^3.0.0",
@@ -22324,8 +23639,7 @@
     "ansi-styles": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
-      "dev": true
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="
     },
     "any-promise": {
       "version": "0.1.0",
@@ -22577,8 +23891,7 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "autoprefixer": {
       "version": "10.4.18",
@@ -22638,14 +23951,12 @@
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
     "base64id": {
       "version": "2.0.0",
@@ -23130,7 +24441,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.5.tgz",
       "integrity": "sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.2",
         "get-intrinsic": "^1.2.1",
@@ -23156,8 +24466,7 @@
     "camelcase": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-      "dev": true
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA=="
     },
     "caniuse-lite": {
       "version": "1.0.30001596",
@@ -23381,7 +24690,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
       "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-      "dev": true,
       "requires": {
         "restore-cursor": "^3.1.0"
       }
@@ -23389,8 +24697,7 @@
     "cli-spinners": {
       "version": "2.9.1",
       "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.1.tgz",
-      "integrity": "sha512-jHgecW0pxkonBJdrKsqxgRX9AcG+u/5k0Q7WPDfi8AogLAdwxEkyYYNWwZ5GvVFoFx2uiY1eNcSK00fh+1+FyQ==",
-      "dev": true
+      "integrity": "sha512-jHgecW0pxkonBJdrKsqxgRX9AcG+u/5k0Q7WPDfi8AogLAdwxEkyYYNWwZ5GvVFoFx2uiY1eNcSK00fh+1+FyQ=="
     },
     "cli-table3": {
       "version": "0.6.3",
@@ -23543,7 +24850,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -23551,8 +24857,7 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
     "color-support": {
       "version": "1.1.3",
@@ -23570,7 +24875,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -23637,6 +24941,11 @@
       "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.1.tgz",
       "integrity": "sha512-buhp5kePrmda3vhc5B9t7pUQXAb2Tnd0qgpkIhPhkHXxJpiPJ11H0ZEU0oBpJ2QztSbzG/ZxMj/CHsYJqRHmyg==",
       "dev": true
+    },
+    "compare-versions": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.0.tgz",
+      "integrity": "sha512-LNZQXhqUvqUTotpZ00qLSaify3b4VFD588aRr8MKFw4CMUr98ytzCW5wDH5qx/DEY5kCDXcbcRuCqL0szEf2tg=="
     },
     "composed-offset-position": {
       "version": "0.0.4",
@@ -23791,8 +25100,7 @@
     "convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
-      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="
     },
     "cookie": {
       "version": "0.4.2",
@@ -23851,7 +25159,6 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
       "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-      "dev": true,
       "requires": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -24147,7 +25454,6 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
       "requires": {
         "ms": "2.1.2"
       }
@@ -24355,7 +25661,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
       "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
-      "dev": true,
       "requires": {
         "clone": "^1.0.2"
       },
@@ -24363,8 +25668,7 @@
         "clone": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-          "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
-          "dev": true
+          "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg=="
         }
       }
     },
@@ -24378,7 +25682,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.1.tgz",
       "integrity": "sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==",
-      "dev": true,
       "requires": {
         "get-intrinsic": "^1.2.1",
         "gopd": "^1.0.1",
@@ -24432,8 +25735,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
     "delegates": {
       "version": "1.0.0",
@@ -24612,6 +25914,11 @@
         "is-obj": "^2.0.0"
       }
     },
+    "dotenv": {
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg=="
+    },
     "download": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/download/-/download-8.0.0.tgz",
@@ -24667,8 +25974,7 @@
     "eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "dev": true
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
     },
     "easy-extender": {
       "version": "2.3.4",
@@ -25352,8 +26658,7 @@
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
     "esquery": {
       "version": "1.5.0",
@@ -25540,6 +26845,14 @@
       "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
       "dev": true
     },
+    "fast-fuzzy": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/fast-fuzzy/-/fast-fuzzy-1.12.0.tgz",
+      "integrity": "sha512-sXxGgHS+ubYpsdLnvOvJ9w5GYYZrtL9mkosG3nfuD446ahvoWEsSKBP7ieGmWIKVLnaxRDgUJkZMdxRgA2Ni+Q==",
+      "requires": {
+        "graphemesplit": "^2.4.1"
+      }
+    },
     "fast-glob": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
@@ -25612,6 +26925,41 @@
       "dev": true,
       "requires": {
         "flat-cache": "^3.0.4"
+      }
+    },
+    "file-system-cache": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/file-system-cache/-/file-system-cache-2.3.0.tgz",
+      "integrity": "sha512-l4DMNdsIPsVnKrgEXbJwDJsA5mB8rGwHYERMgqQx/xAUtChPJMre1bXBzDEqqVbWv9AIbFezXMxeEkZDSrXUOQ==",
+      "requires": {
+        "fs-extra": "11.1.1",
+        "ramda": "0.29.0"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "11.1.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
+          "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        },
+        "jsonfile": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^2.0.0"
+          }
+        },
+        "universalify": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+          "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="
+        }
       }
     },
     "file-type": {
@@ -25719,7 +27067,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-      "dev": true,
       "requires": {
         "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
@@ -25774,10 +27121,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
-      "dev": true
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA=="
     },
     "for-each": {
       "version": "0.3.3",
@@ -25807,7 +27153,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
       "integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
-      "dev": true,
       "requires": {
         "cross-spawn": "^7.0.0",
         "signal-exit": "^4.0.1"
@@ -25816,8 +27161,7 @@
         "signal-exit": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-          "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-          "dev": true
+          "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="
         }
       }
     },
@@ -25825,7 +27169,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -25944,8 +27287,7 @@
     "function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
     },
     "function.prototype.name": {
       "version": "1.1.6",
@@ -26012,6 +27354,11 @@
       "integrity": "sha512-JlKEZnFc6neaeSVlkzBGGgkIoIaSxMgvdamRoPN8r3ozm2r9dusqxeKqYQ7lhzmj2UhFQP8nkyfCaiLQxiLrDA==",
       "dev": true
     },
+    "gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="
+    },
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -26021,7 +27368,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.2.tgz",
       "integrity": "sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.2",
         "has-proto": "^1.0.1",
@@ -26095,7 +27441,6 @@
       "version": "10.3.10",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
       "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
-      "dev": true,
       "requires": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^2.3.5",
@@ -26108,7 +27453,6 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
           "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-          "dev": true,
           "requires": {
             "balanced-match": "^1.0.0"
           }
@@ -26117,7 +27461,6 @@
           "version": "9.0.3",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
           "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
-          "dev": true,
           "requires": {
             "brace-expansion": "^2.0.1"
           }
@@ -26224,7 +27567,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
       "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-      "dev": true,
       "requires": {
         "get-intrinsic": "^1.1.3"
       }
@@ -26278,6 +27620,15 @@
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
+    },
+    "graphemesplit": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/graphemesplit/-/graphemesplit-2.4.4.tgz",
+      "integrity": "sha512-lKrpp1mk1NH26USxC/Asw4OHbhSQf5XfrWZ+CDv/dFVvd1j17kFgMotdJvOesmHkbFX9P9sBfpH8VogxOWLg8w==",
+      "requires": {
+        "js-base64": "^3.6.0",
+        "unicode-trie": "^2.0.0"
+      }
     },
     "gray-matter": {
       "version": "4.0.3",
@@ -26348,8 +27699,7 @@
     "has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
     },
     "has-own-prop": {
       "version": "2.0.0",
@@ -26361,7 +27711,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.1.tgz",
       "integrity": "sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==",
-      "dev": true,
       "requires": {
         "get-intrinsic": "^1.2.2"
       }
@@ -26369,8 +27718,7 @@
     "has-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
-      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
-      "dev": true
+      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg=="
     },
     "has-symbol-support-x": {
       "version": "1.4.2",
@@ -26381,8 +27729,7 @@
     "has-symbols": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-      "dev": true
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
     },
     "has-to-string-tag-x": {
       "version": "1.4.1",
@@ -26418,7 +27765,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
       "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.2"
       }
@@ -26615,8 +27961,7 @@
     "ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
     "ignore": {
       "version": "5.3.0",
@@ -26734,8 +28079,7 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ini": {
       "version": "4.1.1",
@@ -27430,8 +28774,7 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
     "iso-639-1": {
       "version": "2.1.15",
@@ -27497,7 +28840,6 @@
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.6.tgz",
       "integrity": "sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==",
-      "dev": true,
       "requires": {
         "@isaacs/cliui": "^8.0.2",
         "@pkgjs/parseargs": "^0.11.0"
@@ -27557,6 +28899,11 @@
       "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
       "dev": true
     },
+    "js-base64": {
+      "version": "3.7.7",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.7.tgz",
+      "integrity": "sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw=="
+    },
     "js-levenshtein-esm": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/js-levenshtein-esm/-/js-levenshtein-esm-1.2.0.tgz",
@@ -27572,8 +28919,7 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
       "version": "4.1.0",
@@ -27651,6 +28997,11 @@
         }
       }
     },
+    "jsesc": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
+    },
     "json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -27687,8 +29038,7 @@
     "json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="
     },
     "jsonata": {
       "version": "2.0.3",
@@ -28254,7 +29604,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "dev": true,
       "requires": {
         "p-locate": "^5.0.0"
       }
@@ -28262,8 +29611,7 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.assignwith": {
       "version": "4.2.0",
@@ -28534,6 +29882,11 @@
       "integrity": "sha512-8y/eV9QQZCiyn1SprXSrCmqJN0yNRATe+PO8ztwqrvrbdRLA3eYJF0yaR0YayLWkMbsQSKWS9N2gPcGEc4UsZg==",
       "dev": true
     },
+    "map-or-similar": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/map-or-similar/-/map-or-similar-1.5.0.tgz",
+      "integrity": "sha512-0aF7ZmVon1igznGI4VS30yugpduQW3y3GkcgGJOp7d8x8QrizhigUxjI/m2UojsXXto+jLAH3KSz+xOJTiORjg=="
+    },
     "markdown-it": {
       "version": "13.0.2",
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-13.0.2.tgz",
@@ -28649,6 +30002,14 @@
       "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
       "dev": true
     },
+    "memoizerific": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/memoizerific/-/memoizerific-1.11.3.tgz",
+      "integrity": "sha512-/EuHYwAPdLtXwAwSZkh/Gutery6pD2KYd44oQLhAvQp/50mpyduZh8Q7PYHXTCJ+wuXxt7oij2LXyIJOOYFPog==",
+      "requires": {
+        "map-or-similar": "^1.5.0"
+      }
+    },
     "merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -28688,14 +30049,12 @@
     "mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
     },
     "mime-types": {
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "requires": {
         "mime-db": "1.52.0"
       }
@@ -28730,8 +30089,7 @@
     "minipass": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-      "dev": true
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ=="
     },
     "minipass-collect": {
       "version": "1.0.2",
@@ -28908,8 +30266,7 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "multimatch": {
       "version": "5.0.0",
@@ -29667,8 +31024,7 @@
     "object-inspect": {
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
-      "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
-      "dev": true
+      "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ=="
     },
     "object-keys": {
       "version": "1.1.1",
@@ -29950,7 +31306,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "dev": true,
       "requires": {
         "yocto-queue": "^0.1.0"
       }
@@ -29959,7 +31314,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "dev": true,
       "requires": {
         "p-limit": "^3.0.2"
       }
@@ -30206,6 +31560,11 @@
         }
       }
     },
+    "pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA=="
+    },
     "param-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
@@ -30324,8 +31683,7 @@
     "path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -30336,8 +31694,7 @@
     "path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
     },
     "path-parse": {
       "version": "1.0.7",
@@ -30364,7 +31721,6 @@
       "version": "1.10.1",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.1.tgz",
       "integrity": "sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==",
-      "dev": true,
       "requires": {
         "lru-cache": "^9.1.1 || ^10.0.0",
         "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
@@ -30373,8 +31729,7 @@
         "lru-cache": {
           "version": "10.0.3",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.3.tgz",
-          "integrity": "sha512-B7gr+F6MkqB3uzINHXNctGieGsRTMwIBgxkp0yq/5BwcuDzD4A8wQpHQW6vDAm1uKSLQghmRdD9sKqf2vJ1cEg==",
-          "dev": true
+          "integrity": "sha512-B7gr+F6MkqB3uzINHXNctGieGsRTMwIBgxkp0yq/5BwcuDzD4A8wQpHQW6vDAm1uKSLQghmRdD9sKqf2vJ1cEg=="
         }
       }
     },
@@ -30764,6 +32119,22 @@
         "retry": "^0.12.0"
       }
     },
+    "prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "requires": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "dependencies": {
+        "kleur": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+          "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="
+        }
+      }
+    },
     "prompts-ncu": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/prompts-ncu/-/prompts-ncu-3.0.0.tgz",
@@ -30847,8 +32218,7 @@
     "proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "dev": true
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "prr": {
       "version": "1.0.1",
@@ -31043,7 +32413,6 @@
       "version": "6.11.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.2.tgz",
       "integrity": "sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==",
-      "dev": true,
       "requires": {
         "side-channel": "^1.0.4"
       }
@@ -31081,6 +32450,11 @@
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
       "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
       "dev": true
+    },
+    "ramda": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.29.0.tgz",
+      "integrity": "sha512-BBea6L67bYLtdbOqfp8f58fPMqEwx0doL+pAi8TZyp2YWz8R9G8z9x75CZI8W+ftqhFHCpEX2cRnUUXK130iKA=="
     },
     "range-parser": {
       "version": "1.2.1",
@@ -31253,6 +32627,33 @@
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "requires": {
         "picomatch": "^2.2.1"
+      }
+    },
+    "recast": {
+      "version": "0.23.9",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.23.9.tgz",
+      "integrity": "sha512-Hx/BGIbwj+Des3+xy5uAtAbdCyqK9y9wbBcDFDYanLS9JnMqf7OeF87HQwUimE87OEc72mr6tkKUKMBBL+hF9Q==",
+      "requires": {
+        "ast-types": "^0.16.1",
+        "esprima": "~4.0.0",
+        "source-map": "~0.6.1",
+        "tiny-invariant": "^1.3.3",
+        "tslib": "^2.0.1"
+      },
+      "dependencies": {
+        "ast-types": {
+          "version": "0.16.1",
+          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.16.1.tgz",
+          "integrity": "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==",
+          "requires": {
+            "tslib": "^2.0.1"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        }
       }
     },
     "rechoir": {
@@ -31521,7 +32922,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
       "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-      "dev": true,
       "requires": {
         "onetime": "^5.1.0",
         "signal-exit": "^3.0.2"
@@ -31530,14 +32930,12 @@
         "mimic-fn": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-          "dev": true
+          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
         },
         "onetime": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
           "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-          "dev": true,
           "requires": {
             "mimic-fn": "^2.1.0"
           }
@@ -31970,7 +33368,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.1.1.tgz",
       "integrity": "sha512-VoaqjbBJKiWtg4yRcKBQ7g7wnGnLV3M8oLvVWwOk2PdYY6PEFegR1vezXR0tw6fZGF9csVakIRjrJiy2veSBFQ==",
-      "dev": true,
       "requires": {
         "define-data-property": "^1.1.1",
         "get-intrinsic": "^1.2.1",
@@ -31999,7 +33396,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "requires": {
         "shebang-regex": "^3.0.0"
       }
@@ -32007,14 +33403,12 @@
     "shebang-regex": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
     },
     "side-channel": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
       "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.0",
         "get-intrinsic": "^1.0.2",
@@ -32024,8 +33418,7 @@
     "signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
     },
     "sigstore": {
       "version": "1.9.0",
@@ -32057,8 +33450,7 @@
     "sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
-      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
-      "dev": true
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="
     },
     "slash": {
       "version": "4.0.0",
@@ -32377,7 +33769,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       },
@@ -32385,8 +33776,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         }
       }
     },
@@ -32400,7 +33790,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "dev": true,
       "requires": {
         "eastasianwidth": "^0.2.0",
         "emoji-regex": "^9.2.2",
@@ -32410,20 +33799,17 @@
         "ansi-regex": {
           "version": "6.0.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-          "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
-          "dev": true
+          "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA=="
         },
         "emoji-regex": {
           "version": "9.2.2",
           "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-          "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-          "dev": true
+          "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
         },
         "strip-ansi": {
           "version": "7.1.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
           "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-          "dev": true,
           "requires": {
             "ansi-regex": "^6.0.1"
           }
@@ -32434,7 +33820,6 @@
       "version": "npm:string-width@4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "requires": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -32444,14 +33829,12 @@
         "emoji-regex": {
           "version": "8.0.0",
           "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-          "dev": true
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
         },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-          "dev": true
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
         }
       }
     },
@@ -32500,7 +33883,6 @@
       "version": "npm:strip-ansi@6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "requires": {
         "ansi-regex": "^5.0.1"
       }
@@ -32568,7 +33950,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "requires": {
         "has-flag": "^4.0.0"
       }
@@ -32701,6 +34082,14 @@
         }
       }
     },
+    "telejson": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/telejson/-/telejson-7.2.0.tgz",
+      "integrity": "sha512-1QTEcJkJEhc8OnStBx/ILRu5J2p0GjvWsBx56bmZRqnrkdBMUe+nX92jxV+p3dB4CP6PZCdJMQJwCggkNBMzkQ==",
+      "requires": {
+        "memoizerific": "^1.11.3"
+      }
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -32723,6 +34112,16 @@
       "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
       "integrity": "sha512-G7r3AhovYtr5YKOWQkta8RKAPb+J9IsO4uVmzjl8AZwfhs8UcUwTiD6gcJYSgOtzyjvQKrKYn41syHbUWMkafA==",
       "dev": true
+    },
+    "tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw=="
+    },
+    "tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="
     },
     "title-case": {
       "version": "3.0.3",
@@ -32751,8 +34150,7 @@
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
-      "dev": true
+      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog=="
     },
     "to-regex-range": {
       "version": "5.0.1",
@@ -32827,6 +34225,11 @@
       "dev": true,
       "requires": {}
     },
+    "ts-dedent": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
+      "integrity": "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ=="
+    },
     "tsconfig-paths": {
       "version": "3.14.2",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz",
@@ -32853,8 +34256,7 @@
     "tslib": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "tsscmp": {
       "version": "1.0.6",
@@ -32891,8 +34293,7 @@
     "type-fest": {
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-      "dev": true
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="
     },
     "type-is": {
       "version": "1.6.18",
@@ -32961,10 +34362,9 @@
       }
     },
     "typescript": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.2.tgz",
-      "integrity": "sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ==",
-      "dev": true
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.2.tgz",
+      "integrity": "sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ=="
     },
     "typical": {
       "version": "4.0.0",
@@ -33034,8 +34434,16 @@
     "undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+    },
+    "unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "requires": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      }
     },
     "unique-filename": {
       "version": "3.0.0",
@@ -33237,8 +34645,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "utils-merge": {
       "version": "1.0.1",
@@ -33319,7 +34726,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
       "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
-      "dev": true,
       "requires": {
         "defaults": "^1.0.3"
       }
@@ -33359,7 +34765,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "requires": {
         "isexe": "^2.0.0"
       }
@@ -33461,7 +34866,6 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
       "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "dev": true,
       "requires": {
         "ansi-styles": "^6.1.0",
         "string-width": "^5.0.1",
@@ -33471,14 +34875,12 @@
         "ansi-regex": {
           "version": "6.0.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-          "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
-          "dev": true
+          "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA=="
         },
         "strip-ansi": {
           "version": "7.1.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
           "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-          "dev": true,
           "requires": {
             "ansi-regex": "^6.0.1"
           }
@@ -33489,7 +34891,6 @@
       "version": "npm:wrap-ansi@7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
       "requires": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -33500,7 +34901,6 @@
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
           "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
           "requires": {
             "color-convert": "^2.0.1"
           }
@@ -33509,7 +34909,6 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
           "requires": {
             "color-name": "~1.1.4"
           }
@@ -33517,26 +34916,22 @@
         "color-name": {
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
         "emoji-regex": {
           "version": "8.0.0",
           "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-          "dev": true
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
         },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-          "dev": true
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
         },
         "string-width": {
           "version": "4.2.3",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
           "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-          "dev": true,
           "requires": {
             "emoji-regex": "^8.0.0",
             "is-fullwidth-code-point": "^3.0.0",
@@ -33677,8 +35072,18 @@
     "yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
+    },
+    "zod": {
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g=="
+    },
+    "zod-validation-error": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-3.3.0.tgz",
+      "integrity": "sha512-Syib9oumw1NTqEv4LT0e6U83Td9aVRk9iTXPUQr1otyV1PuXQKOvOwhMNqZIq5hluzHP2pMgnOmHEo7kPdI2mw==",
+      "requires": {}
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@teamshares/shoelace",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@teamshares/shoelace",
-      "version": "2.2.1",
+      "version": "2.3.0",
       "license": "MIT",
       "dependencies": {
         "@ctrl/tinycolor": "^4.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,7 +82,7 @@
         "source-map": "^0.7.4",
         "strip-css-comments": "^5.0.0",
         "tslib": "^2.6.2",
-        "typescript": "^5.2.2",
+        "typescript": "5.2.2",
         "user-agent-data-types": "^0.3.1"
       },
       "engines": {
@@ -1977,6 +1977,18 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@figma/code-connect/node_modules/typescript": {
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.2.tgz",
+      "integrity": "sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/@figma/code-connect/node_modules/w3c-xmlserializer": {
@@ -19319,9 +19331,10 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.2.tgz",
-      "integrity": "sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -21691,6 +21704,11 @@
           "requires": {
             "punycode": "^2.3.1"
           }
+        },
+        "typescript": {
+          "version": "5.4.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.2.tgz",
+          "integrity": "sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ=="
         },
         "w3c-xmlserializer": {
           "version": "5.0.0",
@@ -34713,9 +34731,10 @@
       }
     },
     "typescript": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.2.tgz",
-      "integrity": "sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ=="
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "dev": true
     },
     "typical": {
       "version": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@ctrl/tinycolor": "^4.0.2",
-        "@figma/code-connect": "^1.0.3",
+        "@figma/code-connect": "^1.2.0",
         "@floating-ui/dom": "^1.5.3",
         "@lit/react": "^1.0.0",
         "@shoelace-style/animations": "^1.1.0",
@@ -257,11 +257,11 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
-      "integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
+      "version": "7.25.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.25.7.tgz",
+      "integrity": "sha512-0xZJFNE5XMpENsgfHYTw8FbX4kv53mFLn2i3XPoq69LyhYSCBJtitaHx9QnsVTrsogI4Z3+HtEfZ2/GFPOtf5g==",
       "dependencies": {
-        "@babel/highlight": "^7.24.7",
+        "@babel/highlight": "^7.25.7",
         "picocolors": "^1.0.0"
       },
       "engines": {
@@ -269,28 +269,28 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.24.7.tgz",
-      "integrity": "sha512-qJzAIcv03PyaWqxRgO4mSU3lihncDT296vnyuE2O8uA4w3UHWI4S3hgeZd1L8W1Bft40w9JxJ2b412iDUFFRhw==",
+      "version": "7.25.8",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.25.8.tgz",
+      "integrity": "sha512-ZsysZyXY4Tlx+Q53XdnOFmqwfB9QDTHYxaZYajWRoBLuLEAwI2UIbtxOjWh/cFaa9IKUlcB+DDuoskLuKu56JA==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.7.tgz",
-      "integrity": "sha512-nykK+LEK86ahTkX/3TgauT0ikKoNCfKHEaZYTUVupJdTLzGNvrblu4u6fa7DhZONAltdf8e662t/abY8idrd/g==",
+      "version": "7.25.8",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.25.8.tgz",
+      "integrity": "sha512-Oixnb+DzmRT30qu9d3tJSQkxuygWm32DFykT4bRoORPa9hZ/L4KhVB/XiRm6KG+roIEM7DBQlmg27kw2HZkdZg==",
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.24.7",
-        "@babel/generator": "^7.24.7",
-        "@babel/helper-compilation-targets": "^7.24.7",
-        "@babel/helper-module-transforms": "^7.24.7",
-        "@babel/helpers": "^7.24.7",
-        "@babel/parser": "^7.24.7",
-        "@babel/template": "^7.24.7",
-        "@babel/traverse": "^7.24.7",
-        "@babel/types": "^7.24.7",
+        "@babel/code-frame": "^7.25.7",
+        "@babel/generator": "^7.25.7",
+        "@babel/helper-compilation-targets": "^7.25.7",
+        "@babel/helper-module-transforms": "^7.25.7",
+        "@babel/helpers": "^7.25.7",
+        "@babel/parser": "^7.25.8",
+        "@babel/template": "^7.25.7",
+        "@babel/traverse": "^7.25.7",
+        "@babel/types": "^7.25.8",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -314,27 +314,27 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.7.tgz",
-      "integrity": "sha512-oipXieGC3i45Y1A41t4tAqpnEZWgB/lC6Ehh6+rOviR5XWpTtMmLN+fGjz9vOiNRt0p6RtO6DtD0pdU3vpqdSA==",
+      "version": "7.25.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.7.tgz",
+      "integrity": "sha512-5Dqpl5fyV9pIAD62yK9P7fcA768uVPUyrQmqpqstHWgMma4feF1x/oFysBCVZLY5wJ2GkMUCdsNDnGZrPoR6rA==",
       "dependencies": {
-        "@babel/types": "^7.24.7",
+        "@babel/types": "^7.25.7",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
-        "jsesc": "^2.5.1"
+        "jsesc": "^3.0.2"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.24.7.tgz",
-      "integrity": "sha512-ctSdRHBi20qWOfy27RUb4Fhp07KSJ3sXcuSvTrXrc4aG8NSYDo1ici3Vhg9bg69y5bj0Mr1lh0aeEgTvc12rMg==",
+      "version": "7.25.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.25.7.tgz",
+      "integrity": "sha512-DniTEax0sv6isaw6qSQSfV4gVRNtw2rte8HHM45t9ZR0xILaufBRNkpMifCRiAPyvL4ACD6v0gfCwCmtOQaV4A==",
       "dependencies": {
-        "@babel/compat-data": "^7.24.7",
-        "@babel/helper-validator-option": "^7.24.7",
-        "browserslist": "^4.22.2",
+        "@babel/compat-data": "^7.25.7",
+        "@babel/helper-validator-option": "^7.25.7",
+        "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
       },
@@ -363,62 +363,27 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     },
-    "node_modules/@babel/helper-environment-visitor": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.24.7.tgz",
-      "integrity": "sha512-DoiN84+4Gnd0ncbBOM9AZENV4a5ZiL39HYMyZJGZ/AZEykHYdJw0wW3kdcsh9/Kn+BRXHLkkklZ51ecPKmI1CQ==",
-      "dependencies": {
-        "@babel/types": "^7.24.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-function-name": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.24.7.tgz",
-      "integrity": "sha512-FyoJTsj/PEUWu1/TYRiXTIHc8lbw+TDYkZuoE43opPS5TrI7MyONBE1oNvfguEXAD9yhQRrVBnXdXzSLQl9XnA==",
-      "dependencies": {
-        "@babel/template": "^7.24.7",
-        "@babel/types": "^7.24.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-hoist-variables": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.24.7.tgz",
-      "integrity": "sha512-MJJwhkoGy5c4ehfoRyrJ/owKeMl19U54h27YYftT0o2teQ3FJ3nQUf/I3LlJsX4l3qlw7WRXUmiyajvHXoTubQ==",
-      "dependencies": {
-        "@babel/types": "^7.24.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.24.7.tgz",
-      "integrity": "sha512-8AyH3C+74cgCVVXow/myrynrAGv+nTVg5vKu2nZph9x7RcRwzmh0VFallJuFTZ9mx6u4eSdXZfcOzSqTUm0HCA==",
+      "version": "7.25.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.25.7.tgz",
+      "integrity": "sha512-o0xCgpNmRohmnoWKQ0Ij8IdddjyBFE4T2kagL/x6M3+4zUgc+4qTOUBoNe4XxDskt1HPKO007ZPiMgLDq2s7Kw==",
       "dependencies": {
-        "@babel/traverse": "^7.24.7",
-        "@babel/types": "^7.24.7"
+        "@babel/traverse": "^7.25.7",
+        "@babel/types": "^7.25.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.24.7.tgz",
-      "integrity": "sha512-1fuJEwIrp+97rM4RWdO+qrRsZlAeL1lQJoPqtCYWv0NL115XM93hIH4CSRln2w52SqvmY5hqdtauB6QFCDiZNQ==",
+      "version": "7.25.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.25.7.tgz",
+      "integrity": "sha512-k/6f8dKG3yDz/qCwSM+RKovjMix563SLxQFo0UhRNo239SP6n9u5/eLtKD6EAjwta2JHJ49CsD8pms2HdNiMMQ==",
       "dependencies": {
-        "@babel/helper-environment-visitor": "^7.24.7",
-        "@babel/helper-module-imports": "^7.24.7",
-        "@babel/helper-simple-access": "^7.24.7",
-        "@babel/helper-split-export-declaration": "^7.24.7",
-        "@babel/helper-validator-identifier": "^7.24.7"
+        "@babel/helper-module-imports": "^7.25.7",
+        "@babel/helper-simple-access": "^7.25.7",
+        "@babel/helper-validator-identifier": "^7.25.7",
+        "@babel/traverse": "^7.25.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -428,70 +393,59 @@
       }
     },
     "node_modules/@babel/helper-simple-access": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.24.7.tgz",
-      "integrity": "sha512-zBAIvbCMh5Ts+b86r/CjU+4XGYIs+R1j951gxI3KmmxBMhCg4oQMsv6ZXQ64XOm/cvzfU1FmoCyt6+owc5QMYg==",
+      "version": "7.25.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.25.7.tgz",
+      "integrity": "sha512-FPGAkJmyoChQeM+ruBGIDyrT2tKfZJO8NcxdC+CWNJi7N8/rZpSxK7yvBJ5O/nF1gfu5KzN7VKG3YVSLFfRSxQ==",
       "dependencies": {
-        "@babel/traverse": "^7.24.7",
-        "@babel/types": "^7.24.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.7.tgz",
-      "integrity": "sha512-oy5V7pD+UvfkEATUKvIjvIAH/xCzfsFVw7ygW2SI6NClZzquT+mwdTfgfdbUiceh6iQO0CHtCPsyze/MZ2YbAA==",
-      "dependencies": {
-        "@babel/types": "^7.24.7"
+        "@babel/traverse": "^7.25.7",
+        "@babel/types": "^7.25.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.7.tgz",
-      "integrity": "sha512-7MbVt6xrwFQbunH2DNQsAP5sTGxfqQtErvBIvIMi6EQnbgUOuVYanvREcmFrOPhoXBrTtjhhP+lW+o5UfK+tDg==",
+      "version": "7.25.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.7.tgz",
+      "integrity": "sha512-CbkjYdsJNHFk8uqpEkpCvRs3YRp9tY6FmFY7wLMSYuGYkrdUi7r2lc4/wqsvlHoMznX3WJ9IP8giGPq68T/Y6g==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
-      "integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
+      "version": "7.25.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.7.tgz",
+      "integrity": "sha512-AM6TzwYqGChO45oiuPqwL2t20/HdMC1rTPAesnBCgPCSF1x3oN9MVUwQV2iyz4xqWrctwK5RNC8LV22kaQCNYg==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.24.7.tgz",
-      "integrity": "sha512-yy1/KvjhV/ZCL+SM7hBrvnZJ3ZuT9OuZgIJAGpPEToANvc3iM6iDvBnRjtElWibHU6n8/LPR/EjX9EtIEYO3pw==",
+      "version": "7.25.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.25.7.tgz",
+      "integrity": "sha512-ytbPLsm+GjArDYXJ8Ydr1c/KJuutjF2besPNbIZnZ6MKUxi/uTA22t2ymmA4WFjZFpjiAMO0xuuJPqK2nvDVfQ==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.24.7.tgz",
-      "integrity": "sha512-NlmJJtvcw72yRJRcnCmGvSi+3jDEg8qFu3z0AFoymmzLx5ERVWyzd9kVXr7Th9/8yIJi2Zc6av4Tqz3wFs8QWg==",
+      "version": "7.25.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.25.7.tgz",
+      "integrity": "sha512-Sv6pASx7Esm38KQpF/U/OXLwPPrdGHNKoeblRxgZRLXnAtnkEe4ptJPDtAZM7fBLadbc1Q07kQpSiGQ0Jg6tRA==",
       "dependencies": {
-        "@babel/template": "^7.24.7",
-        "@babel/types": "^7.24.7"
+        "@babel/template": "^7.25.7",
+        "@babel/types": "^7.25.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
-      "integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
+      "version": "7.25.7",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.25.7.tgz",
+      "integrity": "sha512-iYyACpW3iW8Fw+ZybQK+drQre+ns/tKpXbNESfrhNnPLIklLbXr7MYJ6gPEd0iETGLOK+SxMjVvKb/ffmk+FEw==",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.24.7",
+        "@babel/helper-validator-identifier": "^7.25.7",
         "chalk": "^2.4.2",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.0.0"
@@ -552,9 +506,12 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.7.tgz",
-      "integrity": "sha512-9uUYRm6OqQrCqQdG1iCBwBPZgN8ciDBro2nIOFaiRz1/BCxaI7CNvQbDHvsArAC7Tw9Hda/B3U+6ui9u4HWXPw==",
+      "version": "7.25.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.8.tgz",
+      "integrity": "sha512-HcttkxzdPucv3nNFmfOOMfFf64KgdJVqm1KaCm25dPGMLElo9nsLvXeJECQg8UzPuBGLyTSA0ZzqCtDSzKTEoQ==",
+      "dependencies": {
+        "@babel/types": "^7.25.8"
+      },
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -563,31 +520,28 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.7.tgz",
-      "integrity": "sha512-jYqfPrU9JTF0PmPy1tLYHW4Mp4KlgxJD9l2nP9fD6yT/ICi554DmrWBAEYpIelzjHf1msDP3PxJIRt/nFNfBig==",
+      "version": "7.25.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.7.tgz",
+      "integrity": "sha512-wRwtAgI3bAS+JGU2upWNL9lSlDcRCqD05BZ1n3X2ONLH1WilFP6O1otQjeMK/1g0pvYcXC7b/qVUB1keofjtZA==",
       "dependencies": {
-        "@babel/code-frame": "^7.24.7",
-        "@babel/parser": "^7.24.7",
-        "@babel/types": "^7.24.7"
+        "@babel/code-frame": "^7.25.7",
+        "@babel/parser": "^7.25.7",
+        "@babel/types": "^7.25.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.7.tgz",
-      "integrity": "sha512-yb65Ed5S/QAcewNPh0nZczy9JdYXkkAbIsEo+P7BE7yO3txAY30Y/oPa3QkQ5It3xVG2kpKMg9MsdxZaO31uKA==",
+      "version": "7.25.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.7.tgz",
+      "integrity": "sha512-jatJPT1Zjqvh/1FyJs6qAHL+Dzb7sTb+xr7Q+gM1b+1oBsMsQQ4FkVKb6dFlJvLlVssqkRzV05Jzervt9yhnzg==",
       "dependencies": {
-        "@babel/code-frame": "^7.24.7",
-        "@babel/generator": "^7.24.7",
-        "@babel/helper-environment-visitor": "^7.24.7",
-        "@babel/helper-function-name": "^7.24.7",
-        "@babel/helper-hoist-variables": "^7.24.7",
-        "@babel/helper-split-export-declaration": "^7.24.7",
-        "@babel/parser": "^7.24.7",
-        "@babel/types": "^7.24.7",
+        "@babel/code-frame": "^7.25.7",
+        "@babel/generator": "^7.25.7",
+        "@babel/parser": "^7.25.7",
+        "@babel/template": "^7.25.7",
+        "@babel/types": "^7.25.7",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -604,12 +558,12 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.7.tgz",
-      "integrity": "sha512-XEFXSlxiG5td2EJRe8vOmRbaXVgfcBlszKujvVmWIK/UpywWljQCfzAv3RQCGujWQ1RD4YYWEAqDXfuJiy8f5Q==",
+      "version": "7.25.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.8.tgz",
+      "integrity": "sha512-JWtuCu8VQsMladxVz/P4HzHUGCAwpuqacmowgXFs5XjxIgKuNjnLokQzuVjlTvIzODaDmpjT3oxcC48vyk9EWg==",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.24.7",
-        "@babel/helper-validator-identifier": "^7.24.7",
+        "@babel/helper-string-parser": "^7.25.7",
+        "@babel/helper-validator-identifier": "^7.25.7",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -1581,16 +1535,16 @@
       }
     },
     "node_modules/@figma/code-connect": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@figma/code-connect/-/code-connect-1.0.3.tgz",
-      "integrity": "sha512-fZzvvAb3LXVUxjD/PjMW8jMh1Ur17I4AQ6DQyDQ99W9P/dCQVd3CLkWRFYPQtOut5whP3DmLNpERlTIzCcJlSg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@figma/code-connect/-/code-connect-1.2.0.tgz",
+      "integrity": "sha512-iwLtg+DyRZaPYY24+scK8nhBBHUGrrOnz2G/4gIOc2AqwlyO2wKFPohvCdjL9wmHseGGxVXXzICxdkJQRKv7kw==",
       "dependencies": {
-        "@babel/core": "^7.24.7",
-        "@babel/generator": "^7.24.7",
-        "@babel/parser": "^7.24.7",
-        "@babel/types": "^7.24.7",
+        "@babel/core": "^7.25.2",
+        "@babel/generator": "^7.25.2",
+        "@babel/parser": "^7.25.2",
+        "@babel/types": "^7.25.2",
         "@storybook/csf-tools": "^7.6.7",
-        "axios": "^1.6.0",
+        "axios": "^1.7.4",
         "boxen": "5.1.1",
         "chalk": "^4.1.2",
         "commander": "^11.1.0",
@@ -1600,12 +1554,15 @@
         "fast-fuzzy": "^1.12.0",
         "find-up": "^5.0.0",
         "glob": "^10.3.10",
+        "jsdom": "^24.1.1",
         "lodash": "^4.17.21",
         "minimatch": "^9.0.3",
         "ora": "^5.4.1",
+        "parse5": "^7.1.2",
         "prettier": "^2.8.8",
         "prompts": "^2.4.2",
         "strip-ansi": "^6.0.0",
+        "ts-morph": "^23.0.0",
         "typescript": "5.4.2",
         "zod": "^3.23.6",
         "zod-validation-error": "^3.2.0"
@@ -1615,6 +1572,17 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/@figma/code-connect/node_modules/agent-base": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
+      "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/@figma/code-connect/node_modules/ansi-styles": {
@@ -1632,9 +1600,9 @@
       }
     },
     "node_modules/@figma/code-connect/node_modules/axios": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
-      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
+      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -1753,10 +1721,79 @@
         "node": ">=16"
       }
     },
+    "node_modules/@figma/code-connect/node_modules/cssstyle": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.1.0.tgz",
+      "integrity": "sha512-h66W1URKpBS5YMI/V8PyXvTMFT8SupJ1IzoIV8IeBC/ji8WVmrO8dGlTi+2dh6whmdk6BiKJLD/ZBkhWbcg6nA==",
+      "dependencies": {
+        "rrweb-cssom": "^0.7.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@figma/code-connect/node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@figma/code-connect/node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "node_modules/@figma/code-connect/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/@figma/code-connect/node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@figma/code-connect/node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@figma/code-connect/node_modules/https-proxy-agent": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
+      "integrity": "sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==",
+      "dependencies": {
+        "agent-base": "^7.0.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/@figma/code-connect/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
@@ -1783,6 +1820,45 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@figma/code-connect/node_modules/jsdom": {
+      "version": "24.1.3",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-24.1.3.tgz",
+      "integrity": "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==",
+      "dependencies": {
+        "cssstyle": "^4.0.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.1.4",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/@figma/code-connect/node_modules/log-symbols": {
@@ -1836,6 +1912,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@figma/code-connect/node_modules/parse5": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
+      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+      "dependencies": {
+        "entities": "^4.4.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/@figma/code-connect/node_modules/prettier": {
       "version": "2.8.8",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
@@ -1863,6 +1950,11 @@
         "node": ">= 6"
       }
     },
+    "node_modules/@figma/code-connect/node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg=="
+    },
     "node_modules/@figma/code-connect/node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -1874,6 +1966,59 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@figma/code-connect/node_modules/tr46": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.0.0.tgz",
+      "integrity": "sha512-tk2G5R2KRwBd+ZN0zaEXpmzdKyOYksXwywulIX95MBODjSzMIuQnQ3m8JxgbhnL1LeVo7lqQKsYa1O3Htl7K5g==",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@figma/code-connect/node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@figma/code-connect/node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@figma/code-connect/node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@figma/code-connect/node_modules/whatwg-url": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.0.0.tgz",
+      "integrity": "sha512-1lfMEm2IEr7RIV+f4lUNPOqfFL+pO+Xw3fJSqmjX9AbXcXcYOkCe1P6+9VBZB6n94af16NfZf+sSk0JCBZC9aw==",
+      "dependencies": {
+        "tr46": "^5.0.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@figma/code-connect/node_modules/widest-line": {
@@ -1901,6 +2046,14 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@figma/code-connect/node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@floating-ui/core": {
@@ -2983,6 +3136,53 @@
       "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
       "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
       "dev": true
+    },
+    "node_modules/@ts-morph/common": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.24.0.tgz",
+      "integrity": "sha512-c1xMmNHWpNselmpIqursHeOHHBTIsJLbB+NuovbTTRCNiTLEr/U9dbJ8qy0jd/O2x5pc3seWuOUN5R2IoOTp8A==",
+      "dependencies": {
+        "fast-glob": "^3.3.2",
+        "minimatch": "^9.0.4",
+        "mkdirp": "^3.0.1",
+        "path-browserify": "^1.0.1"
+      }
+    },
+    "node_modules/@ts-morph/common/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@ts-morph/common/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@ts-morph/common/node_modules/mkdirp": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
+      "bin": {
+        "mkdirp": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/@tufjs/canonical-json": {
       "version": "1.0.0",
@@ -5682,9 +5882,9 @@
       "dev": true
     },
     "node_modules/browserslist": {
-      "version": "4.23.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.0.tgz",
-      "integrity": "sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.0.tgz",
+      "integrity": "sha512-Rmb62sR1Zpjql25eSanFGEhAxcFwfA1K0GuQcLoaJBAcENegrQut3hYdhXFF1obQfiDyqIW/cLM5HSJ/9k884A==",
       "funding": [
         {
           "type": "opencollective",
@@ -5700,10 +5900,10 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001587",
-        "electron-to-chromium": "^1.4.668",
-        "node-releases": "^2.0.14",
-        "update-browserslist-db": "^1.0.13"
+        "caniuse-lite": "^1.0.30001663",
+        "electron-to-chromium": "^1.5.28",
+        "node-releases": "^2.0.18",
+        "update-browserslist-db": "^1.1.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -6022,9 +6222,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001596",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001596.tgz",
-      "integrity": "sha512-zpkZ+kEr6We7w63ORkoJ2pOfBwBkY/bJrG/UZ90qNb45Isblu8wzDgevEOrRL1r9dWayHjYiiyCMEXPn4DweGQ==",
+      "version": "1.0.30001669",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001669.tgz",
+      "integrity": "sha512-DlWzFDJqstqtIVx1zeSpIMLjunf5SmwOw0N2Ck/QSQdS8PLS4+9HrLaYei4w8BIAL7IB/UEDu889d8vhCTPA0w==",
       "funding": [
         {
           "type": "opencollective",
@@ -6557,6 +6757,11 @@
         "raw-body": "^2.3.3",
         "type-is": "^1.6.16"
       }
+    },
+    "node_modules/code-block-writer": {
+      "version": "13.0.3",
+      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-13.0.3.tgz",
+      "integrity": "sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg=="
     },
     "node_modules/color-convert": {
       "version": "1.9.3",
@@ -7329,8 +7534,7 @@
     "node_modules/decimal.js": {
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
-      "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
-      "dev": true
+      "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA=="
     },
     "node_modules/decode-uri-component": {
       "version": "0.2.2",
@@ -8091,9 +8295,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.696",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.696.tgz",
-      "integrity": "sha512-SOr0bHP52OvYg2chCsz/0+FUSMGFm8L8HKwPpx3cbwRY24EOemVJtbgTm+IFO8LzhcnPy+hXmTq7ZcZ8uUuaYg=="
+      "version": "1.5.39",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.39.tgz",
+      "integrity": "sha512-4xkpSR6CjuiaNyvwiWDI85N9AxsvbPawB8xc7yzLPonYTuP19BVgYweKyUMFtHEZgIcHWMt1ks5Cqx2m+6/Grg=="
     },
     "node_modules/emoji-regex": {
       "version": "10.3.0",
@@ -8414,9 +8618,9 @@
       }
     },
     "node_modules/escalade": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "engines": {
         "node": ">=6"
       }
@@ -10596,7 +10800,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -11555,8 +11758,7 @@
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
-      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
-      "dev": true
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="
     },
     "node_modules/is-promise": {
       "version": "2.2.2",
@@ -12084,14 +12286,14 @@
       }
     },
     "node_modules/jsesc": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
+      "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
       "bin": {
         "jsesc": "bin/jsesc"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=6"
       }
     },
     "node_modules/json-buffer": {
@@ -14221,9 +14423,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
-      "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw=="
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
+      "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g=="
     },
     "node_modules/nopt": {
       "version": "6.0.0",
@@ -14700,10 +14902,9 @@
       }
     },
     "node_modules/nwsapi": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.7.tgz",
-      "integrity": "sha512-ub5E4+FBPKwAZx0UwIQOjYWGHTEq5sPqHQNRN8Z9e4A7u3Tj1weLJsL59yH9vmvqEtBHaOmT6cYQKIZOxp35FQ==",
-      "dev": true
+      "version": "2.2.12",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.12.tgz",
+      "integrity": "sha512-qXDmcVlZV4XRtKFzddidpfVP4oMSGhga+xdMc25mv8kaLUHtgzCDhUxkrN8exkGdTlLNaXj7CV3GtON7zuGZ+w=="
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -15605,6 +15806,11 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
+    },
     "node_modules/path-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
@@ -15711,9 +15917,9 @@
       "dev": true
     },
     "node_modules/picocolors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.0.tgz",
+      "integrity": "sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw=="
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -16401,8 +16607,7 @@
     "node_modules/psl": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
-      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
-      "dev": true
+      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
     },
     "node_modules/pug": {
       "version": "3.0.2",
@@ -16542,7 +16747,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -16644,8 +16848,7 @@
     "node_modules/querystringify": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
-      "dev": true
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -17109,8 +17312,7 @@
     "node_modules/requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-      "dev": true
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
     },
     "node_modules/resolve": {
       "version": "1.22.8",
@@ -17498,8 +17700,7 @@
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/sass": {
       "version": "1.71.1",
@@ -17526,7 +17727,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
       "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
-      "dev": true,
       "dependencies": {
         "xmlchars": "^2.2.0"
       },
@@ -18626,8 +18826,7 @@
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
-      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
-      "dev": true
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
     },
     "node_modules/table-layout": {
       "version": "3.0.2",
@@ -18865,10 +19064,9 @@
       "dev": true
     },
     "node_modules/tough-cookie": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
-      "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
-      "dev": true,
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
       "dependencies": {
         "psl": "^1.1.33",
         "punycode": "^2.1.1",
@@ -18883,7 +19081,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
       "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
-      "dev": true,
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -18939,6 +19136,15 @@
       "integrity": "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==",
       "engines": {
         "node": ">=6.10"
+      }
+    },
+    "node_modules/ts-morph": {
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-23.0.0.tgz",
+      "integrity": "sha512-FcvFx7a9E8TUe6T3ShihXJLiJOiqyafzFKUO4aqIHDUCIvADdGNShcbc2W5PMr3LerXRv7mafvFZ9lRENxJmug==",
+      "dependencies": {
+        "@ts-morph/common": "~0.24.0",
+        "code-block-writer": "^13.0.1"
       }
     },
     "node_modules/tsconfig-paths": {
@@ -19324,9 +19530,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
-      "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.1.tgz",
+      "integrity": "sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==",
       "funding": [
         {
           "type": "opencollective",
@@ -19342,8 +19548,8 @@
         }
       ],
       "dependencies": {
-        "escalade": "^3.1.1",
-        "picocolors": "^1.0.0"
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.0"
       },
       "bin": {
         "update-browserslist-db": "cli.js"
@@ -19499,7 +19705,6 @@
       "version": "1.5.10",
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
       "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
-      "dev": true,
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
@@ -19645,7 +19850,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
       "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
-      "dev": true,
       "engines": {
         "node": ">=12"
       }
@@ -19949,10 +20153,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.14.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
-      "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
-      "dev": true,
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -19990,8 +20193,7 @@
     "node_modules/xmlchars": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
-      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
-      "dev": true
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
     },
     "node_modules/xmlhttprequest-ssl": {
       "version": "2.0.0",
@@ -20256,34 +20458,34 @@
       }
     },
     "@babel/code-frame": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
-      "integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
+      "version": "7.25.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.25.7.tgz",
+      "integrity": "sha512-0xZJFNE5XMpENsgfHYTw8FbX4kv53mFLn2i3XPoq69LyhYSCBJtitaHx9QnsVTrsogI4Z3+HtEfZ2/GFPOtf5g==",
       "requires": {
-        "@babel/highlight": "^7.24.7",
+        "@babel/highlight": "^7.25.7",
         "picocolors": "^1.0.0"
       }
     },
     "@babel/compat-data": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.24.7.tgz",
-      "integrity": "sha512-qJzAIcv03PyaWqxRgO4mSU3lihncDT296vnyuE2O8uA4w3UHWI4S3hgeZd1L8W1Bft40w9JxJ2b412iDUFFRhw=="
+      "version": "7.25.8",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.25.8.tgz",
+      "integrity": "sha512-ZsysZyXY4Tlx+Q53XdnOFmqwfB9QDTHYxaZYajWRoBLuLEAwI2UIbtxOjWh/cFaa9IKUlcB+DDuoskLuKu56JA=="
     },
     "@babel/core": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.7.tgz",
-      "integrity": "sha512-nykK+LEK86ahTkX/3TgauT0ikKoNCfKHEaZYTUVupJdTLzGNvrblu4u6fa7DhZONAltdf8e662t/abY8idrd/g==",
+      "version": "7.25.8",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.25.8.tgz",
+      "integrity": "sha512-Oixnb+DzmRT30qu9d3tJSQkxuygWm32DFykT4bRoORPa9hZ/L4KhVB/XiRm6KG+roIEM7DBQlmg27kw2HZkdZg==",
       "requires": {
         "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.24.7",
-        "@babel/generator": "^7.24.7",
-        "@babel/helper-compilation-targets": "^7.24.7",
-        "@babel/helper-module-transforms": "^7.24.7",
-        "@babel/helpers": "^7.24.7",
-        "@babel/parser": "^7.24.7",
-        "@babel/template": "^7.24.7",
-        "@babel/traverse": "^7.24.7",
-        "@babel/types": "^7.24.7",
+        "@babel/code-frame": "^7.25.7",
+        "@babel/generator": "^7.25.7",
+        "@babel/helper-compilation-targets": "^7.25.7",
+        "@babel/helper-module-transforms": "^7.25.7",
+        "@babel/helpers": "^7.25.7",
+        "@babel/parser": "^7.25.8",
+        "@babel/template": "^7.25.7",
+        "@babel/traverse": "^7.25.7",
+        "@babel/types": "^7.25.8",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -20299,24 +20501,24 @@
       }
     },
     "@babel/generator": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.7.tgz",
-      "integrity": "sha512-oipXieGC3i45Y1A41t4tAqpnEZWgB/lC6Ehh6+rOviR5XWpTtMmLN+fGjz9vOiNRt0p6RtO6DtD0pdU3vpqdSA==",
+      "version": "7.25.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.7.tgz",
+      "integrity": "sha512-5Dqpl5fyV9pIAD62yK9P7fcA768uVPUyrQmqpqstHWgMma4feF1x/oFysBCVZLY5wJ2GkMUCdsNDnGZrPoR6rA==",
       "requires": {
-        "@babel/types": "^7.24.7",
+        "@babel/types": "^7.25.7",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
-        "jsesc": "^2.5.1"
+        "jsesc": "^3.0.2"
       }
     },
     "@babel/helper-compilation-targets": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.24.7.tgz",
-      "integrity": "sha512-ctSdRHBi20qWOfy27RUb4Fhp07KSJ3sXcuSvTrXrc4aG8NSYDo1ici3Vhg9bg69y5bj0Mr1lh0aeEgTvc12rMg==",
+      "version": "7.25.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.25.7.tgz",
+      "integrity": "sha512-DniTEax0sv6isaw6qSQSfV4gVRNtw2rte8HHM45t9ZR0xILaufBRNkpMifCRiAPyvL4ACD6v0gfCwCmtOQaV4A==",
       "requires": {
-        "@babel/compat-data": "^7.24.7",
-        "@babel/helper-validator-option": "^7.24.7",
-        "browserslist": "^4.22.2",
+        "@babel/compat-data": "^7.25.7",
+        "@babel/helper-validator-option": "^7.25.7",
+        "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
       },
@@ -20341,99 +20543,65 @@
         }
       }
     },
-    "@babel/helper-environment-visitor": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.24.7.tgz",
-      "integrity": "sha512-DoiN84+4Gnd0ncbBOM9AZENV4a5ZiL39HYMyZJGZ/AZEykHYdJw0wW3kdcsh9/Kn+BRXHLkkklZ51ecPKmI1CQ==",
-      "requires": {
-        "@babel/types": "^7.24.7"
-      }
-    },
-    "@babel/helper-function-name": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.24.7.tgz",
-      "integrity": "sha512-FyoJTsj/PEUWu1/TYRiXTIHc8lbw+TDYkZuoE43opPS5TrI7MyONBE1oNvfguEXAD9yhQRrVBnXdXzSLQl9XnA==",
-      "requires": {
-        "@babel/template": "^7.24.7",
-        "@babel/types": "^7.24.7"
-      }
-    },
-    "@babel/helper-hoist-variables": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.24.7.tgz",
-      "integrity": "sha512-MJJwhkoGy5c4ehfoRyrJ/owKeMl19U54h27YYftT0o2teQ3FJ3nQUf/I3LlJsX4l3qlw7WRXUmiyajvHXoTubQ==",
-      "requires": {
-        "@babel/types": "^7.24.7"
-      }
-    },
     "@babel/helper-module-imports": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.24.7.tgz",
-      "integrity": "sha512-8AyH3C+74cgCVVXow/myrynrAGv+nTVg5vKu2nZph9x7RcRwzmh0VFallJuFTZ9mx6u4eSdXZfcOzSqTUm0HCA==",
+      "version": "7.25.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.25.7.tgz",
+      "integrity": "sha512-o0xCgpNmRohmnoWKQ0Ij8IdddjyBFE4T2kagL/x6M3+4zUgc+4qTOUBoNe4XxDskt1HPKO007ZPiMgLDq2s7Kw==",
       "requires": {
-        "@babel/traverse": "^7.24.7",
-        "@babel/types": "^7.24.7"
+        "@babel/traverse": "^7.25.7",
+        "@babel/types": "^7.25.7"
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.24.7.tgz",
-      "integrity": "sha512-1fuJEwIrp+97rM4RWdO+qrRsZlAeL1lQJoPqtCYWv0NL115XM93hIH4CSRln2w52SqvmY5hqdtauB6QFCDiZNQ==",
+      "version": "7.25.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.25.7.tgz",
+      "integrity": "sha512-k/6f8dKG3yDz/qCwSM+RKovjMix563SLxQFo0UhRNo239SP6n9u5/eLtKD6EAjwta2JHJ49CsD8pms2HdNiMMQ==",
       "requires": {
-        "@babel/helper-environment-visitor": "^7.24.7",
-        "@babel/helper-module-imports": "^7.24.7",
-        "@babel/helper-simple-access": "^7.24.7",
-        "@babel/helper-split-export-declaration": "^7.24.7",
-        "@babel/helper-validator-identifier": "^7.24.7"
+        "@babel/helper-module-imports": "^7.25.7",
+        "@babel/helper-simple-access": "^7.25.7",
+        "@babel/helper-validator-identifier": "^7.25.7",
+        "@babel/traverse": "^7.25.7"
       }
     },
     "@babel/helper-simple-access": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.24.7.tgz",
-      "integrity": "sha512-zBAIvbCMh5Ts+b86r/CjU+4XGYIs+R1j951gxI3KmmxBMhCg4oQMsv6ZXQ64XOm/cvzfU1FmoCyt6+owc5QMYg==",
+      "version": "7.25.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.25.7.tgz",
+      "integrity": "sha512-FPGAkJmyoChQeM+ruBGIDyrT2tKfZJO8NcxdC+CWNJi7N8/rZpSxK7yvBJ5O/nF1gfu5KzN7VKG3YVSLFfRSxQ==",
       "requires": {
-        "@babel/traverse": "^7.24.7",
-        "@babel/types": "^7.24.7"
-      }
-    },
-    "@babel/helper-split-export-declaration": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.7.tgz",
-      "integrity": "sha512-oy5V7pD+UvfkEATUKvIjvIAH/xCzfsFVw7ygW2SI6NClZzquT+mwdTfgfdbUiceh6iQO0CHtCPsyze/MZ2YbAA==",
-      "requires": {
-        "@babel/types": "^7.24.7"
+        "@babel/traverse": "^7.25.7",
+        "@babel/types": "^7.25.7"
       }
     },
     "@babel/helper-string-parser": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.7.tgz",
-      "integrity": "sha512-7MbVt6xrwFQbunH2DNQsAP5sTGxfqQtErvBIvIMi6EQnbgUOuVYanvREcmFrOPhoXBrTtjhhP+lW+o5UfK+tDg=="
+      "version": "7.25.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.7.tgz",
+      "integrity": "sha512-CbkjYdsJNHFk8uqpEkpCvRs3YRp9tY6FmFY7wLMSYuGYkrdUi7r2lc4/wqsvlHoMznX3WJ9IP8giGPq68T/Y6g=="
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
-      "integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w=="
+      "version": "7.25.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.7.tgz",
+      "integrity": "sha512-AM6TzwYqGChO45oiuPqwL2t20/HdMC1rTPAesnBCgPCSF1x3oN9MVUwQV2iyz4xqWrctwK5RNC8LV22kaQCNYg=="
     },
     "@babel/helper-validator-option": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.24.7.tgz",
-      "integrity": "sha512-yy1/KvjhV/ZCL+SM7hBrvnZJ3ZuT9OuZgIJAGpPEToANvc3iM6iDvBnRjtElWibHU6n8/LPR/EjX9EtIEYO3pw=="
+      "version": "7.25.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.25.7.tgz",
+      "integrity": "sha512-ytbPLsm+GjArDYXJ8Ydr1c/KJuutjF2besPNbIZnZ6MKUxi/uTA22t2ymmA4WFjZFpjiAMO0xuuJPqK2nvDVfQ=="
     },
     "@babel/helpers": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.24.7.tgz",
-      "integrity": "sha512-NlmJJtvcw72yRJRcnCmGvSi+3jDEg8qFu3z0AFoymmzLx5ERVWyzd9kVXr7Th9/8yIJi2Zc6av4Tqz3wFs8QWg==",
+      "version": "7.25.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.25.7.tgz",
+      "integrity": "sha512-Sv6pASx7Esm38KQpF/U/OXLwPPrdGHNKoeblRxgZRLXnAtnkEe4ptJPDtAZM7fBLadbc1Q07kQpSiGQ0Jg6tRA==",
       "requires": {
-        "@babel/template": "^7.24.7",
-        "@babel/types": "^7.24.7"
+        "@babel/template": "^7.25.7",
+        "@babel/types": "^7.25.7"
       }
     },
     "@babel/highlight": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
-      "integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
+      "version": "7.25.7",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.25.7.tgz",
+      "integrity": "sha512-iYyACpW3iW8Fw+ZybQK+drQre+ns/tKpXbNESfrhNnPLIklLbXr7MYJ6gPEd0iETGLOK+SxMjVvKb/ffmk+FEw==",
       "requires": {
-        "@babel/helper-validator-identifier": "^7.24.7",
+        "@babel/helper-validator-identifier": "^7.25.7",
         "chalk": "^2.4.2",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.0.0"
@@ -20478,33 +20646,33 @@
       }
     },
     "@babel/parser": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.7.tgz",
-      "integrity": "sha512-9uUYRm6OqQrCqQdG1iCBwBPZgN8ciDBro2nIOFaiRz1/BCxaI7CNvQbDHvsArAC7Tw9Hda/B3U+6ui9u4HWXPw=="
+      "version": "7.25.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.8.tgz",
+      "integrity": "sha512-HcttkxzdPucv3nNFmfOOMfFf64KgdJVqm1KaCm25dPGMLElo9nsLvXeJECQg8UzPuBGLyTSA0ZzqCtDSzKTEoQ==",
+      "requires": {
+        "@babel/types": "^7.25.8"
+      }
     },
     "@babel/template": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.7.tgz",
-      "integrity": "sha512-jYqfPrU9JTF0PmPy1tLYHW4Mp4KlgxJD9l2nP9fD6yT/ICi554DmrWBAEYpIelzjHf1msDP3PxJIRt/nFNfBig==",
+      "version": "7.25.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.7.tgz",
+      "integrity": "sha512-wRwtAgI3bAS+JGU2upWNL9lSlDcRCqD05BZ1n3X2ONLH1WilFP6O1otQjeMK/1g0pvYcXC7b/qVUB1keofjtZA==",
       "requires": {
-        "@babel/code-frame": "^7.24.7",
-        "@babel/parser": "^7.24.7",
-        "@babel/types": "^7.24.7"
+        "@babel/code-frame": "^7.25.7",
+        "@babel/parser": "^7.25.7",
+        "@babel/types": "^7.25.7"
       }
     },
     "@babel/traverse": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.7.tgz",
-      "integrity": "sha512-yb65Ed5S/QAcewNPh0nZczy9JdYXkkAbIsEo+P7BE7yO3txAY30Y/oPa3QkQ5It3xVG2kpKMg9MsdxZaO31uKA==",
+      "version": "7.25.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.7.tgz",
+      "integrity": "sha512-jatJPT1Zjqvh/1FyJs6qAHL+Dzb7sTb+xr7Q+gM1b+1oBsMsQQ4FkVKb6dFlJvLlVssqkRzV05Jzervt9yhnzg==",
       "requires": {
-        "@babel/code-frame": "^7.24.7",
-        "@babel/generator": "^7.24.7",
-        "@babel/helper-environment-visitor": "^7.24.7",
-        "@babel/helper-function-name": "^7.24.7",
-        "@babel/helper-hoist-variables": "^7.24.7",
-        "@babel/helper-split-export-declaration": "^7.24.7",
-        "@babel/parser": "^7.24.7",
-        "@babel/types": "^7.24.7",
+        "@babel/code-frame": "^7.25.7",
+        "@babel/generator": "^7.25.7",
+        "@babel/parser": "^7.25.7",
+        "@babel/template": "^7.25.7",
+        "@babel/types": "^7.25.7",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -20517,12 +20685,12 @@
       }
     },
     "@babel/types": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.7.tgz",
-      "integrity": "sha512-XEFXSlxiG5td2EJRe8vOmRbaXVgfcBlszKujvVmWIK/UpywWljQCfzAv3RQCGujWQ1RD4YYWEAqDXfuJiy8f5Q==",
+      "version": "7.25.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.8.tgz",
+      "integrity": "sha512-JWtuCu8VQsMladxVz/P4HzHUGCAwpuqacmowgXFs5XjxIgKuNjnLokQzuVjlTvIzODaDmpjT3oxcC48vyk9EWg==",
       "requires": {
-        "@babel/helper-string-parser": "^7.24.7",
-        "@babel/helper-validator-identifier": "^7.24.7",
+        "@babel/helper-string-parser": "^7.25.7",
+        "@babel/helper-validator-identifier": "^7.25.7",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -21216,16 +21384,16 @@
       }
     },
     "@figma/code-connect": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@figma/code-connect/-/code-connect-1.0.3.tgz",
-      "integrity": "sha512-fZzvvAb3LXVUxjD/PjMW8jMh1Ur17I4AQ6DQyDQ99W9P/dCQVd3CLkWRFYPQtOut5whP3DmLNpERlTIzCcJlSg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@figma/code-connect/-/code-connect-1.2.0.tgz",
+      "integrity": "sha512-iwLtg+DyRZaPYY24+scK8nhBBHUGrrOnz2G/4gIOc2AqwlyO2wKFPohvCdjL9wmHseGGxVXXzICxdkJQRKv7kw==",
       "requires": {
-        "@babel/core": "^7.24.7",
-        "@babel/generator": "^7.24.7",
-        "@babel/parser": "^7.24.7",
-        "@babel/types": "^7.24.7",
+        "@babel/core": "^7.25.2",
+        "@babel/generator": "^7.25.2",
+        "@babel/parser": "^7.25.2",
+        "@babel/types": "^7.25.2",
         "@storybook/csf-tools": "^7.6.7",
-        "axios": "^1.6.0",
+        "axios": "^1.7.4",
         "boxen": "5.1.1",
         "chalk": "^4.1.2",
         "commander": "^11.1.0",
@@ -21235,17 +21403,28 @@
         "fast-fuzzy": "^1.12.0",
         "find-up": "^5.0.0",
         "glob": "^10.3.10",
+        "jsdom": "^24.1.1",
         "lodash": "^4.17.21",
         "minimatch": "^9.0.3",
         "ora": "^5.4.1",
+        "parse5": "^7.1.2",
         "prettier": "^2.8.8",
         "prompts": "^2.4.2",
         "strip-ansi": "^6.0.0",
+        "ts-morph": "^23.0.0",
         "typescript": "5.4.2",
         "zod": "^3.23.6",
         "zod-validation-error": "^3.2.0"
       },
       "dependencies": {
+        "agent-base": {
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
+          "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
+          "requires": {
+            "debug": "^4.3.4"
+          }
+        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -21255,9 +21434,9 @@
           }
         },
         "axios": {
-          "version": "1.7.2",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
-          "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
+          "version": "1.7.4",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
+          "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
           "requires": {
             "follow-redirects": "^1.15.6",
             "form-data": "^4.0.0",
@@ -21338,10 +21517,58 @@
           "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
           "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="
         },
+        "cssstyle": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.1.0.tgz",
+          "integrity": "sha512-h66W1URKpBS5YMI/V8PyXvTMFT8SupJ1IzoIV8IeBC/ji8WVmrO8dGlTi+2dh6whmdk6BiKJLD/ZBkhWbcg6nA==",
+          "requires": {
+            "rrweb-cssom": "^0.7.1"
+          }
+        },
+        "data-urls": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+          "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+          "requires": {
+            "whatwg-mimetype": "^4.0.0",
+            "whatwg-url": "^14.0.0"
+          }
+        },
         "emoji-regex": {
           "version": "8.0.0",
           "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
           "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+        },
+        "entities": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+          "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="
+        },
+        "html-encoding-sniffer": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+          "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+          "requires": {
+            "whatwg-encoding": "^3.1.1"
+          }
+        },
+        "http-proxy-agent": {
+          "version": "7.0.2",
+          "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+          "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+          "requires": {
+            "agent-base": "^7.1.0",
+            "debug": "^4.3.4"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "7.0.5",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
+          "integrity": "sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==",
+          "requires": {
+            "agent-base": "^7.0.2",
+            "debug": "4"
+          }
         },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
@@ -21357,6 +21584,34 @@
           "version": "0.1.0",
           "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
           "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw=="
+        },
+        "jsdom": {
+          "version": "24.1.3",
+          "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-24.1.3.tgz",
+          "integrity": "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==",
+          "requires": {
+            "cssstyle": "^4.0.1",
+            "data-urls": "^5.0.0",
+            "decimal.js": "^10.4.3",
+            "form-data": "^4.0.0",
+            "html-encoding-sniffer": "^4.0.0",
+            "http-proxy-agent": "^7.0.2",
+            "https-proxy-agent": "^7.0.5",
+            "is-potential-custom-element-name": "^1.0.1",
+            "nwsapi": "^2.2.12",
+            "parse5": "^7.1.2",
+            "rrweb-cssom": "^0.7.1",
+            "saxes": "^6.0.0",
+            "symbol-tree": "^3.2.4",
+            "tough-cookie": "^4.1.4",
+            "w3c-xmlserializer": "^5.0.0",
+            "webidl-conversions": "^7.0.0",
+            "whatwg-encoding": "^3.1.1",
+            "whatwg-mimetype": "^4.0.0",
+            "whatwg-url": "^14.0.0",
+            "ws": "^8.18.0",
+            "xml-name-validator": "^5.0.0"
+          }
         },
         "log-symbols": {
           "version": "4.1.0",
@@ -21391,6 +21646,14 @@
             "wcwidth": "^1.0.1"
           }
         },
+        "parse5": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
+          "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+          "requires": {
+            "entities": "^4.4.0"
+          }
+        },
         "prettier": {
           "version": "2.8.8",
           "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
@@ -21406,6 +21669,11 @@
             "util-deprecate": "^1.0.1"
           }
         },
+        "rrweb-cssom": {
+          "version": "0.7.1",
+          "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+          "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg=="
+        },
         "string-width": {
           "version": "4.2.3",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -21414,6 +21682,44 @@
             "emoji-regex": "^8.0.0",
             "is-fullwidth-code-point": "^3.0.0",
             "strip-ansi": "^6.0.1"
+          }
+        },
+        "tr46": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.0.0.tgz",
+          "integrity": "sha512-tk2G5R2KRwBd+ZN0zaEXpmzdKyOYksXwywulIX95MBODjSzMIuQnQ3m8JxgbhnL1LeVo7lqQKsYa1O3Htl7K5g==",
+          "requires": {
+            "punycode": "^2.3.1"
+          }
+        },
+        "w3c-xmlserializer": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+          "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+          "requires": {
+            "xml-name-validator": "^5.0.0"
+          }
+        },
+        "whatwg-encoding": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+          "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+          "requires": {
+            "iconv-lite": "0.6.3"
+          }
+        },
+        "whatwg-mimetype": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+          "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="
+        },
+        "whatwg-url": {
+          "version": "14.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.0.0.tgz",
+          "integrity": "sha512-1lfMEm2IEr7RIV+f4lUNPOqfFL+pO+Xw3fJSqmjX9AbXcXcYOkCe1P6+9VBZB6n94af16NfZf+sSk0JCBZC9aw==",
+          "requires": {
+            "tr46": "^5.0.0",
+            "webidl-conversions": "^7.0.0"
           }
         },
         "widest-line": {
@@ -21433,6 +21739,11 @@
             "string-width": "^4.1.0",
             "strip-ansi": "^6.0.0"
           }
+        },
+        "xml-name-validator": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+          "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="
         }
       }
     },
@@ -22239,6 +22550,40 @@
       "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
       "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
       "dev": true
+    },
+    "@ts-morph/common": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.24.0.tgz",
+      "integrity": "sha512-c1xMmNHWpNselmpIqursHeOHHBTIsJLbB+NuovbTTRCNiTLEr/U9dbJ8qy0jd/O2x5pc3seWuOUN5R2IoOTp8A==",
+      "requires": {
+        "fast-glob": "^3.3.2",
+        "minimatch": "^9.0.4",
+        "mkdirp": "^3.0.1",
+        "path-browserify": "^1.0.1"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "9.0.5",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+          "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        },
+        "mkdirp": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+          "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg=="
+        }
+      }
     },
     "@tufjs/canonical-json": {
       "version": "1.0.0",
@@ -24222,14 +24567,14 @@
       }
     },
     "browserslist": {
-      "version": "4.23.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.0.tgz",
-      "integrity": "sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.0.tgz",
+      "integrity": "sha512-Rmb62sR1Zpjql25eSanFGEhAxcFwfA1K0GuQcLoaJBAcENegrQut3hYdhXFF1obQfiDyqIW/cLM5HSJ/9k884A==",
       "requires": {
-        "caniuse-lite": "^1.0.30001587",
-        "electron-to-chromium": "^1.4.668",
-        "node-releases": "^2.0.14",
-        "update-browserslist-db": "^1.0.13"
+        "caniuse-lite": "^1.0.30001663",
+        "electron-to-chromium": "^1.5.28",
+        "node-releases": "^2.0.18",
+        "update-browserslist-db": "^1.1.0"
       }
     },
     "bs-recipes": {
@@ -24469,9 +24814,9 @@
       "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA=="
     },
     "caniuse-lite": {
-      "version": "1.0.30001596",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001596.tgz",
-      "integrity": "sha512-zpkZ+kEr6We7w63ORkoJ2pOfBwBkY/bJrG/UZ90qNb45Isblu8wzDgevEOrRL1r9dWayHjYiiyCMEXPn4DweGQ=="
+      "version": "1.0.30001669",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001669.tgz",
+      "integrity": "sha512-DlWzFDJqstqtIVx1zeSpIMLjunf5SmwOw0N2Ck/QSQdS8PLS4+9HrLaYei4w8BIAL7IB/UEDu889d8vhCTPA0w=="
     },
     "capital-case": {
       "version": "1.0.4",
@@ -24845,6 +25190,11 @@
         "raw-body": "^2.3.3",
         "type-is": "^1.6.16"
       }
+    },
+    "code-block-writer": {
+      "version": "13.0.3",
+      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-13.0.3.tgz",
+      "integrity": "sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg=="
     },
     "color-convert": {
       "version": "1.9.3",
@@ -25461,8 +25811,7 @@
     "decimal.js": {
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
-      "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
-      "dev": true
+      "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA=="
     },
     "decode-uri-component": {
       "version": "0.2.2",
@@ -26046,9 +26395,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.696",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.696.tgz",
-      "integrity": "sha512-SOr0bHP52OvYg2chCsz/0+FUSMGFm8L8HKwPpx3cbwRY24EOemVJtbgTm+IFO8LzhcnPy+hXmTq7ZcZ8uUuaYg=="
+      "version": "1.5.39",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.39.tgz",
+      "integrity": "sha512-4xkpSR6CjuiaNyvwiWDI85N9AxsvbPawB8xc7yzLPonYTuP19BVgYweKyUMFtHEZgIcHWMt1ks5Cqx2m+6/Grg=="
     },
     "emoji-regex": {
       "version": "10.3.0",
@@ -26302,9 +26651,9 @@
       }
     },
     "escalade": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="
     },
     "escape-goat": {
       "version": "4.0.0",
@@ -27953,7 +28302,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       }
@@ -28617,8 +28965,7 @@
     "is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
-      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
-      "dev": true
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="
     },
     "is-promise": {
       "version": "2.2.2",
@@ -28998,9 +29345,9 @@
       }
     },
     "jsesc": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
+      "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g=="
     },
     "json-buffer": {
       "version": "3.0.1",
@@ -30668,9 +31015,9 @@
       }
     },
     "node-releases": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
-      "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw=="
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
+      "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g=="
     },
     "nopt": {
       "version": "6.0.0",
@@ -31010,10 +31357,9 @@
       }
     },
     "nwsapi": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.7.tgz",
-      "integrity": "sha512-ub5E4+FBPKwAZx0UwIQOjYWGHTEq5sPqHQNRN8Z9e4A7u3Tj1weLJsL59yH9vmvqEtBHaOmT6cYQKIZOxp35FQ==",
-      "dev": true
+      "version": "2.2.12",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.12.tgz",
+      "integrity": "sha512-qXDmcVlZV4XRtKFzddidpfVP4oMSGhga+xdMc25mv8kaLUHtgzCDhUxkrN8exkGdTlLNaXj7CV3GtON7zuGZ+w=="
     },
     "object-assign": {
       "version": "4.1.1",
@@ -31670,6 +32016,11 @@
         "tslib": "^2.0.3"
       }
     },
+    "path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
+    },
     "path-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
@@ -31751,9 +32102,9 @@
       "dev": true
     },
     "picocolors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.0.tgz",
+      "integrity": "sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw=="
     },
     "picomatch": {
       "version": "2.3.1",
@@ -32229,8 +32580,7 @@
     "psl": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
-      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
-      "dev": true
+      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
     },
     "pug": {
       "version": "3.0.2",
@@ -32369,8 +32719,7 @@
     "punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="
     },
     "pupa": {
       "version": "3.1.0",
@@ -32431,8 +32780,7 @@
     "querystringify": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
-      "dev": true
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
     },
     "queue-microtask": {
       "version": "1.2.3",
@@ -32789,8 +33137,7 @@
     "requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-      "dev": true
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
     },
     "resolve": {
       "version": "1.22.8",
@@ -33080,8 +33427,7 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sass": {
       "version": "1.71.1",
@@ -33104,7 +33450,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
       "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
-      "dev": true,
       "requires": {
         "xmlchars": "^2.2.0"
       }
@@ -33963,8 +34308,7 @@
     "symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
-      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
-      "dev": true
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
     },
     "table-layout": {
       "version": "3.0.2",
@@ -34173,10 +34517,9 @@
       "dev": true
     },
     "tough-cookie": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
-      "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
-      "dev": true,
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
       "requires": {
         "psl": "^1.1.33",
         "punycode": "^2.1.1",
@@ -34187,8 +34530,7 @@
         "universalify": {
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
-          "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
-          "dev": true
+          "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg=="
         }
       }
     },
@@ -34229,6 +34571,15 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
       "integrity": "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ=="
+    },
+    "ts-morph": {
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-23.0.0.tgz",
+      "integrity": "sha512-FcvFx7a9E8TUe6T3ShihXJLiJOiqyafzFKUO4aqIHDUCIvADdGNShcbc2W5PMr3LerXRv7mafvFZ9lRENxJmug==",
+      "requires": {
+        "@ts-morph/common": "~0.24.0",
+        "code-block-writer": "^13.0.1"
+      }
     },
     "tsconfig-paths": {
       "version": "3.14.2",
@@ -34500,12 +34851,12 @@
       "dev": true
     },
     "update-browserslist-db": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
-      "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.1.tgz",
+      "integrity": "sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==",
       "requires": {
-        "escalade": "^3.1.1",
-        "picocolors": "^1.0.0"
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.0"
       }
     },
     "update-notifier": {
@@ -34615,7 +34966,6 @@
       "version": "1.5.10",
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
       "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
-      "dev": true,
       "requires": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
@@ -34733,8 +35083,7 @@
     "webidl-conversions": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
-      "dev": true
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="
     },
     "whatwg-encoding": {
       "version": "2.0.0",
@@ -34959,10 +35308,9 @@
       }
     },
     "ws": {
-      "version": "8.14.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
-      "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
-      "dev": true,
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "requires": {}
     },
     "xdg-basedir": {
@@ -34980,8 +35328,7 @@
     "xmlchars": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
-      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
-      "dev": true
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
     },
     "xmlhttprequest-ssl": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "source-map": "^0.7.4",
     "strip-css-comments": "^5.0.0",
     "tslib": "^2.6.2",
-    "typescript": "^5.2.2",
+    "typescript": "5.2.2",
     "user-agent-data-types": "^0.3.1"
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
   },
   "dependencies": {
     "@ctrl/tinycolor": "^4.0.2",
+    "@figma/code-connect": "^1.0.3",
     "@floating-ui/dom": "^1.5.3",
     "@lit/react": "^1.0.0",
     "@shoelace-style/animations": "^1.1.0",
@@ -147,6 +148,9 @@
     "user-agent-data-types": "^0.3.1"
   },
   "lint-staged": {
-    "*.{ts,js}": ["eslint --max-warnings 0 --cache --fix", "prettier --write"]
+    "*.{ts,js}": [
+      "eslint --max-warnings 0 --cache --fix",
+      "prettier --write"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamshares/shoelace",
   "description": "The Teamshares flavor of a forward-thinking library of web components.",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "upstreamVersion": "2.14.0",
   "homepage": "https://github.com/teamshares/shoelace",
   "author": "Cory LaViska",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   },
   "dependencies": {
     "@ctrl/tinycolor": "^4.0.2",
-    "@figma/code-connect": "^1.0.3",
+    "@figma/code-connect": "^1.2.0",
     "@floating-ui/dom": "^1.5.3",
     "@lit/react": "^1.0.0",
     "@shoelace-style/animations": "^1.1.0",

--- a/src/components/alert/alert.styles.ts
+++ b/src/components/alert/alert.styles.ts
@@ -105,7 +105,7 @@ export default css`
     flex: 0 0 auto;
     display: flex;
     align-items: flex-start;
-    font-size: var(--sl-font-size-medium);
+    font-size: var(--sl-font-size-small);
     padding: var(--sl-spacing-x-small);
     margin-top: 2px;
   }

--- a/src/components/card/card.component.ts
+++ b/src/components/card/card.component.ts
@@ -13,7 +13,7 @@ import type { CSSResultGroup } from 'lit';
  * @status stable
  * @since 2.0
  * @pattern stable
- * @figma draft
+ * @figma ready
  *
  * @slot - The card's main content.
  * @slot header - An optional header for the card.

--- a/src/components/divider/divider.styles.ts
+++ b/src/components/divider/divider.styles.ts
@@ -2,7 +2,7 @@ import { css } from 'lit';
 
 export default css`
   :host {
-    --color: var(--sl-panel-border-color);
+    --color: var(--sl-color-neutral-300);
     --width: var(--sl-panel-border-width);
     --spacing: var(--sl-spacing-medium);
   }

--- a/src/components/drawer/drawer.component.ts
+++ b/src/components/drawer/drawer.component.ts
@@ -22,6 +22,7 @@ import type { CSSResultGroup } from 'lit';
  * @documentation https://shoelace.style/components/drawer
  * @status stable
  * @since 2.0
+ * @figma draft
  *
  * @dependency sl-icon-button
  *

--- a/src/components/tab-group/tab-group.component.ts
+++ b/src/components/tab-group/tab-group.component.ts
@@ -299,11 +299,12 @@ export default class SlTabGroup extends ShoelaceElement {
     // We can't used offsetLeft/offsetTop here due to a shadow parent issue where neither can getBoundingClientRect
     // because it provides invalid values for animating elements: https://bugs.chromium.org/p/chromium/issues/detail?id=920069
     const allTabs = this.getAllTabs();
+    const gap = 16;
     const precedingTabs = allTabs.slice(0, allTabs.indexOf(currentTab));
     const offset = precedingTabs.reduce(
       (previous, current) => ({
-        left: previous.left + current.clientWidth,
-        top: previous.top + current.clientHeight
+        left: previous.left + current.clientWidth + gap,
+        top: previous.top + current.clientHeight + gap
       }),
       { left: 0, top: 0 }
     );
@@ -330,6 +331,7 @@ export default class SlTabGroup extends ShoelaceElement {
     this.tabs = this.getAllTabs({ includeDisabled: false });
     this.panels = this.getAllPanels();
     this.syncIndicator();
+    this.addPlacementClasses();
 
     // After updating, show or hide scroll controls as needed
     this.updateComplete.then(() => this.updateScrollControls());
@@ -355,6 +357,29 @@ export default class SlTabGroup extends ShoelaceElement {
     } else {
       this.indicator.style.display = 'none';
     }
+  }
+
+  addPlacementClasses() {
+    if (!this.tabs || this.tabs.length === 0) return;
+
+    this.tabs.forEach(tab => {
+      tab.classList.remove('tab--top', 'tab--bottom', 'tab--start', 'tab--end');
+
+      switch (this.placement) {
+        case 'top':
+          tab.classList.add('tab--top');
+          break;
+        case 'bottom':
+          tab.classList.add('tab--bottom');
+          break;
+        case 'start':
+          tab.classList.add('tab--start');
+          break;
+        case 'end':
+          tab.classList.add('tab--end');
+          break;
+      }
+    });
   }
 
   /** Shows the specified tab panel. */

--- a/src/components/tab-group/tab-group.styles.ts
+++ b/src/components/tab-group/tab-group.styles.ts
@@ -17,6 +17,7 @@ export default css`
   .tab-group__tabs {
     display: flex;
     position: relative;
+    gap: var(--sl-spacing-medium);
   }
 
   .tab-group__indicator {

--- a/src/components/tab/tab.component.ts
+++ b/src/components/tab/tab.component.ts
@@ -28,6 +28,8 @@ let id = 0;
  * @csspart base - The component's base wrapper.
  * @csspart close-button - The close button, an `<sl-icon-button>`.
  * @csspart close-button__base - The close button's exported `base` part.
+ *
+ * @cssproperty --group-track-width - Used to calculate the tab's padding and border width. Must match the tab group's track width (default is 1px).
  */
 export default class SlTab extends ShoelaceElement {
   static styles: CSSResultGroup = [componentStyles, styles];

--- a/src/components/tab/tab.styles.ts
+++ b/src/components/tab/tab.styles.ts
@@ -2,6 +2,8 @@ import { css } from 'lit';
 
 export default css`
   :host {
+    --group-track-width: 1px;
+
     display: inline-block;
   }
 
@@ -12,9 +14,8 @@ export default css`
     font-size: var(--sl-font-size-small);
     font-weight: var(--sl-font-weight-semibold);
     line-height: var(--ts-leading-6);
-    border-radius: var(--sl-border-radius-medium);
     color: var(--sl-color-neutral-700);
-    padding: var(--ts-spacing-large) var(--sl-spacing-medium) var(--sl-spacing-large);
+    padding: var(--sl-spacing-medium);
     white-space: nowrap;
     user-select: none;
     -webkit-user-select: none;
@@ -24,8 +25,37 @@ export default css`
       var(--transition-speed) color;
   }
 
-  .tab:hover:not(.tab--disabled) {
-    color: var(--sl-color-primary-600);
+  .tab:hover:not(.tab--disabled):not(.tab--active) {
+    color: var(--sl-color-neutral-900);
+  }
+
+  :host(.tab--top) .tab {
+    border-bottom: calc(var(--sl-spacing-2x-small) - var(--group-track-width)) solid transparent;
+    padding-bottom: calc(var(--sl-spacing-medium) + var(--group-track-width));
+    transition: var(--sl-transition-medium) border-color ease;
+  }
+
+  :host(.tab--bottom) .tab {
+    border-top: calc(var(--sl-spacing-2x-small) - var(--group-track-width)) solid transparent;
+    padding-top: calc(var(--sl-spacing-medium) + var(--group-track-width));
+    transition: var(--sl-transition-medium) border-color ease;
+  }
+
+  :host(.tab--start) .tab {
+    display: flex;
+    border-right: calc(var(--sl-spacing-2x-small) - var(--group-track-width)) solid transparent;
+    padding-right: calc(var(--sl-spacing-medium) + var(--group-track-width));
+    transition: var(--sl-transition-medium) border-color ease;
+  }
+
+  :host(.tab--end) .tab {
+    border-left: calc(var(--sl-spacing-2x-small) - var(--group-track-width)) solid transparent;
+    padding-left: calc(var(--sl-spacing-medium) + var(--group-track-width));
+    transition: var(--sl-transition-medium) border-color ease;
+  }
+
+  .tab:hover:not(.tab--disabled):not(.tab--active) {
+    border-color: var(--sl-color-neutral-400);
   }
 
   .tab:focus {
@@ -38,7 +68,7 @@ export default css`
 
   .tab:focus-visible {
     outline: var(--sl-focus-ring);
-    outline-offset: calc(-1 * var(--sl-focus-ring-width) - var(--sl-focus-ring-offset));
+    outline-offset: calc(-1 * var(--sl-focus-ring-width));
   }
 
   .tab.tab--active:not(.tab--disabled) {

--- a/src/components/tag/tag.styles.ts
+++ b/src/components/tag/tag.styles.ts
@@ -11,6 +11,7 @@ export default css`
     border: none;
     border-radius: var(--ts-border-radius-x-small);
     line-height: 1;
+    font-weight: var(--sl-font-weight-semibold);
     white-space: nowrap;
     user-select: none;
     -webkit-user-select: none;

--- a/src/styles/exports/generated.css
+++ b/src/styles/exports/generated.css
@@ -408,7 +408,7 @@
   --ts-font-sans: Inter, Helvetica, Arial, -apple-system, BlinkMacSystemFont,
     "Segoe UI", sans-serif;
   --ts-font-serif: "DM Serif Display", Georgia, Times, serif;
-  --ts-font-mono: SFMono-Regular, Menlo, mono;
+  --ts-font-mono: SFMono-Regular, Menlo, Consolas, mono;
   --ts-font-body: var(--ts-font-sans);
   --ts-font-display: var(--ts-font-serif);
 }

--- a/src/styles/exports/overrides.css
+++ b/src/styles/exports/overrides.css
@@ -156,10 +156,6 @@ sl-menu-item[type]:focus {
   box-shadow: none;
 }
 
-sl-divider {
-  border-top: solid var(--sl-panel-border-color) var(--sl-panel-border-width);
-}
-
 sl-select[multiple] {
   appearance: initial;
   background-color: transparent;
@@ -255,14 +251,6 @@ sl-details.no-border::part(base) {
     margin-right: var(--sl-spacing-medium);
     /* 16px */
   }
-}
-
-/** ****************** */
-/** Divider */
-/** ****************** */
-
-sl-divider {
-  --color: var(--sl-color-neutral-300);
 }
 
 /** ****************** */

--- a/src/styles/tokens.json
+++ b/src/styles/tokens.json
@@ -103,7 +103,7 @@
   "fontFamily": {
     "sans": "Inter, Helvetica, Arial, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
     "serif": "'DM Serif Display', Georgia, Times, serif",
-    "mono": "SFMono-Regular, Menlo, mono",
+    "mono": "SFMono-Regular, Menlo, Consolas, mono",
     "display": "'DM Serif Display', Georgia, Times, serif",
     "body": "Inter, Helvetica, Arial, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -36,6 +36,7 @@
     ]
   },
   "include": [
-    "src"
+    "src",
+    "figma_connect"
   ]
 }


### PR DESCRIPTION
# v2.3.0
- Documentation and Figma Code Connect updates (no visible changes to components)
  - Set up Figma Code Connect for some components
  - Add Cypress testing docs to several form-related components
  - Add separate `TS Form` code example panel for components that can be rendered with `ts_form_for`
  - Update string syntax in Slim code examples to use boolean (e.g. `open=true` instead of `open='true'`)
  - Add code example for `sl-drawer` opened from `sl-dropdown` with button trigger
- Minor component styling updates
  - Update `sl-divider` default color
  - Update size of close icon (x) in `sl-alert`
  - Update `sl-tag` font weight to medium
  - Update spacing and hover state for `sl-tab-group` and `sl-tab` to match ViewComponent Tab

---
🔗 [Review app](https://shoelace-ft4dp64y2-teamshares.vercel.app/) 