### PR TITLE
Bump to 2.4.0

### DIFF
--- a/docs/pages/components/drawer.md
+++ b/docs/pages/components/drawer.md
@@ -12,35 +12,41 @@ layout: component
 ```html:preview
 <sl-drawer label="Drawer" class="drawer-overview">
   Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-  <sl-button slot="footer" variant="primary">Close</sl-button>
+  <sl-button id="cancel" slot="footer" variant="default">Cancel</sl-button>
+  <sl-button id="save" slot="footer" variant="primary">Save</sl-button>
 </sl-drawer>
 
-<sl-button>Open Drawer</sl-button>
+<sl-button>Open drawer</sl-button>
 
 <script>
   const drawer = document.querySelector('.drawer-overview');
   const openButton = drawer.nextElementSibling;
-  const closeButton = drawer.querySelector('sl-button[variant="primary"]');
+  const closeButton = drawer.querySelector('sl-button#cancel');
+  const saveButton = drawer.querySelector('sl-button#save');
 
   openButton.addEventListener('click', () => drawer.show());
   closeButton.addEventListener('click', () => drawer.hide());
+  saveButton.addEventListener('click', () => drawer.hide());
 
 </script>
 ```
 
 ```pug:slim
-sl-drawer.drawer-overview label="Drawer"
+sl-drawer.drawer-overview label="Drawer" class="drawer-overview"
   | Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-  sl-button slot="footer" variant="primary" Close
-sl-button Open Drawer
+  sl-button id="cancel" slot="footer" variant="default" Cancel
+  sl-button id="save" slot="footer" variant="primary" Save
+sl-button Open drawer
 
 javascript:
-  const drawer = document.querySelector(.drawer-overview);
+  const drawer = document.querySelector('.drawer-overview');
   const openButton = drawer.nextElementSibling;
-  const closeButton = drawer.querySelector(sl-button[variant=primary]);
+  const closeButton = drawer.querySelector('sl-button#cancel');
+  const saveButton = drawer.querySelector('sl-button#save');
 
   openButton.addEventListener(click, () => drawer.show());
   closeButton.addEventListener(click, () => drawer.hide());
+  saveButton.addEventListener(click, () => drawer.hide());
 ```
 
 ```jsx:react
@@ -60,13 +66,13 @@ const App = () => {
         </SlButton>
       </SlDrawer>
 
-      <SlButton onClick={() => setOpen(true)}>Open Drawer</SlButton>
+      <SlButton onClick={() => setOpen(true)}>Open drawer</SlButton>
     </>
   );
 };
 ```
 
-### Slide in From Start
+<!-- ### Slide in From Start
 
 By default, drawers slide in from the end. To make the drawer slide in from the start, set the `placement` attribute to `start`.
 
@@ -76,7 +82,7 @@ By default, drawers slide in from the end. To make the drawer slide in from the 
   <sl-button slot="footer" variant="primary">Close</sl-button>
 </sl-drawer>
 
-<sl-button>Open Drawer</sl-button>
+<sl-button>Open drawer</sl-button>
 
 <script>
   const drawer = document.querySelector('.drawer-placement-start');
@@ -92,7 +98,7 @@ By default, drawers slide in from the end. To make the drawer slide in from the 
 sl-drawer.drawer-placement-start label="Drawer" placement="start"
   | This drawer slides in from the start.
   sl-button slot="footer" variant="primary" Close
-sl-button Open Drawer
+sl-button Open drawer
 
 javascript:
   const drawer = document.querySelector(.drawer-placement-start);
@@ -120,7 +126,7 @@ const App = () => {
         </SlButton>
       </SlDrawer>
 
-      <SlButton onClick={() => setOpen(true)}>Open Drawer</SlButton>
+      <SlButton onClick={() => setOpen(true)}>Open drawer</SlButton>
     </>
   );
 };
@@ -136,7 +142,7 @@ To make the drawer slide in from the top, set the `placement` attribute to `top`
   <sl-button slot="footer" variant="primary">Close</sl-button>
 </sl-drawer>
 
-<sl-button>Open Drawer</sl-button>
+<sl-button>Open drawer</sl-button>
 
 <script>
   const drawer = document.querySelector('.drawer-placement-top');
@@ -152,7 +158,7 @@ To make the drawer slide in from the top, set the `placement` attribute to `top`
 sl-drawer.drawer-placement-top label="Drawer" placement="top"
   | This drawer slides in from the top.
   sl-button slot="footer" variant="primary" Close
-sl-button Open Drawer
+sl-button Open drawer
 
 javascript:
   const drawer = document.querySelector(.drawer-placement-top);
@@ -180,7 +186,7 @@ const App = () => {
         </SlButton>
       </SlDrawer>
 
-      <SlButton onClick={() => setOpen(true)}>Open Drawer</SlButton>
+      <SlButton onClick={() => setOpen(true)}>Open drawer</SlButton>
     </>
   );
 };
@@ -196,7 +202,7 @@ To make the drawer slide in from the bottom, set the `placement` attribute to `b
   <sl-button slot="footer" variant="primary">Close</sl-button>
 </sl-drawer>
 
-<sl-button>Open Drawer</sl-button>
+<sl-button>Open drawer</sl-button>
 
 <script>
   const drawer = document.querySelector('.drawer-placement-bottom');
@@ -212,7 +218,7 @@ To make the drawer slide in from the bottom, set the `placement` attribute to `b
 sl-drawer.drawer-placement-bottom label="Drawer" placement="bottom"
   | This drawer slides in from the bottom.
   sl-button slot="footer" variant="primary" Close
-sl-button Open Drawer
+sl-button Open drawer
 
 javascript:
   const drawer = document.querySelector(.drawer-placement-bottom);
