### PR TITLE
Bump to 2.5.0 (Update `sl-card`)

### DIFF
--- a/docs/pages/components/card.md
+++ b/docs/pages/components/card.md
@@ -502,7 +502,7 @@ To optionally apply a `flex/flex-end` layout to a footer with one or more button
     </div>
   </sl-card>
   <sl-card class="card-footer" buttonFooter>
-    This card is using the <code>buttonFooter</code> property, which applies a <code>flex/flex-end</code> layout and <code>8 px gap</code>to footer elements.
+    This card is using the <code>buttonFooter</code> property, which applies a <code>flex/flex-end</code> layout and <code>8px gap</code>to footer elements.
     <div slot="footer">
       <sl-button variant="default">Default</sl-button>
       <sl-button variant="primary">Primary</sl-button>
@@ -534,7 +534,7 @@ To optionally apply a `flex/flex-end` layout to a footer with one or more button
     |  property, which applies a
     code flex/flex-end
     |  layout and
-    code 8 px gap
+    code 8px gap
     |  to footer elements.
     div slot="footer"
       sl-button variant="default" Default

--- a/docs/pages/components/card.md
+++ b/docs/pages/components/card.md
@@ -529,7 +529,7 @@ To optionally apply a `flex/flex-end` layout to a footer with one or more button
     div slot="footer"
       a href="#" class="ts-body-2 ts-text-link" Use for links or whatever!
   sl-card.card-footer buttonFooter=true
-    | Thi s card is using the
+    | This card is using the
     code buttonFooter
     |  property, which applies a
     code flex/flex-end

