### PR TITLE
Fix FormControlController: fall back to document.getElementById when root is a ShadowRoot

### DIFF
--- a/src/internal/form.ts
+++ b/src/internal/form.ts
@@ -74,7 +74,7 @@ export class FormControlController implements ReactiveController {
         if (formId) {
           const root = input.getRootNode() as Document | ShadowRoot;
 
-          const form = root.getElementById(formId);
+          const form = ('getElementById' in root ? root : document).getElementById(formId);
 
           if (form) {
             return form as HTMLFormElement;


### PR DESCRIPTION
## Problem

`FormControlController` calls `root.getElementById(formId)` where `root = input.getRootNode()`. When a Shoelace form control is inside a shadow DOM context (e.g. nested inside `sl-dialog`), `getRootNode()` returns a `ShadowRoot`, which does not have `getElementById`. This throws a `TypeError: root.getElementById is not a function` as an uncaught browser exception.

## Fix

Fall back to `document.getElementById()` when the root node doesn't have `getElementById`:

```ts
const form = ('getElementById' in root ? root : document).getElementById(formId);
```

This preserves the intent — find the form by ID starting from the nearest root — and gracefully falls back to the document when the root is a shadow root.

## Context

Discovered via a Playwright `pageerror` listener added to system tests in teamshares/os-app. The error was surfacing on the Departures and Grants flows where Shoelace form inputs appear inside `sl-dialog`.