@@ -240,11 +246,474 @@ const App = () => {
         </SlButton>
       </SlDrawer>
 
-      <SlButton onClick={() => setOpen(true)}>Open Drawer</SlButton>
+      <SlButton onClick={() => setOpen(true)}>Open drawer</SlButton>
+    </>
+  );
+};
+``` -->
+
+### Using with UI Drawer Component and Stimulus
+
+To open a [UI::Drawer::Component](https://os.teamshares.com/teamshares/lookbook/inspect/ui/drawer/default) (which wraps the `sl-drawer`):
+
+```pug:slim
+ div id="my-drawer-id"
+    = render UI::Drawer::Component.new(title: "My drawer title") do |d|
+      - d.with_trigger
+        sl-button Open my drawer
+```
+
+Add `slot="footer"` to buttons to take advantage of the drawer's built-in placement for footer buttons.
+
+Use the following Stimulus `data-action` attributes to close the drawer and also submit Simple Form/ts_form_for forms in the body of the drawer:
+
+```pug:slim
+ sl-button[
+  slot="footer"
+  type="button"
+  data-action="click->components--ui--drawer#closeDrawer"
+ ] Cancel
+ sl-button[
+  slot="footer"
+  variant="primary"
+  type="button"
+  data-action="click->components--ui--drawer#submitForm"
+ ] Submit
+```
+
+### Opening from Dropdown Menu
+
+When opening a drawer from a `sl-dropdown` menu item triggered by a `sl-button`, wrap the button in a `div` and add `slot="trigger"` to the `div` rather than the button to prevent the drawer from skipping when opening.
+
+```html:preview
+<sl-drawer label="Drawer" class="drawer-dropdown">
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+  <sl-button slot="footer" variant="primary">Close</sl-button>
+</sl-drawer>
+
+<sl-dropdown>
+  <div slot="trigger"><sl-button caret>Dropdown</sl-button></div>
+  <sl-menu>
+    <sl-menu-item class="open-link">Open drawer</sl-menu-item>
+  </sl-menu>
+</sl-dropdown>
+
+<script>
+  const drawer = document.querySelector('.drawer-dropdown');
+  const openButton = document.querySelector('.open-link');
+  const closeButton = drawer.querySelector('sl-button[variant="primary"]');
+
+  openButton.addEventListener('click', (event) => drawer.show());
+  closeButton.addEventListener('click', () => drawer.hide());
+
+</script>
+```
+
+```pug:slim
+sl-drawer.drawer-dropdown label="Drawer"
+  | Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+  sl-button slot="footer" variant="primary" Close
+
+sl-dropdown
+  div slot="trigger"
+    sl-button caret=true Dropdown
+    sl-menu
+      sl-menu-item.open-link Open drawer
+
+javascript:
+  const drawer = document.querySelector(.drawer-dropdown);
+  const openButton = drawer.querySelector(.open-link);
+  const closeButton = drawer.querySelector(sl-button[variant=primary]);
+
+  openButton.addEventListener(click, () => drawer.show());
+  closeButton.addEventListener(click, () => drawer.hide());
+```
+
+```jsx:react
+import { useState } from 'react';
+import SlButton from '@teamshares/shoelace/dist/react/button';
+import SlDrawer from '@teamshares/shoelace/dist/react/drawer';
+
+const App = () => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <SlDrawer label="Drawer" open={open} onSlAfterHide={() => setOpen(false)}>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+        <SlButton slot="footer" variant="primary" onClick={() => setOpen(false)}>
+          Close
+        </SlButton>
+      </SlDrawer>
+
+      <SlButton onClick={() => setOpen(true)}>Open drawer</SlButton>
     </>
   );
 };
 ```
+
+### Custom Size
+
+Use the `--size` custom property to set the drawer's size. This will be applied to the drawer's width or height depending on its `placement`.
+
+```html:preview
+<sl-drawer label="Drawer" class="drawer-custom-size" style="--size: 50vw;">
+  This drawer is always 50% of the viewport.
+  <sl-button slot="footer" variant="primary">Close</sl-button>
+</sl-drawer>
+
+<sl-button>Open drawer</sl-button>
+
+<script>
+  const drawer = document.querySelector('.drawer-custom-size');
+  const openButton = drawer.nextElementSibling;
+  const closeButton = drawer.querySelector('sl-button[variant="primary"]');
+
+  openButton.addEventListener('click', () => drawer.show());
+  closeButton.addEventListener('click', () => drawer.hide());
+</script>
+```
+
+```pug:slim
+sl-drawer.drawer-custom-size label="Drawer" style="--size: 50vw;"
+  | This drawer is always 50% of the viewport.
+  sl-button slot="footer" variant="primary" Close
+sl-button Open drawer
+
+javascript:
+  const drawer = document.querySelector(.drawer-custom-size);
+  const openButton = drawer.nextElementSibling;
+  const closeButton = drawer.querySelector(sl-button[variant=primary]);
+
+  openButton.addEventListener(click, () => drawer.show());
+  closeButton.addEventListener(click, () => drawer.hide());
+```
+
+{% raw %}
+
+```jsx:react
+import { useState } from 'react';
+import SlButton from '@teamshares/shoelace/dist/react/button';
+import SlDrawer from '@teamshares/shoelace/dist/react/drawer';
+
+const App = () => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <SlDrawer label="Drawer" open={open} onSlAfterHide={() => setOpen(false)} style={{ '--size': '50vw' }}>
+        This drawer is always 50% of the viewport.
+        <SlButton slot="footer" variant="primary" onClick={() => setOpen(false)}>
+          Close
+        </SlButton>
+      </SlDrawer>
+
+      <SlButton onClick={() => setOpen(true)}>Open drawer</SlButton>
+    </>
+  );
+};
+```
+
+{% endraw %}
+
+### Scrolling
+
+By design, a drawer's height will never exceed 100% of its container. As such, drawers will not scroll with the page to ensure the header and footer are always accessible to the user.
+
+```html:preview
+<sl-drawer label="Drawer" class="drawer-scrolling">
+  <div style="height: 150vh; border: dashed 2px var(--sl-color-neutral-200); padding: 0 1rem;">
+    <p>Scroll down and give it a try! 👇</p>
+  </div>
+  <sl-button slot="footer" variant="primary">Close</sl-button>
+</sl-drawer>
+
+<sl-button>Open drawer</sl-button>
+
+<script>
+  const drawer = document.querySelector('.drawer-scrolling');
+  const openButton = drawer.nextElementSibling;
+  const closeButton = drawer.querySelector('sl-button[variant="primary"]');
+
+  openButton.addEventListener('click', () => drawer.show());
+  closeButton.addEventListener('click', () => drawer.hide());
+</script>
+```
+
+```pug:slim
+sl-drawer.drawer-scrolling label="Drawer"
+  div style="height: 150vh; border: dashed 2px var(--sl-color-neutral-200); padding: 0 1rem;"
+    p Scroll down and give it a try! 👇
+  sl-button slot="footer" variant="primary" Close
+sl-button Open drawer
+
+javascript:
+  const drawer = document.querySelector(.drawer-scrolling);
+  const openButton = drawer.nextElementSibling;
+  const closeButton = drawer.querySelector(sl-button[variant=primary]);
+
+  openButton.addEventListener(click, () => drawer.show());
+  closeButton.addEventListener(click, () => drawer.hide());
+```
+
+{% raw %}
+
+```jsx:react
+import { useState } from 'react';
+import SlButton from '@teamshares/shoelace/dist/react/button';
+import SlDrawer from '@teamshares/shoelace/dist/react/drawer';
+
+const App = () => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <SlDrawer label="Drawer" open={open} onSlAfterHide={() => setOpen(false)}>
+        <div
+          style={{
+            height: '150vh',
+            border: 'dashed 2px var(--sl-color-neutral-200)',
+            padding: '0 1rem'
+          }}
+        >
+          <p>Scroll down and give it a try! 👇</p>
+        </div>
+        <SlButton slot="footer" variant="primary" onClick={() => setOpen(false)}>
+          Close
+        </SlButton>
+      </SlDrawer>
+
+      <SlButton onClick={() => setOpen(true)}>Open drawer</SlButton>
+    </>
+  );
+};
+```
+
+{% endraw %}
+
+### Header Actions
+
+The header shows a functional close button by default. You can use the `header-actions` slot to add additional [icon buttons](/components/icon-button) if needed.
+
+```html:preview
+<sl-drawer label="Drawer" class="drawer-header-actions">
+  <sl-icon-button class="new-window" slot="header-actions" name="arrow-top-right-on-square"></sl-icon-button>
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+  <sl-button slot="footer" variant="primary">Close</sl-button>
+</sl-drawer>
+
+<sl-button>Open drawer</sl-button>
+
+<script>
+  const drawer = document.querySelector('.drawer-header-actions');
+  const openButton = drawer.nextElementSibling;
+  const closeButton = drawer.querySelector('sl-button[variant="primary"]');
+  const newWindowButton = drawer.querySelector('.new-window');
+
+  openButton.addEventListener('click', () => drawer.show());
+  closeButton.addEventListener('click', () => drawer.hide());
+  newWindowButton.addEventListener('click', () => window.open(location.href));
+</script>
+```
+
+```pug:slim
+sl-drawer.drawer-header-actions label="Drawer"
+  sl-icon-button.new-window slot="header-actions" name="arrow-top-right-on-square"
+  | Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+  sl-button slot="footer" variant="primary" Close
+sl-button Open drawer
+
+javascript:
+  const drawer = document.querySelector(.drawer-header-actions);
+  const openButton = drawer.nextElementSibling;
+  const closeButton = drawer.querySelector(sl-button[variant=primary]);
+  const newWindowButton = drawer.querySelector(.new-window);
+
+  openButton.addEventListener(click, () => drawer.show());
+  closeButton.addEventListener(click, () => drawer.hide());
+  newWindowButton.addEventListener(click, () => window.open(location.href));
+```
+
+```jsx:react
+import { useState } from 'react';
+import SlButton from '@teamshares/shoelace/dist/react/button';
+import SlDrawer from '@teamshares/shoelace/dist/react/drawer';
+import SlIconButton from '@teamshares/shoelace/dist/react/icon-button';
+
+const App = () => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <SlDrawer label="Drawer" open={open} onSlAfterHide={() => setOpen(false)}>
+        <SlIconButton
+          slot="header-actions"
+          name="arrow-top-right-on-square"
+          onClick={() => window.open(location.href)}
+        />
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+        <SlButton slot="footer" variant="primary" onClick={() => setOpen(false)}>
+          Close
+        </SlButton>
+      </SlDrawer>
+
+      <SlButton onClick={() => setOpen(true)}>Open drawer</SlButton>
+    </>
+  );
+};
+```
+
+### Preventing the Drawer from Closing
+
+By default, drawers will close when the user clicks the close button, clicks the overlay, or presses the [[Escape]] key. In most cases, the default behavior is the best behavior in terms of UX. However, there are situations where this may be undesirable, such as when data loss will occur.
+
+To keep the drawer open in such cases, you can cancel the `sl-request-close` event. When canceled, the drawer will remain open and pulse briefly to draw the user's attention to it.
+
+You can use `event.detail.source` to determine what triggered the request to close. This example prevents the drawer from closing when the overlay is clicked, but allows the close button or [[Escape]] to dismiss it.
+
+```html:preview
+<sl-drawer label="Drawer" class="drawer-deny-close">
+  This drawer will not close when you click on the overlay.
+  <sl-button slot="footer" variant="primary">Close</sl-button>
+</sl-drawer>
+
+<sl-button>Open drawer</sl-button>
+
+<script>
+  const drawer = document.querySelector('.drawer-deny-close');
+  const openButton = drawer.nextElementSibling;
+  const closeButton = drawer.querySelector('sl-button[variant="primary"]');
+
+  openButton.addEventListener('click', () => drawer.show());
+  closeButton.addEventListener('click', () => drawer.hide());
+
+  // Prevent the drawer from closing when the user clicks on the overlay
+  drawer.addEventListener('sl-request-close', event => {
+    if (event.detail.source === 'overlay') {
+      event.preventDefault();
+    }
+  });
+</script>
+```
+
+```pug:slim
+sl-drawer.drawer-deny-close label="Drawer"
+  | This drawer will not close when you click on the overlay.
+  sl-button slot="footer" variant="primary" Close
+sl-button Open drawer
+
+javascript:
+  const drawer = document.querySelector(.drawer-deny-close);
+  const openButton = drawer.nextElementSibling;
+  const closeButton = drawer.querySelector(sl-button[variant=primary]);
+
+  openButton.addEventListener(click, () => drawer.show());
+  closeButton.addEventListener(click, () => drawer.hide());
+
+  // Prevent the drawer from closing when the user clicks on the overlay
+  drawer.addEventListener(sl-request-close, event => {
+  if (event.detail.source === overlay) {
+  event.preventDefault();
+  }
+  });
+```
+
+```jsx:react
+import { useState } from 'react';
+import SlButton from '@teamshares/shoelace/dist/react/button';
+import SlDrawer from '@teamshares/shoelace/dist/react/drawer';
+
+const App = () => {
+  const [open, setOpen] = useState(false);
+
+  // Prevent the drawer from closing when the user clicks on the overlay
+  function handleRequestClose(event) {
+    if (event.detail.source === 'overlay') {
+      event.preventDefault();
+    }
+  }
+
+  return (
+    <>
+      <SlDrawer label="Drawer" open={open} onSlRequestClose={handleRequestClose} onSlAfterHide={() => setOpen(false)}>
+        This drawer will not close when you click on the overlay.
+        <SlButton slot="footer" variant="primary" onClick={() => setOpen(false)}>
+          Save &amp; Close
+        </SlButton>
+      </SlDrawer>
+
+      <SlButton onClick={() => setOpen(true)}>Open drawer</SlButton>
+    </>
+  );
+};
+```
+
+### Customizing Initial Focus
+
+By default, the drawer's panel will gain focus when opened. This allows a subsequent tab press to focus on the first tabbable element in the drawer. If you want a different element to have focus, add the `autofocus` attribute to it as shown below.
+
+```html:preview
+<sl-drawer label="Drawer" class="drawer-focus">
+  <sl-input autofocus placeholder="I will have focus when the drawer is opened"></sl-input>
+  <sl-button slot="footer" variant="primary">Close</sl-button>
+</sl-drawer>
+
+<sl-button>Open drawer</sl-button>
+
+<script>
+  const drawer = document.querySelector('.drawer-focus');
+  const input = drawer.querySelector('sl-input');
+  const openButton = drawer.nextElementSibling;
+  const closeButton = drawer.querySelector('sl-button[variant="primary"]');
+
+  openButton.addEventListener('click', () => drawer.show());
+  closeButton.addEventListener('click', () => drawer.hide());
+</script>
+```
+
+```pug:slim
+sl-drawer.drawer-focus label="Drawer"
+  sl-input autofocus=true placeholder="I will have focus when the drawer is opened"
+  sl-button slot="footer" variant="primary" Close
+sl-button Open drawer
+
+javascript:
+  const drawer = document.querySelector(.drawer-focus);
+  const input = drawer.querySelector(sl-input);
+  const openButton = drawer.nextElementSibling;
+  const closeButton = drawer.querySelector(sl-button[variant=primary]);
+
+  openButton.addEventListener(click, () => drawer.show());
+  closeButton.addEventListener(click, () => drawer.hide());
+```
+
+```jsx:react
+import { useState } from 'react';
+import SlButton from '@teamshares/shoelace/dist/react/button';
+import SlDrawer from '@teamshares/shoelace/dist/react/drawer';
+import SlInput from '@teamshares/shoelace/dist/react/input';
+
+const App = () => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <SlDrawer label="Drawer" open={open} onSlAfterHide={() => setOpen(false)}>
+        <SlInput autofocus placeholder="I will have focus when the drawer is opened" />
+        <SlButton slot="footer" variant="primary" onClick={() => setOpen(false)}>
+          Close
+        </SlButton>
+      </SlDrawer>
+
+      <SlButton onClick={() => setOpen(true)}>Open drawer</SlButton>
+    </>
+  );
+};
+```
+
+:::tip
+You can further customize initial focus behavior by canceling the `sl-initial-focus` event and setting focus yourself inside the event handler.
+:::
 
 ### Contained to an Element
 
@@ -333,444 +802,10 @@ const App = () => {
         </SlDrawer>
       </div>
 
-      <SlButton onClick={() => setOpen(true)}>Open Drawer</SlButton>
+      <SlButton onClick={() => setOpen(true)}>Open drawer</SlButton>
     </>
   );
 };
 ```
 
 {% endraw %}