--- a/docs/pages/components/card.md
+++ b/docs/pages/components/card.md
@@ -121,14 +121,20 @@ const App = () => (
 
 ### Basic Card
 
-Basic cards aren't very exciting, but they can display any content you want them to.
+Basic cards aren't very exciting, but they can display any content you want them to. This is the standard container to use when displaying content on a standard page with a `gray-100` background.
 
 ```html:preview
-<sl-card class="card-basic">
-  This is just a basic card. No image, no header, and no footer. Just your content.
-</sl-card>
+<div class="page-basic">
+  <sl-card class="card-basic">
+    This is just a basic card. No image, no header, and no footer. Just your content.
+  </sl-card>
+</div>
 
 <style>
+  .page-basic {
+    background: var(--sl-color-neutral-100);
+    padding: var(--ts-spacing-large);
+  }
   .card-basic {
     max-width: 300px;
   }
@@ -136,12 +142,17 @@ Basic cards aren't very exciting, but they can display any content you want them
 ```
 
 ```pug:slim
-sl-card.card-basic
-  | This is just a basic card. No image, no header, and no footer. Just your content.
+.page-basic
+  sl-card.card-basic
+    | This is just a basic card. No image, no header, and no footer. Just your content.
 
 css:
+  .page-basic {
+    @apply bg-gray-100 p-6;
+  }
+
   .card-basic {
-    max-width: 300px;
+    @apply max-w-[300px];
   }
 ```
 
@@ -149,6 +160,10 @@ css:
 import SlCard from '@teamshares/shoelace/dist/react/card';
 
 const css = `
+  .page-basic {
+    background: var(--sl-color-neutral-100);
+    padding: var(--ts-spacing-large);
+  }
   .card-basic {
     max-width: 300px;
   }
@@ -167,25 +182,52 @@ const App = () => (
 
 ### Card with No Shadow
 
-Use the `noShadow` property to remove a card's default box shadow.
+Use the `noShadow` property to remove a card's default box shadow. This is useful when nesting cards inside another card.
 
 ```html:preview
-<sl-card class="card-basic" noShadow> This is just a basic card with no shadow. </sl-card>
+<div class="page-basic">
+  <sl-card>
+    <div slot="header">Card with nested cards</div>
+    <div class="nested-cards">
+      <sl-card noShadow> This is a basic card with no shadow, nested inside a standard card with shadow.</sl-card>
+      <sl-card noShadow> This is a basic card with no shadow, nested inside a standard card with shadow.</sl-card>
+      <sl-card noShadow> This is a basic card with no shadow, nested inside a standard card with shadow.</sl-card>
+    </div>
+  </sl-card>
+</div>
 
 <style>
-  .card-basic {
-    max-width: 300px;
+  .page-basic {
+    background: var(--sl-color-neutral-100);
+    padding: var(--ts-spacing-large);
   }
+  .nested-cards {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    width: 100%;
+    gap: var(--sl-spacing-medium);
+}
 </style>
 ```
 
 ```pug:slim
-sl-card.card-basic noShadow=true
-  |   This is just a basic card with no shadow.
+.page-basic
+  sl-card
+    div slot="header" Card with nested cards
+    .nested-cards
+      sl-card noShadow=true
+        |  This is a basic card with no shadow, nested inside a standard card with shadow.
+      sl-card noShadow=true
+        |  This is a basic card with no shadow, nested inside a standard card with shadow.
+      sl-card noShadow=true
+        |  This is a basic card with no shadow, nested inside a standard card with shadow.
 
 css:
-  .card-basic {
-    max-width: 300px;
+  .page-basic {
+    @apply bg-gray-100 p-6;
+  }
+  .nested-cards {
+    @apply grid grid-cols-2 w-full gap-4;
   }
 ```
 
@@ -209,57 +251,204 @@ const App = () => (
 );
 ```
 
-### Card with Header
+### Loading Card
 
-Headers can be used to display titles, actions, and more. Other than padding and a bottom border, headers have no styling applied by default.
+Use the `loading` property to indicate that a process related to a card is in progress. An overlay will cover the entire card and an `sl-spinner` component will be displayed on top of the overlay.
 
 ```html:preview
-<sl-card class="card-header">
-  <div slot="header">
-    Card header
-    <sl-icon-button library="fa" name="fas-pencil" label="Edit settings"></sl-icon-button>
-  </div>
-
-  This card has a header. You can put all sorts of things in it!
-</sl-card>
+<div class="page-basic">
+  <sl-card class="card-loading" loading>
+    This is a basic card in a loading state.
+  </sl-card>
+</div>
 
 <style>
-  .card-header {
+  .page-basic {
+    background: var(--sl-color-neutral-100);
+    padding: var(--ts-spacing-large);
+  }
+  .card-loading {
     max-width: 300px;
-  }
-
-  .card-header [slot='header'] {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-  }
-
-.card-header sl-icon-button {
-    font-size: var(--sl-font-size-medium);
   }
 </style>
 ```
 
 ```pug:slim
-sl-card.card-header
-  div slot="header"
-    | Card header
-    sl-icon-button library="fa" name="fas-pencil" label="Edit settings"
-  | This card has a header. You can put all sorts of things in it!
+.page-basic
+  sl-card.card-loading loading=true
+    |   This is a basic card in a loading state.
 
 css:
-  .card-header {
+  .page-basic {
+    @apply bg-gray-100 p-6;
+  }
+  .card-loading {
+    @apply max-w-[300px];
+  }
+```
+
+```jsx:react
+import { SlCard } from '@teamshares/shoelace/dist/react';
+
+const css = `
+  .card-basic {
     max-width: 300px;
   }
+`;
 
-  .card-header [slot=header] {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
+const App = () => (
+  <>
+    <SlCard className="card-basic" loading>
+      This is a basic card in a loading state.
+    </SlCard>
+
+    <style>{css}</style>
+  </>
+);
+```
+
+### Empty State Card
+
+Use the `emptyState` property to style the card for an empty state. This will make the card less prominent by setting the background color to transparent (showing the `gray-100` page behind it) and darken the border slightly.
+
+```html:preview
+<div class="page-basic">
+    <sl-card class="card-empty" emptyState>
+      This is a basic card styled as an empty state container.
+      <br/><br/>
+      Fill it with content using the Empty State View Component!
+    </sl-card>
+</div>
+<style>
+  .page-basic {
+    background: var(--sl-color-neutral-100);
+    padding: var(--ts-spacing-large);
+  }
+  .card-empty {
+    max-width: 300px;
+  }
+</style>
+```
+
+```pug:slim
+.page-basic
+  sl-card.card-empty emptyState=true
+    |  This is a basic card styled as an empty state container.
+    br
+    br
+    |  Fill it with content using the Empty State View Component!
+
+css:
+  .page-basic {
+    @apply bg-gray-100 p-6;
+  }
+  .card-empty {
+    @apply max-w-[300px];
+  }
+```
+
+```jsx:react
+import { SlCard } from '@teamshares/shoelace/dist/react';
+
+const css = `
+  .card-basic {
+    max-width: 300px;
+  }
+`;
+
+const App = () => (
+  <>
+    <SlCard className="card-basic" loading>
+      This is a basic card in a loading state.
+    </SlCard>
+
+    <style>{css}</style>
+  </>
+);
+```
+
+### Card with Header
+
+Use `slot="header"` to display header content in the card. Other than padding and a bottom border, headers have no styling applied by default.
+
+To optionally apply a <code>flex/space-between</code> layout to a header with a title and one or more button actions (or other content to display on the right), use the `actionHeader` property on `sl-card`.
+
+```html:preview
+<div class="page-basic">
+  <sl-card class="card-header">
+    <div slot="header">
+      <div class="ts-heading-7">Card title</div>
+      <div class="ts-body-2">Description</div>
+    </div>
+    This card has a header with no additional styling applied by default.
+  </sl-card>
+    <sl-card class="card-header" actionHeader >
+    <div slot="header">
+      <div class="ts-heading-7">Card title</div>
+      <div class="header-actions">
+        <sl-tooltip content="Edit">
+          <sl-icon-button library="fa" name="pencil"></sl-icon-button>
+        </sl-tooltip>
+        <sl-tooltip content="Delete">
+          <sl-icon-button library="fa" name="trash"></sl-icon-button>
+        </sl-tooltip>
+      </div>
+    </div>
+    This card is using the <code>actionHeader</code> property, which applies a <code>flex/space-between</code> layout to the header.
+    <br/><br/>
+    To display more than one action button, wrap the buttons in a container.
+  </sl-card>
+</div>
+<style>
+  .page-basic {
+    background: var(--sl-color-neutral-100);
+    padding: var(--ts-spacing-large);
+  }
+  .card-header {
+    margin: var(--sl-spacing-x-small) 0;
+    width: 100%;
+  }
+  .header-actions * {
+    margin-inline-start: var(--sl-spacing-x-small);
+  }
+</style>
+```
+
+```pug:slim
+.page-basic
+  sl-card.card-header
+    div slot="header"
+      .ts-heading-7 Card title
+      .ts-body-2 Description
+    | This card has a header with no additional styling applied by default.
+  sl-card.card-header actionHeader=true
+    div slot="header"
+      .ts-heading-7 Card title
+      .header-actions
+        sl-tooltip content="Edit"
+          sl-icon-button library="fa" name="pencil"
+        sl-tooltip content="Delete"
+          sl-icon-button library="fa" name="trash"
+    | This card is using the
+    code actionHeader
+    |  property, which applies a
+    code flex/space-between
+    |  layout to the header.
+    br
+    br
+    | To display more than one action button, wrap the buttons in a container.
+
+css:
+  .page-basic {
+    @apply bg-gray-100 p-6;
   }
 
-  .card-header sl-icon-button {
-    font-size: var(--sl-font-size-medium);
+  .card-header {
+    @apply my-2 w-full;
+  }
+
+  .header-actions * {
+    @apply ms-2;
   }
 ```
 
@@ -300,55 +489,143 @@ const App = () => (
 
 ### Card with Footer
 
-Footers can be used to display actions, summaries, or other relevant content. Similar to the header, footers have no styling applied by default other than padding and a top border.
+Use `slot="footer"` to display footer content in the card. Similar to the header, footers have no styling applied by default other than padding and a top border.
+
+To optionally apply a `flex/flex-end` layout to a footer with one or more buttons, use the `buttonFooter` property on `sl-card`.
 
 ```html:preview
-<sl-card class="card-footer">
-  This card has a footer. You can put all sorts of things in it!
-
-  <div slot="footer">
-    <sl-button variant="default">Previous</sl-button>
-    <sl-button variant="primary">Next</sl-button>
-  </div>
-</sl-card>
+<div class="page-basic">
+  <sl-card class="card-footer">
+    This card has a footer with no additional styling applied by default.
+    <div slot="footer">
+      <a href="#" class="ts-body-2 ts-text-link">Use for links or whatever!</a>
+    </div>
+  </sl-card>
+  <sl-card class="card-footer" buttonFooter>
+    This card is using the <code>buttonFooter</code> property, which applies a <code>flex/flex-end</code> layout and <code>8 px gap</code>to footer elements.
+    <div slot="footer">
+      <sl-button variant="default">Default</sl-button>
+      <sl-button variant="primary">Primary</sl-button>
+    </div>
+  </sl-card>
+</div>
 
 <style>
+  .page-basic {
+    background: var(--sl-color-neutral-100);
+    padding: var(--ts-spacing-large);
+  }
   .card-footer {
-    max-width: 300px;
-  }
-
-  .card-footer [slot='footer'] {
-    display: flex;
-    justify-content: flex-end;
-    align-items: center;
-  }
-
-  .card-footer [slot='footer'] > * {
-    margin-inline-start: 0.5rem;
+    margin: var(--sl-spacing-x-small) 0;
+    width: 100%;
   }
 </style>
 ```
 
 ```pug:slim
-sl-card.card-footer
-  | This card has a footer. You can put all sorts of things in it!
-  div slot="footer"
-    sl-rating
-    sl-button variant="primary" Preview
-
+.page-basic
+  sl-card.card-footer
+    | This card has a footer with no additional styling applied by default.
+    div slot="footer"
+      a href="#" class="ts-body-2 ts-text-link" Use for links or whatever!
+  sl-card.card-footer buttonFooter=true
+    | Thi s card is using the
+    code buttonFooter
+    |  property, which applies a
+    code flex/flex-end
+    |  layout and
+    code 8 px gap
+    |  to footer elements.
+    div slot="footer"
+      sl-button variant="default" Default
+      sl-button variant="primary" Primary
 css:
+  .page-basic {
+    @apply bg-gray-100 p-6;
+  }
+  .card-footer {
+    @apply my-2 w-full;
+  }
+```
+
+```jsx:react
+import SlButton from '@teamshares/shoelace/dist/react/button';
+import SlCard from '@teamshares/shoelace/dist/react/card';
+import SlRating from '@teamshares/shoelace/dist/react/rating';
+
+const css = `
   .card-footer {
     max-width: 300px;
   }
 
-  .card-footer [slot=footer] {
+  .card-footer [slot="footer"] {
     display: flex;
     justify-content: space-between;
     align-items: center;
   }
 
   .card-footer [slot='footer'] > * {
-    margin-inline-start: 0.5rem;
+  margin-inline-start: 0.5rem;
+  }
+`;
+
+const App = () => (
+  <>
+    <SlCard className="card-footer">
+      This card has a footer. You can put all sorts of things in it!
+      <div slot="footer">
+        <SlRating></SlRating>
+        <SlButton slot="footer" variant="primary">
+          Preview
+        </SlButton>
+      </div>
+    </SlCard>
+
+    <style>{css}</style>
+  </>
+);
+```
+
+### Compact Card
+
+Use the `compact` property to reduce spacing and remove the borders between the header, body, and footer.
+
+```html:preview
+<div class="page-basic">
+  <sl-card class="card-compact" compact buttonFooter>
+    <div slot="header">
+      <div class="ts-heading-8">Compact card header</div>
+    </div>
+    This card is using the <code>compact</code> property, which reduces spacing and removes the borders between the header, body, and footer.
+    <div slot="footer">
+      <sl-button variant="default" size="small">Default</sl-button>
+      <sl-button variant="primary" size="small">Primary</sl-button>
+    </div>
+  </sl-card>
+</div>
+
+<style>
+  .card-compact {
+    width: 400px;
+  }
+</style>
+```
+
+```pug:slim
+.page-basic
+  sl-card.card-compact compact=true buttonFooter=true
+    div slot="header
+      .ts-heading-8 Compact card header
+    | This card is using the
+    code compact
+    | property, which reduces spacing and removes the borders between the header, body, and footer.
+    div slot="footer"
+      sl-button variant="default" size="small" Default
+      sl-button variant="primary" size="small" Primary
+
+css:
+  .card-footer {
+    @apply w-[400px];
   }
 ```
 

--- a/docs/pages/components/icon-button.md
+++ b/docs/pages/components/icon-button.md
@@ -9,14 +9,16 @@ layout: component
 
 ### Basic Icon Button
 
-For a full list of icons that come bundled with Shoelace, refer to the [icon component](/components/icon).
+Our official Design System icon set is Font Awesome. Use Font Awesome icons when displaying Icon Buttons by setting the `sl-icon-button`'s `library` attribute to `fa` and passing the icon's name to the `name` attribute.
+
+This will display `Regular` style icons by default:
 
 ```html:preview
-<sl-icon-button name="cog-6-tooth" label="Settings"></sl-icon-button>
+<sl-icon-button library="fa" name="cog" label="Settings"></sl-icon-button>
 ```
 
 ```pug:slim
-sl-icon-button name="cog-6-tooth" label="Settings"
+sl-icon-button library="fa" name="cog" label="Settings"
 ```
 
 ```jsx:react
@@ -30,15 +32,15 @@ const App = () => <SlIconButton name="cog-6-tooth" label="Settings" />;
 Icon buttons inherit their parent element's `font-size`.
 
 ```html:preview
-<sl-icon-button name="pencil" label="Edit" style="font-size: 1.5rem;"></sl-icon-button>
-<sl-icon-button name="pencil" label="Edit" style="font-size: 2rem;"></sl-icon-button>
-<sl-icon-button name="pencil" label="Edit" style="font-size: 2.5rem;"></sl-icon-button>
+<sl-icon-button library="fa" name="pencil" label="Edit" style="font-size: 1rem;"></sl-icon-button>
+<sl-icon-button library="fa" name="pencil" label="Edit" style="font-size: 1.25rem;"></sl-icon-button>
+<sl-icon-button library="fa" name="pencil" label="Edit" style="font-size: 1.5rem;"></sl-icon-button>
 ```
 
 ```pug:slim
-sl-icon-button name="pencil" label="Edit" style="font-size: 1.5rem;"
-sl-icon-button name="pencil" label="Edit" style="font-size: 2rem;"
-sl-icon-button name="pencil" label="Edit" style="font-size: 2.5rem;"
+sl-icon-button library="fa" name="pencil" label="Edit" style="font-size: 1rem;"
+sl-icon-button library="fa" name="pencil" label="Edit" style="font-size: 1.25rem;"
+sl-icon-button library="fa" name="pencil" label="Edit" style="font-size: 1.5rem;"
 ```
 
 {% raw %}
@@ -61,47 +63,51 @@ const App = () => (
 
 Icon buttons are designed to have a uniform appearance, so their color is not inherited. However, you can still customize them by styling the `base` part.
 
+:::warning
+**Note:** In general, you shouldn't need to do this. If you are working on a design that requires an icon button to have a color other than the standard `gray-700`, please consult the design team before implementing, so that the team can determine whether the existing pattern should be updated.
+:::
+
 ```html:preview
 <div class="icon-button-color">
-  <sl-icon-button name="at-symbol" label="Bold"></sl-icon-button>
-  <sl-icon-button name="bolt" label="Italic"></sl-icon-button>
-  <sl-icon-button name="no-symbol" label="Underline"></sl-icon-button>
+  <sl-icon-button library="fa" name="envelope" label="Send email"></sl-icon-button>
+  <sl-icon-button library="fa" name="building" label="Company"></sl-icon-button>
+  <sl-icon-button library="fa" name="user-plus" label="Add employee"></sl-icon-button>
 </div>
 
 <style>
   .icon-button-color sl-icon-button::part(base) {
-    color: #b00091;
+    color: #6339ac;
   }
 
   .icon-button-color sl-icon-button::part(base):hover,
   .icon-button-color sl-icon-button::part(base):focus {
-    color: #c913aa;
+    color: #6339ac;
   }
 
   .icon-button-color sl-icon-button::part(base):active {
-    color: #960077;
+    color: #6339ac;
   }
 </style>
 ```
 
 ```pug:slim
 div.icon-button-color
-  sl-icon-button name="at-symbol" label="Bold"
-  sl-icon-button name="bolt" label="Italic"
-  sl-icon-button name="no-symbol" label="Underline"
+  sl-icon-button library="fa" name="envelope" label="Send email"
+  sl-icon-button library="fa" name="building" label="Company"
+  sl-icon-button library="fa" name="user-plus" label="Add employee"
 
 css:
   .icon-button-color sl-icon-button::part(base) {
-    color: #b00091;
+    color: #6339ac;
   }
 
   .icon-button-color sl-icon-button::part(base):hover,
   .icon-button-color sl-icon-button::part(base):focus {
-    color: #c913aa;
+    color: #6339ac;
   }
 
   .icon-button-color sl-icon-button::part(base):active {
-    color: #960077;
+    color: #6339ac;
   }
 ```
 
@@ -141,11 +147,11 @@ const App = () => (
 Use the `href` attribute to convert the button to a link.
 
 ```html:preview
-<sl-icon-button name="cog-6-tooth" label="Settings" href="https://example.com" target="_blank"></sl-icon-button>
+<sl-icon-button library="fa" name="arrow-up-right-from-square" label="Open link" href="https://example.com" target="_blank"></sl-icon-button>
 ```
 
 ```pug:slim
-sl-icon-button name="cog-6-tooth" label="Settings" href="https://example.com" target="_blank"
+sl-icon-button library="fa" name="arrow-up-right-from-square" label="Open link" href="https://example.com" target="_blank"
 ```
 
 ```jsx:react
@@ -159,14 +165,14 @@ const App = () => <SlIconButton name="cog-6-tooth" label="Settings" href="https:
 Wrap a tooltip around an icon button to provide contextual information to the user.
 
 ```html:preview
-<sl-tooltip content="Settings">
-  <sl-icon-button name="cog-6-tooth" label="Settings"></sl-icon-button>
+<sl-tooltip content="Update settings">
+  <sl-icon-button library="fa" name="cog" label="Settings"></sl-icon-button>
 </sl-tooltip>
 ```
 
 ```pug:slim
-sl-tooltip content="Settings"
-  sl-icon-button name="cog-6-tooth" label="Settings"
+sl-tooltip content="Update settings"
+  sl-icon-button library="fa" name="cog" label="Settings"
 ```
 
 ```jsx:react
@@ -185,7 +191,7 @@ const App = () => (
 Use the `disabled` attribute to disable the icon button.
 
 ```html:preview
-<sl-icon-button name="cog-6-tooth" label="Settings" disabled></sl-icon-button>
+<sl-icon-button library="fa" name="cog" label="Settings" disabled></sl-icon-button>
 ```
 
 ```pug:slim

--- a/docs/pages/teamshares/changelog.md
+++ b/docs/pages/teamshares/changelog.md
@@ -13,8 +13,8 @@ meta:
   - `compact`: Remove borders and reduce spacing between card header, body, and footer
   - `actionHeader`: Apply flex layout to card header for showing a title and action icon or button
   - `buttonFooter`: Apply flex layout to card footer for showing one or more right-aligned buttons
-- Update Icon Button documentation to user Font Awesome icons
-- Explicitly set `sl-drawer` title to `ts-heading-6` styles for consistency (otherwise they inherit & are inconsistent)
+- Update Icon Button documentation to use Font Awesome icons
+- Explicitly set `sl-drawer` title to `ts-heading-6` styles for consistency (otherwise they inherit & are inconsistent from page to page)
 - Fix to display `sl-divider` again even with Tailwind border resets
 - Fix `disconnectedCallback` error for `sl-textarea`
 

--- a/docs/pages/teamshares/changelog.md
+++ b/docs/pages/teamshares/changelog.md
@@ -5,6 +5,19 @@ meta:
 
 # Changelog
 
+## 2.5.0
+
+- Update `sl-card` to include new properties:
+  - `loading`: Show card in loading state
+  - `emptyState`: Show card with empty state styling
+  - `compact`: Remove borders and reduce spacing between card header, body, and footer
+  - `actionHeader`: Apply flex layout to card header for showing a title and action icon or button
+  - `buttonFooter`: Apply flex layout to card footer for showing one or more right-aligned buttons
+- Update Icon Button documentation to user Font Awesome icons
+- Explicitly set `sl-drawer` title to `ts-heading-6` styles for consistency (otherwise they inherit & are inconsistent)
+- Fix to display `sl-divider` again even with Tailwind border resets
+- Fix `disconnectedCallback` error for `sl-textarea`
+
 ## 2.4.0
 
 - Add `percentage` type to `sl-input` to make it easier to add a `%` suffix for inputs rendered with `ts_form_for`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@teamshares/shoelace",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@teamshares/shoelace",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "license": "MIT",
       "dependencies": {
         "@ctrl/tinycolor": "^4.0.2",
@@ -16545,9 +16545,9 @@
       }
     },
     "node_modules/prismjs": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
-      "integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -32482,9 +32482,9 @@
       "integrity": "sha512-66hKPCr+72mlfiSjlEB1+45IjXSqvVAIy6mocupoww4tBFE9R9IhwwUGoI4G++Tc9Aq+2rxOt0RFU6gPcrte0A=="
     },
     "prismjs": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
-      "integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
       "dev": true
     },
     "proc-log": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamshares/shoelace",
   "description": "The Teamshares flavor of a forward-thinking library of web components.",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "upstreamVersion": "2.14.0",
   "homepage": "https://github.com/teamshares/shoelace",
   "author": "Cory LaViska",

--- a/src/components/card/card.component.ts
+++ b/src/components/card/card.component.ts
@@ -39,6 +39,21 @@ export default class SlCard extends ShoelaceElement {
   /** Option to remove the card's default box shadow. */
   @property({ type: Boolean, reflect: true }) noShadow = false;
 
+  /** Option to apply a flex/space-between layout for header elements. Useful for displaying a header with a title on the left and action buttons on the right. */
+  @property({ type: Boolean, reflect: true }) actionHeader = false;
+
+  /** Option to apply a flex/flex-end layout to footer elements. Useful for displaying a card footer with one or more buttons. */
+  @property({ type: Boolean, reflect: true }) buttonFooter = false;
+
+  /** Option to reduce spacing and remove the borders between the header, body, and footer. */
+  @property({ type: Boolean, reflect: true }) compact = false;
+
+  /** Option to show the card in a loading state. */
+  @property({ type: Boolean, reflect: true }) loading = false;
+
+  /** Option to style the card for an empty state. */
+  @property({ type: Boolean, reflect: true }) emptyState = false;
+
   render() {
     return html`
       <div
@@ -48,13 +63,24 @@ export default class SlCard extends ShoelaceElement {
           'card--has-footer': this.hasSlotController.test('footer'),
           'card--has-image': this.hasSlotController.test('image'),
           'card--has-header': this.hasSlotController.test('header'),
-          'card--no-shadow': this.noShadow
+          'card--no-shadow': this.noShadow,
+          'card--action-header': this.actionHeader,
+          'card--button-footer': this.buttonFooter,
+          'card--compact': this.compact,
+          'card--loading': this.loading,
+          'card--empty-state': this.emptyState
         })}
       >
         <slot name="image" part="image" class="card__image"></slot>
         <slot name="header" part="header" class="card__header"></slot>
         <slot part="body" class="card__body"></slot>
         <slot name="footer" part="footer" class="card__footer"></slot>
+
+        ${this.loading
+          ? html`<div class="spinner-overlay">
+        <sl-spinner style="position: absolute" size="x-large">
+      </div>`
+          : ''}
       </div>
     `;
   }

--- a/src/components/card/card.styles.ts
+++ b/src/components/card/card.styles.ts
@@ -19,8 +19,17 @@ export default css`
     border-radius: var(--border-radius);
   }
 
+  .card--loading {
+    position: relative;
+  }
+
   .card--no-shadow {
     box-shadow: none;
+  }
+
+  .card--empty-state {
+    background-color: transparent;
+    border-color: rgba(205, 207, 209, 0.6); /* gray-400 at 60% */
   }
 
   .card__image {
@@ -40,10 +49,21 @@ export default css`
     display: none;
   }
 
-  .card__header {
+  .card--has-header .card__header {
     display: block;
     border-bottom: solid var(--border-width) var(--border-color);
     padding: var(--padding);
+  }
+
+  .card--compact .card__header {
+    border-bottom: none;
+    padding-bottom: 0;
+  }
+
+  .card--action-header .card__header::slotted(*) {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
   }
 
   .card:not(.card--has-header) .card__header {
@@ -66,7 +86,32 @@ export default css`
     padding: var(--padding);
   }
 
+  .card--compact .card__footer {
+    border-top: none;
+    padding-top: 0;
+  }
+
+  .card--button-footer .card__footer::slotted(*) {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    gap: var(--sl-spacing-x-small);
+  }
+
   .card:not(.card--has-footer) .card__footer {
     display: none;
+  }
+
+  .spinner-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: rgba(255, 255, 255, 0.8);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: var(--border-radius);
   }
 `;

--- a/src/components/card/card.test.ts
+++ b/src/components/card/card.test.ts
@@ -26,7 +26,52 @@ describe('<sl-card>', () => {
     });
   });
 
-  describe('when provided an element in the slot "header" to render a header', () => {
+  describe('when noShadow', () => {
+    before(async () => {
+      el = await fixture<SlCard>(html` <sl-card noShadow>This card has no shadow.</sl-card> `);
+    });
+
+    it('should pass accessibility tests', async () => {
+      await expect(el).to.be.accessible();
+    });
+
+    it('should contain the class card--no-shadow', () => {
+      const card = el.shadowRoot!.querySelector('.card')!;
+      expect(card.classList.value.trim()).to.eq('card card--no-shadow');
+    });
+  });
+
+  describe('when loading', () => {
+    before(async () => {
+      el = await fixture<SlCard>(html` <sl-card loading>This card is loading.</sl-card> `);
+    });
+
+    it('should pass accessibility tests', async () => {
+      await expect(el).to.be.accessible();
+    });
+
+    it('should have a spinner present', () => {
+      const spinner = el.shadowRoot!.querySelector('sl-spinner')!;
+      expect(spinner).to.exist;
+    });
+  });
+
+  describe('when emptyState', () => {
+    before(async () => {
+      el = await fixture<SlCard>(html` <sl-card emptyState>This card has an empty state style.</sl-card> `);
+    });
+
+    it('should pass accessibility tests', async () => {
+      await expect(el).to.be.accessible();
+    });
+
+    it('should contain the class card--empty-state', () => {
+      const card = el.shadowRoot!.querySelector('.card')!;
+      expect(card.classList.value.trim()).to.eq('card card--empty-state');
+    });
+  });
+
+  describe('when provided an element in the slot "header" to render a header and actionHeader is false', () => {
     before(async () => {
       el = await fixture<SlCard>(
         html`<sl-card>
@@ -60,9 +105,50 @@ describe('<sl-card>', () => {
       const card = el.shadowRoot!.querySelector('.card')!;
       expect(card.classList.value.trim()).to.eq('card card--has-header');
     });
+
+    it('should not contain the class card--action-header.', () => {
+      const card = el.shadowRoot!.querySelector('.card')!;
+      expect(card.classList.contains('card--action-header')).not.to.be.true;
+    });
   });
 
-  describe('when provided an element in the slot "footer" to render a footer', () => {
+  describe('when provided an element in the slot "header" to render a header and actionHeader is true', () => {
+    before(async () => {
+      el = await fixture<SlCard>(
+        html`<sl-card actionHeader>
+          <div slot="header">Header Title</div>
+          This card has a header. You can put all sorts of things in it!
+        </sl-card>`
+      );
+    });
+
+    it('should pass accessibility tests', async () => {
+      await expect(el).to.be.accessible();
+    });
+
+    it('should render the child content provided.', () => {
+      expect(el.innerText).to.contain('This card has a header. You can put all sorts of things in it!');
+    });
+
+    it('render the header content provided.', () => {
+      const header = el.querySelector<HTMLElement>('div[slot=header]')!;
+      expect(header.innerText).eq('Header Title');
+    });
+
+    it('accept "header" as an assigned child in the shadow root.', () => {
+      const slot = el.shadowRoot!.querySelector<HTMLSlotElement>('slot[name=header]')!;
+      const childNodes = slot.assignedNodes({ flatten: true });
+
+      expect(childNodes.length).to.eq(1);
+    });
+
+    it('should contain the classes card--has-header and card--action-header.', () => {
+      const card = el.shadowRoot!.querySelector('.card')!;
+      expect(card.classList.value.trim()).to.eq('card card--has-header card--action-header');
+    });
+  });
+
+  describe('when provided an element in the slot "footer" to render a footer and buttonFooter is false', () => {
     before(async () => {
       el = await fixture<SlCard>(
         html`<sl-card>
@@ -96,6 +182,69 @@ describe('<sl-card>', () => {
     it('should contain the class card--has-footer.', () => {
       const card = el.shadowRoot!.querySelector('.card')!;
       expect(card.classList.value.trim()).to.eq('card card--has-footer');
+    });
+
+    it('should not contain the class card--button-footer.', () => {
+      const card = el.shadowRoot!.querySelector('.card')!;
+      expect(card.classList.contains('card--button-footer')).not.to.be.true;
+    });
+  });
+
+  describe('when provided an element in the slot "footer" to render a footer and buttonFooter is true', () => {
+    before(async () => {
+      el = await fixture<SlCard>(
+        html`<sl-card buttonFooter>
+          This card has a footer. You can put all sorts of things in it!
+
+          <div slot="footer">Footer Content</div>
+        </sl-card>`
+      );
+    });
+
+    it('should pass accessibility tests', async () => {
+      await expect(el).to.be.accessible();
+    });
+
+    it('should render the child content provided.', () => {
+      expect(el.innerText).to.contain('This card has a footer. You can put all sorts of things in it!');
+    });
+
+    it('render the footer content provided.', () => {
+      const footer = el.querySelector<HTMLElement>('div[slot=footer]')!;
+      expect(footer.innerText).eq('Footer Content');
+    });
+
+    it('accept "footer" as an assigned child in the shadow root.', () => {
+      const slot = el.shadowRoot!.querySelector<HTMLSlotElement>('slot[name=footer]')!;
+      const childNodes = slot.assignedNodes({ flatten: true });
+
+      expect(childNodes.length).to.eq(1);
+    });
+
+    it('should contain the classes card--has-footer and card--button-footer.', () => {
+      const card = el.shadowRoot!.querySelector('.card')!;
+      expect(card.classList.value.trim()).to.eq('card card--has-footer card--button-footer');
+    });
+  });
+
+  describe('when compact', () => {
+    before(async () => {
+      el = await fixture<SlCard>(
+        html`<sl-card compact>
+          <div slot="header">Header Title</div>
+          This is a compact card has with a header, body, and footer
+          <div slot="footer">Footer Content</div>
+        </sl-card> `
+      );
+    });
+
+    it('should pass accessibility tests', async () => {
+      await expect(el).to.be.accessible();
+    });
+
+    it('should contain the class card--compact', () => {
+      const card = el.shadowRoot!.querySelector('.card')!;
+      expect(card.classList.contains('card--compact')).to.be.true;
     });
   });
 

--- a/src/components/divider/divider.styles.ts
+++ b/src/components/divider/divider.styles.ts
@@ -9,14 +9,14 @@ export default css`
 
   :host(:not([vertical])) {
     display: block;
-    border-top: solid var(--width) var(--color);
+    border-top: solid var(--width) var(--color) !important; /* !important needed to override Tailwind's border resets */
     margin: var(--spacing) 0;
   }
 
   :host([vertical]) {
     display: inline-block;
     height: 100%;
-    border-left: solid var(--width) var(--color);
+    border-left: solid var(--width) var(--color) !important; /* !important needed to override Tailwind's border resets */
     margin: 0 var(--spacing);
   }
 `;

--- a/src/components/drawer/drawer.styles.ts
+++ b/src/components/drawer/drawer.styles.ts
@@ -89,8 +89,11 @@ export default css`
   .drawer__title {
     flex: 1 1 auto;
     font: inherit;
-    font-size: var(--sl-font-size-large);
-    line-height: var(--sl-line-height-dense);
+    /* ts-heading-6 */
+    font-size: var(--ts-font-xl); /* 20px */
+    font-weight: var(--ts-font-medium); /* 500 */
+    letter-spacing: var(--ts-tracking-tight); /* -0.025em */
+    line-height: var(--ts-leading-6); /* 1.5rem * 24px */
     padding: var(--header-spacing);
     margin: 0;
   }

--- a/src/components/textarea/textarea.component.ts
+++ b/src/components/textarea/textarea.component.ts
@@ -173,7 +173,9 @@ export default class SlTextarea extends ShoelaceElement implements ShoelaceFormC
 
   disconnectedCallback() {
     super.disconnectedCallback();
-    this.resizeObserver.unobserve(this.input);
+    if (this.input) {
+      this.resizeObserver.unobserve(this.input);
+    }
   }
 
   private handleBlur() {


### PR DESCRIPTION
### Changes
- Update `sl-card` to include new properties ([`sl-card` docs in Review app](https://shoelace-kfppuu2qi-teamshares.vercel.app/components/card))
  - `loading`: Show card in loading state
  - `emptyState`: Show card with empty state styling
  - `compact`: Remove borders and reduce spacing between card header, body, and footer
  - `actionHeader`: Apply flex layout to card header for showing a title and action icon or button
  - `buttonFooter`: Apply flex layout to card footer for showing one or more right-aligned buttons
- Update Icon Button documentation to use Font Awesome icons [`sl-icon-button` docs in Review app](https://shoelace-kfppuu2qi-teamshares.vercel.app/components/icon-button)
- Explicitly set `sl-drawer` title to `ts-heading-6` styles for consistency (otherwise they inherit & are inconsistent from page to page)
- Fix to display `sl-divider` again even with Tailwind border resets
- Fix `disconnectedCallback` error for `sl-textarea` (Fix for [this HB error](https://app.honeybadger.io/projects/94242/faults/89625349))