-
-### Opening from Dropdown Menu
-
-When opening a drawer from a `sl-dropdown` menu item triggered by a `sl-button`, wrap the button in a `div` and add `slot="trigger"` to the `div` rather than the button to prevent the drawer from skipping when opening.
-
-```html:preview
-<sl-drawer label="Drawer" class="drawer-overview">
-  Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-  <sl-button slot="footer" variant="primary">Close</sl-button>
-</sl-drawer>
-
-<sl-dropdown>
-  <div slot="trigger"><sl-button caret>Dropdown</sl-button></div>
-  <sl-menu>
-    <sl-menu-item class="open-link">Open drawer</sl-menu-item>
-  </sl-menu>
-</sl-dropdown>
-
-<script>
-  const drawer = document.querySelector('.drawer-overview');
-  const openButton = document.querySelector('.open-link');
-  const closeButton = drawer.querySelector('sl-button[variant="primary"]');
-
-  openButton.addEventListener('click', (event) => drawer.show());
-  closeButton.addEventListener('click', () => drawer.hide());
-
-</script>
-```
-
-```pug:slim
-sl-drawer.drawer-overview label="Drawer"
-  | Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-  sl-button slot="footer" variant="primary" Close
-
-sl-dropdown
-  div slot="trigger"
-    sl-button caret=true Dropdown
-    sl-menu
-      sl-menu-item.open-link Open drawer
-
-javascript:
-  const drawer = document.querySelector(.drawer-overview);
-  const openButton = drawer.querySelector(.open-link);
-  const closeButton = drawer.querySelector(sl-button[variant=primary]);
-
-  openButton.addEventListener(click, () => drawer.show());
-  closeButton.addEventListener(click, () => drawer.hide());
-```
-
-```jsx:react
-import { useState } from 'react';
-import SlButton from '@teamshares/shoelace/dist/react/button';
-import SlDrawer from '@teamshares/shoelace/dist/react/drawer';
-
-const App = () => {
-  const [open, setOpen] = useState(false);
-
-  return (
-    <>
-      <SlDrawer label="Drawer" open={open} onSlAfterHide={() => setOpen(false)}>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-        <SlButton slot="footer" variant="primary" onClick={() => setOpen(false)}>
-          Close
-        </SlButton>
-      </SlDrawer>
-
-      <SlButton onClick={() => setOpen(true)}>Open Drawer</SlButton>
-    </>
-  );
-};
-```
-
-### Custom Size
-
-Use the `--size` custom property to set the drawer's size. This will be applied to the drawer's width or height depending on its `placement`.
-
-```html:preview
-<sl-drawer label="Drawer" class="drawer-custom-size" style="--size: 50vw;">
-  This drawer is always 50% of the viewport.
-  <sl-button slot="footer" variant="primary">Close</sl-button>
-</sl-drawer>
-
-<sl-button>Open Drawer</sl-button>
-
-<script>
-  const drawer = document.querySelector('.drawer-custom-size');
-  const openButton = drawer.nextElementSibling;
-  const closeButton = drawer.querySelector('sl-button[variant="primary"]');
-
-  openButton.addEventListener('click', () => drawer.show());
-  closeButton.addEventListener('click', () => drawer.hide());
-</script>
-```
-
-```pug:slim
-sl-drawer.drawer-custom-size label="Drawer" style="--size: 50vw;"
-  | This drawer is always 50% of the viewport.
-  sl-button slot="footer" variant="primary" Close
-sl-button Open Drawer
-
-javascript:
-  const drawer = document.querySelector(.drawer-custom-size);
-  const openButton = drawer.nextElementSibling;
-  const closeButton = drawer.querySelector(sl-button[variant=primary]);
-
-  openButton.addEventListener(click, () => drawer.show());
-  closeButton.addEventListener(click, () => drawer.hide());
-```
-
-{% raw %}
-
-```jsx:react
-import { useState } from 'react';
-import SlButton from '@teamshares/shoelace/dist/react/button';
-import SlDrawer from '@teamshares/shoelace/dist/react/drawer';
-
-const App = () => {
-  const [open, setOpen] = useState(false);
-
-  return (
-    <>
-      <SlDrawer label="Drawer" open={open} onSlAfterHide={() => setOpen(false)} style={{ '--size': '50vw' }}>
-        This drawer is always 50% of the viewport.
-        <SlButton slot="footer" variant="primary" onClick={() => setOpen(false)}>
-          Close
-        </SlButton>
-      </SlDrawer>
-
-      <SlButton onClick={() => setOpen(true)}>Open Drawer</SlButton>
-    </>
-  );
-};
-```
-
-{% endraw %}
-
-### Scrolling
-
-By design, a drawer's height will never exceed 100% of its container. As such, drawers will not scroll with the page to ensure the header and footer are always accessible to the user.
-
-```html:preview
-<sl-drawer label="Drawer" class="drawer-scrolling">
-  <div style="height: 150vh; border: dashed 2px var(--sl-color-neutral-200); padding: 0 1rem;">
-    <p>Scroll down and give it a try! 👇</p>
-  </div>
-  <sl-button slot="footer" variant="primary">Close</sl-button>
-</sl-drawer>
-
-<sl-button>Open Drawer</sl-button>
-
-<script>
-  const drawer = document.querySelector('.drawer-scrolling');
-  const openButton = drawer.nextElementSibling;
-  const closeButton = drawer.querySelector('sl-button[variant="primary"]');
-
-  openButton.addEventListener('click', () => drawer.show());
-  closeButton.addEventListener('click', () => drawer.hide());
-</script>
-```
-
-```pug:slim
-sl-drawer.drawer-scrolling label="Drawer"
-  div style="height: 150vh; border: dashed 2px var(--sl-color-neutral-200); padding: 0 1rem;"
-    p Scroll down and give it a try! 👇
-  sl-button slot="footer" variant="primary" Close
-sl-button Open Drawer
-
-javascript:
-  const drawer = document.querySelector(.drawer-scrolling);
-  const openButton = drawer.nextElementSibling;
-  const closeButton = drawer.querySelector(sl-button[variant=primary]);
-
-  openButton.addEventListener(click, () => drawer.show());
-  closeButton.addEventListener(click, () => drawer.hide());
-```
-
-{% raw %}
-
-```jsx:react
-import { useState } from 'react';
-import SlButton from '@teamshares/shoelace/dist/react/button';
-import SlDrawer from '@teamshares/shoelace/dist/react/drawer';
-
-const App = () => {
-  const [open, setOpen] = useState(false);
-
-  return (
-    <>
-      <SlDrawer label="Drawer" open={open} onSlAfterHide={() => setOpen(false)}>
-        <div
-          style={{
-            height: '150vh',
-            border: 'dashed 2px var(--sl-color-neutral-200)',
-            padding: '0 1rem'
-          }}
-        >
-          <p>Scroll down and give it a try! 👇</p>
-        </div>
-        <SlButton slot="footer" variant="primary" onClick={() => setOpen(false)}>
-          Close
-        </SlButton>
-      </SlDrawer>
-
-      <SlButton onClick={() => setOpen(true)}>Open Drawer</SlButton>
-    </>
-  );
-};
-```
-
-{% endraw %}
-
-### Header Actions
-
-The header shows a functional close button by default. You can use the `header-actions` slot to add additional [icon buttons](/components/icon-button) if needed.
-
-```html:preview
-<sl-drawer label="Drawer" class="drawer-header-actions">
-  <sl-icon-button class="new-window" slot="header-actions" name="arrow-top-right-on-square"></sl-icon-button>
-  Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-  <sl-button slot="footer" variant="primary">Close</sl-button>
-</sl-drawer>
-
-<sl-button>Open Drawer</sl-button>
-
-<script>
-  const drawer = document.querySelector('.drawer-header-actions');
-  const openButton = drawer.nextElementSibling;
-  const closeButton = drawer.querySelector('sl-button[variant="primary"]');
-  const newWindowButton = drawer.querySelector('.new-window');
-
-  openButton.addEventListener('click', () => drawer.show());
-  closeButton.addEventListener('click', () => drawer.hide());
-  newWindowButton.addEventListener('click', () => window.open(location.href));
-</script>
-```
-
-```pug:slim
-sl-drawer.drawer-header-actions label="Drawer"
-  sl-icon-button.new-window slot="header-actions" name="arrow-top-right-on-square"
-  | Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-  sl-button slot="footer" variant="primary" Close
-sl-button Open Drawer
-
-javascript:
-  const drawer = document.querySelector(.drawer-header-actions);
-  const openButton = drawer.nextElementSibling;
-  const closeButton = drawer.querySelector(sl-button[variant=primary]);
-  const newWindowButton = drawer.querySelector(.new-window);
-
-  openButton.addEventListener(click, () => drawer.show());
-  closeButton.addEventListener(click, () => drawer.hide());
-  newWindowButton.addEventListener(click, () => window.open(location.href));
-```
-
-```jsx:react
-import { useState } from 'react';
-import SlButton from '@teamshares/shoelace/dist/react/button';
-import SlDrawer from '@teamshares/shoelace/dist/react/drawer';
-import SlIconButton from '@teamshares/shoelace/dist/react/icon-button';
-
-const App = () => {
-  const [open, setOpen] = useState(false);
-
-  return (
-    <>
-      <SlDrawer label="Drawer" open={open} onSlAfterHide={() => setOpen(false)}>
-        <SlIconButton
-          slot="header-actions"
-          name="arrow-top-right-on-square"
-          onClick={() => window.open(location.href)}
-        />
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-        <SlButton slot="footer" variant="primary" onClick={() => setOpen(false)}>
-          Close
-        </SlButton>
-      </SlDrawer>
-
-      <SlButton onClick={() => setOpen(true)}>Open Drawer</SlButton>
-    </>
-  );
-};
-```
-
-### Preventing the Drawer from Closing
-
-By default, drawers will close when the user clicks the close button, clicks the overlay, or presses the [[Escape]] key. In most cases, the default behavior is the best behavior in terms of UX. However, there are situations where this may be undesirable, such as when data loss will occur.
-
-To keep the drawer open in such cases, you can cancel the `sl-request-close` event. When canceled, the drawer will remain open and pulse briefly to draw the user's attention to it.
-
-You can use `event.detail.source` to determine what triggered the request to close. This example prevents the drawer from closing when the overlay is clicked, but allows the close button or [[Escape]] to dismiss it.
-
-```html:preview
-<sl-drawer label="Drawer" class="drawer-deny-close">
-  This drawer will not close when you click on the overlay.
-  <sl-button slot="footer" variant="primary">Close</sl-button>
-</sl-drawer>
-
-<sl-button>Open Drawer</sl-button>
-
-<script>
-  const drawer = document.querySelector('.drawer-deny-close');
-  const openButton = drawer.nextElementSibling;
-  const closeButton = drawer.querySelector('sl-button[variant="primary"]');
-
-  openButton.addEventListener('click', () => drawer.show());
-  closeButton.addEventListener('click', () => drawer.hide());
-
-  // Prevent the drawer from closing when the user clicks on the overlay
-  drawer.addEventListener('sl-request-close', event => {
-    if (event.detail.source === 'overlay') {
-      event.preventDefault();
-    }
-  });
-</script>
-```
-
-```pug:slim
-sl-drawer.drawer-deny-close label="Drawer"
-  | This drawer will not close when you click on the overlay.
-  sl-button slot="footer" variant="primary" Close
-sl-button Open Drawer
-
-javascript:
-  const drawer = document.querySelector(.drawer-deny-close);
-  const openButton = drawer.nextElementSibling;
-  const closeButton = drawer.querySelector(sl-button[variant=primary]);
-
-  openButton.addEventListener(click, () => drawer.show());
-  closeButton.addEventListener(click, () => drawer.hide());
-
-  // Prevent the drawer from closing when the user clicks on the overlay
-  drawer.addEventListener(sl-request-close, event => {
-  if (event.detail.source === overlay) {
-  event.preventDefault();
-  }
-  });
-```
-
-```jsx:react
-import { useState } from 'react';
-import SlButton from '@teamshares/shoelace/dist/react/button';
-import SlDrawer from '@teamshares/shoelace/dist/react/drawer';
-
-const App = () => {
-  const [open, setOpen] = useState(false);
-
-  // Prevent the drawer from closing when the user clicks on the overlay
-  function handleRequestClose(event) {
-    if (event.detail.source === 'overlay') {
-      event.preventDefault();
-    }
-  }
-
-  return (
-    <>
-      <SlDrawer label="Drawer" open={open} onSlRequestClose={handleRequestClose} onSlAfterHide={() => setOpen(false)}>
-        This drawer will not close when you click on the overlay.
-        <SlButton slot="footer" variant="primary" onClick={() => setOpen(false)}>
-          Save &amp; Close
-        </SlButton>
-      </SlDrawer>
-
-      <SlButton onClick={() => setOpen(true)}>Open Drawer</SlButton>
-    </>
-  );
-};
-```
-
-### Customizing Initial Focus
-
-By default, the drawer's panel will gain focus when opened. This allows a subsequent tab press to focus on the first tabbable element in the drawer. If you want a different element to have focus, add the `autofocus` attribute to it as shown below.
-
-```html:preview
-<sl-drawer label="Drawer" class="drawer-focus">
-  <sl-input autofocus placeholder="I will have focus when the drawer is opened"></sl-input>
-  <sl-button slot="footer" variant="primary">Close</sl-button>
-</sl-drawer>
-
-<sl-button>Open Drawer</sl-button>
-
-<script>
-  const drawer = document.querySelector('.drawer-focus');
-  const input = drawer.querySelector('sl-input');
-  const openButton = drawer.nextElementSibling;
-  const closeButton = drawer.querySelector('sl-button[variant="primary"]');
-
-  openButton.addEventListener('click', () => drawer.show());
-  closeButton.addEventListener('click', () => drawer.hide());
-</script>
-```
-
-```pug:slim
-sl-drawer.drawer-focus label="Drawer"
-  sl-input autofocus=true placeholder="I will have focus when the drawer is opened"
-  sl-button slot="footer" variant="primary" Close
-sl-button Open Drawer
-
-javascript:
-  const drawer = document.querySelector(.drawer-focus);
-  const input = drawer.querySelector(sl-input);
-  const openButton = drawer.nextElementSibling;
-  const closeButton = drawer.querySelector(sl-button[variant=primary]);
-
-  openButton.addEventListener(click, () => drawer.show());
-  closeButton.addEventListener(click, () => drawer.hide());
-```
-
-```jsx:react
-import { useState } from 'react';
-import SlButton from '@teamshares/shoelace/dist/react/button';
-import SlDrawer from '@teamshares/shoelace/dist/react/drawer';
-import SlInput from '@teamshares/shoelace/dist/react/input';
-
-const App = () => {
-  const [open, setOpen] = useState(false);
-
-  return (
-    <>
-      <SlDrawer label="Drawer" open={open} onSlAfterHide={() => setOpen(false)}>
-        <SlInput autofocus placeholder="I will have focus when the drawer is opened" />
-        <SlButton slot="footer" variant="primary" onClick={() => setOpen(false)}>
-          Close
-        </SlButton>
-      </SlDrawer>
-
-      <SlButton onClick={() => setOpen(true)}>Open Drawer</SlButton>
-    </>
-  );
-};
-```
-
-:::tip
-You can further customize initial focus behavior by canceling the `sl-initial-focus` event and setting focus yourself inside the event handler.
-:::

--- a/docs/pages/components/drawer.md
+++ b/docs/pages/components/drawer.md
@@ -497,7 +497,7 @@ The header shows a functional close button by default. You can use the `header-a
 
 ```html:preview
 <sl-drawer label="Drawer" class="drawer-header-actions">
-  <sl-icon-button class="new-window" slot="header-actions" name="arrow-top-right-on-square"></sl-icon-button>
+  <sl-icon-button library="fa" class="new-window" slot="header-actions" name="arrow-up-right-from-square"></sl-icon-button>
   Lorem ipsum dolor sit amet, consectetur adipiscing elit.
   <sl-button slot="footer" variant="primary">Close</sl-button>
 </sl-drawer>

--- a/docs/pages/components/input.md
+++ b/docs/pages/components/input.md
@@ -571,6 +571,8 @@ The `type` attribute controls the type of input the browser renders. As shown in
     <div slot="help-text">Use the <code>no-spin-buttons</code> attribute to hide the browser's default increment/decrement buttons for number inputs</div>
 </sl-input>
 <br />
+<sl-input type="percentage" label="Input type: Percentage"></sl-input>
+<br />
 <sl-input type="search" label="Input type: Search" clearable><div slot="help-text">Has a search icon by default. Use the <code>clearable</code> attribute to make the input clearable</div></sl-input>
 <br />
 ```

--- a/docs/pages/teamshares/changelog.md
+++ b/docs/pages/teamshares/changelog.md
@@ -11,6 +11,7 @@ meta:
 - Add documentation for `UI::Drawer::Component` to the Drawer component docs
 - Fix small UI bug for Drawer component close icon
 - Move `sl-icon-button` styles from the overrides stylesheet into the `sl-dialog` and `sl-drawer` stylesheets
+- Update styles for `sl-button variant="success" outline` to match other variants
 
 ## 2.3.2
 

--- a/docs/pages/teamshares/changelog.md
+++ b/docs/pages/teamshares/changelog.md
@@ -5,6 +5,13 @@ meta:
 
 # Changelog
 
+## 2.4.0
+
+- Add `percentage` type to `sl-input` to make it easier to add a `%` suffix for inputs rendered with `ts_form_for`
+- Add documentation for `UI::Drawer::Component` to the Drawer component docs
+- Fix small UI bug for Drawer component close icon
+- Move `sl-icon-button` styles from the overrides stylesheet into the `sl-dialog` and `sl-drawer` stylesheets
+
 ## 2.3.2
 
 - Dependency update (Figma Code Connect to 1.3.1)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@teamshares/shoelace",
-  "version": "2.3.2",
+  "version": "2.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@teamshares/shoelace",
-      "version": "2.3.2",
+      "version": "2.4.0",
       "license": "MIT",
       "dependencies": {
         "@ctrl/tinycolor": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamshares/shoelace",
   "description": "The Teamshares flavor of a forward-thinking library of web components.",
-  "version": "2.3.2",
+  "version": "2.4.0",
   "upstreamVersion": "2.14.0",
   "homepage": "https://github.com/teamshares/shoelace",
   "author": "Cory LaViska",

--- a/src/components/button/button.styles.ts
+++ b/src/components/button/button.styles.ts
@@ -138,13 +138,13 @@ export default css`
   }
 
   .button--standard.button--success:hover:not(.button--disabled) {
-    background-color: var(--sl-color-success-500);
-    border-color: var(--sl-color-success-500);
+    background-color: var(--sl-color-success-700);
+    border-color: var(--sl-color-success-600);
     color: var(--sl-color-neutral-0);
   }
 
   .button--standard.button--success:active:not(.button--disabled) {
-    background-color: var(--sl-color-success-600);
+    background-color: var(--sl-color-success-800);
     border-color: var(--sl-color-success-600);
     color: var(--sl-color-neutral-0);
   }
@@ -255,20 +255,20 @@ export default css`
 
   /* Success */
   .button--outline.button--success {
-    border-color: var(--sl-color-success-600);
-    color: var(--sl-color-success-600);
+    border-color: var(--sl-color-success-200);
+    color: var(--sl-color-success-700);
   }
 
   .button--outline.button--success:hover:not(.button--disabled),
   .button--outline.button--success.button--checked:not(.button--disabled) {
-    background-color: var(--sl-color-success-600);
-    color: var(--sl-color-neutral-0);
+    background-color: var(--sl-color-success-100);
+    color: var(--sl-color-success-700);
   }
 
   .button--outline.button--success:active:not(.button--disabled) {
-    border-color: var(--sl-color-success-700);
-    background-color: var(--sl-color-success-700);
-    color: var(--sl-color-neutral-0);
+    border-color: var(--sl-color-success-200);
+    background-color: var(--sl-color-success-200);
+    color: var(--sl-color-success-700);
   }
 
   /* Neutral */

--- a/src/components/dialog/dialog.styles.ts
+++ b/src/components/dialog/dialog.styles.ts
@@ -149,6 +149,18 @@ export default css`
     align-items: center;
     display: flex;
     flex: none;
+    border-radius: var(--sl-border-radius-circle);
+    color: var(--ts-color-text-subdued);
+  }
+
+  .dialog__close:hover {
+    background-color: var(--sl-color-neutral-200);
+    color: var(--ts-color-text-default);
+  }
+
+  .dialog__close:active {
+    background-color: var(--sl-color-neutral-300);
+    color: var(--ts-color-text-default);
   }
 
   .dialog--announcement .dialog__header-actions {

--- a/src/components/drawer/drawer.styles.ts
+++ b/src/components/drawer/drawer.styles.ts
@@ -96,10 +96,10 @@ export default css`
   }
 
   .drawer__header-actions {
-    flex-shrink: 0;
+    flex: 0 0 auto;
     display: flex;
-    flex-wrap: wrap;
     justify-content: end;
+    align-items: center;
     gap: var(--sl-spacing-2x-small);
     padding: 0 var(--header-spacing);
   }
@@ -112,9 +112,26 @@ export default css`
     font-size: var(--sl-font-size-medium);
   }
 
+  .drawer__close {
+    border-radius: var(--sl-border-radius-circle);
+    color: var(--ts-color-text-subdued);
+  }
+
+  .drawer__close:hover {
+    background-color: var(--sl-color-neutral-200);
+    color: var(--ts-color-text-default);
+  }
+
+  .drawer__close:active {
+    background-color: var(--sl-color-neutral-300);
+    color: var(--ts-color-text-default);
+  }
+
   .drawer__body {
     flex: 1 1 auto;
     display: block;
+    border-top: 1px solid var(--sl-color-neutral-300);
+    border-bottom: 1px solid var(--sl-color-neutral-300);
     padding: var(--body-spacing);
     overflow: auto;
     -webkit-overflow-scrolling: touch;

--- a/src/components/icon-button/icon-button.styles.ts
+++ b/src/components/icon-button/icon-button.styles.ts
@@ -12,7 +12,7 @@ export default css`
     align-items: center;
     background: none;
     border: none;
-    border-radius: var(--sl-border-radius-medium);
+    border-radius: var(--sl-border-radius-circle);
     font-size: inherit;
     color: inherit;
     padding: var(--sl-spacing-x-small);
@@ -23,11 +23,11 @@ export default css`
 
   .icon-button:hover:not(.icon-button--disabled),
   .icon-button:focus-visible:not(.icon-button--disabled) {
-    color: var(--sl-color-primary-600);
+    background-color: var(--sl-color-neutral-200);
   }
 
   .icon-button:active:not(.icon-button--disabled) {
-    color: var(--sl-color-primary-700);
+    background-color: var(--sl-color-neutral-300);
   }
 
   .icon-button:focus {

--- a/src/components/icon-button/icon-button.styles.ts
+++ b/src/components/icon-button/icon-button.styles.ts
@@ -14,7 +14,7 @@ export default css`
     border: none;
     border-radius: var(--sl-border-radius-circle);
     font-size: inherit;
-    color: inherit;
+    color: var(--ts-color-text-subdued);
     padding: var(--sl-spacing-x-small);
     cursor: pointer;
     transition: var(--sl-transition-x-fast) color;
@@ -23,10 +23,12 @@ export default css`
 
   .icon-button:hover:not(.icon-button--disabled),
   .icon-button:focus-visible:not(.icon-button--disabled) {
+    color: var(--ts-color-text-default);
     background-color: var(--sl-color-neutral-200);
   }
 
   .icon-button:active:not(.icon-button--disabled) {
+    color: var(--ts-color-text-default);
     background-color: var(--sl-color-neutral-300);
   }
 

--- a/src/components/input/input.component.ts
+++ b/src/components/input/input.component.ts
@@ -82,6 +82,7 @@ export default class SlInput extends ShoelaceElement implements ShoelaceFormCont
     | 'datetime-local'
     | 'email'
     | 'number'
+    | 'percentage'
     | 'password'
     | 'search'
     | 'tel'
@@ -488,7 +489,7 @@ export default class SlInput extends ShoelaceElement implements ShoelaceFormCont
               'input--disabled': this.disabled,
               'input--focused': this.hasFocus,
               'input--empty': !this.value,
-              'input--no-spin-buttons': this.noSpinButtons || this.type === 'currency'
+              'input--no-spin-buttons': this.noSpinButtons || this.type === 'currency' || this.type === 'percentage'
             })}
           >
             <span part="prefix" class="input__prefix">
@@ -510,7 +511,7 @@ export default class SlInput extends ShoelaceElement implements ShoelaceFormCont
               class="input__control"
               type=${this.type === 'password' && this.passwordVisible
                 ? 'text'
-                : this.type === 'currency'
+                : this.type === 'currency' || this.type === 'percentage' || this.type === 'number'
                   ? 'number'
                   : this.type}
               title=${this.title /* An empty title prevents browser validation tooltips from appearing on hover */}
@@ -587,7 +588,11 @@ export default class SlInput extends ShoelaceElement implements ShoelaceFormCont
               : ''}
 
             <span part="suffix" class="input__suffix">
-              ${this.type === 'currency' ? html`<span class="input__suffix-default">USD</span>` : ''}
+              ${this.type === 'currency'
+                ? html`<span class="input__suffix-default">USD</span>`
+                : this.type === 'percentage'
+                  ? html`<span class="input__suffix-default">%</span>`
+                  : ''}
               <slot name="suffix"></slot>
             </span>
           </div>

--- a/src/styles/exports/overrides.css
+++ b/src/styles/exports/overrides.css
@@ -296,27 +296,6 @@ sl-icon.contained {
   padding: var(--sl-spacing-x-small);
 }
 
-/** ********** **/
-/* Icon button custom */
-/** ********** **/
-sl-icon-button::part(base),
-sl-dialog::part(close-button__base) {
-  border-radius: var(--sl-border-radius-circle);
-  color: var(--ts-color-text-subdued);
-}
-
-sl-icon-button::part(base):hover,
-sl-dialog::part(close-button__base):hover {
-  background-color: var(--sl-color-neutral-200);
-  color: var(--ts-color-text-default);
-}
-
-sl-icon-button::part(base):active,
-sl-dialog::part(close-button__base):active {
-  background-color: var(--sl-color-neutral-300);
-  color: var(--ts-color-text-default);
-}
-
 /** ****************** */
 /* Range */
 /** ****************** */


### PR DESCRIPTION
- Add `percentage` type to `sl-input` to make it easier to add a `%` suffix for inputs rendered with `ts_form_for`
- Add documentation for `UI::Drawer::Component` to the Drawer component docs
- Fix small UI bug for Drawer component close icon
- Update styles of `sl-button variant="success" outline` to match other variants
- Move `sl-icon-button` styles from the overrides stylesheet into the `sl-dialog` and `sl-drawer` stylesheets